### PR TITLE
Fixed a major bug in NCMCEngine and added more NCMC tests

### DIFF
--- a/examples/rjmc/run_example.py
+++ b/examples/rjmc/run_example.py
@@ -186,8 +186,8 @@ def run():
         geometry_proposal = geometry_engine.propose(top_proposal.new_to_old_atom_map, top_proposal.new_system, system, ncmc_old_positions)
 
         # Alchemically introduce new atoms.
-        new_alchemical_system = alchemical_engine.make_alchemical_system(top_proposal.new_system, top_proposal, direction='create')
-        [ncmc_new_positions, ncmc_introduction_logp] = ncmc_engine.integrate(new_alchemical_system, geometry_proposal.new_positions, direction='create')
+        new_alchemical_system = alchemical_engine.make_alchemical_system(top_proposal.new_system, top_proposal, direction='insert')
+        [ncmc_new_positions, ncmc_introduction_logp] = ncmc_engine.integrate(new_alchemical_system, geometry_proposal.new_positions, direction='insert')
         #print(ncmc_new_positions)
         #print(ncmc_introduction_logp)
 

--- a/perses/annihilation/alchemical_engine.py
+++ b/perses/annihilation/alchemical_engine.py
@@ -28,7 +28,7 @@ class AlchemicalEliminationEngine(object):
     Create some alchemical systems
 
     >>> engine = AlchemicalEliminationEngine()
-    >>> alchemical_system_insert = engine.make_alchemical_system(testsystem.system, topology_proposal, direction='create')
+    >>> alchemical_system_create = engine.make_alchemical_system(testsystem.system, topology_proposal, direction='insert')
     >>> alchemical_system_delete = engine.make_alchemical_system(testsystem.system, topology_proposal, direction='delete')
 
     """
@@ -37,7 +37,7 @@ class AlchemicalEliminationEngine(object):
         pass
 
 
-    def make_alchemical_system(self, unmodified_system, topology_proposal, direction='create'):
+    def make_alchemical_system(self, unmodified_system, topology_proposal, direction='insert'):
         """
         Generate an alchemically-modified system at the correct atoms
         based on the topology proposal
@@ -63,15 +63,15 @@ class AlchemicalEliminationEngine(object):
         #take the unique atoms as those not in the {new_atom : old_atom} atom map
         if direction == 'delete':
             alchemical_atoms = [atom for atom in range(n_atoms) if atom not in atom_map.values()]
-        elif direction == 'create':
+        elif direction == 'insert':
             alchemical_atoms = [atom for atom in range(n_atoms) if atom not in atom_map.keys()]
         else:
-            raise Exception("direction must be one of ['delete', 'create']; found '%s' instead" % direction)
+            raise Exception("direction must be one of ['delete', 'insert']; found '%s' instead" % direction)
 
         logging.debug(alchemical_atoms)
         # Create an alchemical factory.
         from alchemy import AbsoluteAlchemicalFactory
-        alchemical_factory = AbsoluteAlchemicalFactory(unmodified_system, ligand_atoms=alchemical_atoms)
+        alchemical_factory = AbsoluteAlchemicalFactory(unmodified_system, ligand_atoms=alchemical_atoms, annihilate_electrostatics=True, annihilate_sterics=True)
 
         # Return the alchemically-modified system.
         alchemical_system = alchemical_factory.createPerturbedSystem()

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -1,0 +1,101 @@
+"""
+Unit tests for NCMC switching engine.
+
+"""
+
+__author__ = 'John D. Chodera'
+
+################################################################################
+# IMPORTS
+################################################################################
+
+from simtk import openmm, unit
+import math
+import numpy as np
+from functools import partial
+
+################################################################################
+# CONSTANTS
+################################################################################
+
+kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
+
+################################################################################
+# TESTS
+################################################################################
+
+def simulate(system, positions, nsteps=500, timestep=1.0*unit.femtoseconds, temperature=300.0*unit.kelvin, collision_rate=20.0/unit.picoseconds):
+    integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
+    context = openmm.Context(system, integrator)
+    context.setPositions(positions)
+    context.setVelocitiesToTemperature(temperature)
+    integrator.step(nsteps)
+    positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+    return positions
+
+def check_alchemical_elimination(ncmc_nsteps=50):
+    """
+    Test alchemical elimination engine on alanine dipeptide null transformation.
+
+    """
+
+    NSIGMA_MAX = 6.0 # number of standard errors away from analytical solution tolerated before Exception is thrown
+
+    # Create an alanine dipeptide null transformation, where N-methyl group is deleted and then inserted.
+    from openmmtools import testsystems
+    testsystem = testsystems.AlanineDipeptideVacuum()
+    from perses.rjmc.topology_proposal import TopologyProposal
+    new_to_old_atom_map = { index : index for index in range(testsystem.system.getNumParticles()) if (index > 3) } # all atoms but N-methyl
+    topology_proposal = TopologyProposal(old_system=testsystem.system, old_topology=testsystem.topology, old_positions=testsystem.positions, new_system=testsystem.system, new_topology=testsystem.topology, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=dict())
+
+    # Initialize engine
+    from perses.annihilation.alchemical_engine import AlchemicalEliminationEngine
+    from perses.annihilation.ncmc_switching import NCMCEngine
+    engine = AlchemicalEliminationEngine()
+    ncmc_engine = NCMCEngine(nsteps=ncmc_nsteps)
+
+    niterations = 20 # number of round-trip switching trials
+    positions = testsystem.positions
+    logP_insert_n = np.zeros([niterations], np.float64)
+    logP_delete_n = np.zeros([niterations], np.float64)
+    for iteration in range(niterations):
+        # Equilibrate
+        positions = simulate(testsystem.system, positions)
+
+        # Delete atoms
+        alchemical_system_delete = engine.make_alchemical_system(testsystem.system, topology_proposal, direction='delete')
+        [positions, logP_delete] = ncmc_engine.integrate(alchemical_system_delete, positions, direction='delete')
+
+        # Insert atoms
+        alchemical_system_insert = engine.make_alchemical_system(testsystem.system, topology_proposal, direction='insert')
+        [positions, logP_insert] = ncmc_engine.integrate(alchemical_system_insert, positions, direction='insert')
+
+        # Compute total probability
+        logP_delete_n[iteration] = logP_delete
+        logP_insert_n[iteration] = logP_insert
+
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    logP_n = logP_delete_n + logP_insert_n
+    from pymbar import EXP
+    [df, ddf] = EXP(logP_n)
+    if (abs(df) > NSIGMA_MAX * ddf):
+        msg = 'Delta F (%d steps switching) = %f +- %f kT; should be within %f sigma of 0' % (ncmc_nsteps, df, ddf, NSIGMA_MAX)
+        msg += 'delete logP:\n'
+        msg += str(logP_delete_n) + '\n'
+        msg += 'insert logP:\n'
+        msg += str(logP_insert_n) + '\n'
+        msg += 'logP:\n'
+        msg += str(logP_n) + '\n'
+        raise Exception(msg)
+
+def test_alchemical_elimination():
+    """
+    Check alchemical elimination for alanine dipeptide in vacuum with 0, 1, and 50 switching steps.
+
+    """
+    for ncmc_nsteps in [0, 1, 50]:
+        f = partial(check_alchemical_elimination, ncmc_nsteps)
+        f.description = "Testing alchemical elimination using alanine dipeptide with %d NCMC steps" % ncmc_nsteps
+        yield f
+


### PR DESCRIPTION
In preparation for the changes in #32, I added more NCMC tests and found a couple of bugs:
* Direction (`insert/delete`) was being ignored
* NCMC did not reduce to instantaneous Monte Carlo when number of switching steps was 0

Now, `nsteps = 0, 1, 50` are all tested for a harmonic oscillator and a null transformation for alanine dipeptide in vacuum.