### PR TITLE
Refactor geometry engine

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -144,7 +144,7 @@ class FFGeometryEngine(GeometryEngine):
                 new_atoms.remove(atom.idx)
         return new_positions, logp_proposal
 
-    def logp(self, top_proposal, new_coordinates, old_coordinates, direction='reverse'):
+    def logp_reverse(self, top_proposal, new_coordinates, old_coordinates):
         """
         Calculate the logp for the given geometry proposal
 
@@ -164,15 +164,10 @@ class FFGeometryEngine(GeometryEngine):
         """
         logp = 0.0
         top_proposal = topology_proposal.SmallMoleculeTopologyProposal()
-        new_atoms = top_proposal.unique_new_atoms
-        if direction == 'reverse':
-            structure = parmed.openmm.load_topology(top_proposal.old_topology, top_proposal.old_system)
-            atoms_with_positions = [structure.atoms[atom_idx] for atom_idx in range(top_proposal.n_atoms_old) if atom_idx not in top_proposal.unique_old_atoms]
-        elif direction == 'forward':
-            structure = parmed.openmm.load_topology(top_proposal.new_topology, top_proposal.new_system)
-            atoms_with_positions = [structure.atoms[atom_idx] for atom_idx in range(top_proposal.n_atoms_new) if atom_idx not in top_proposal.unique_new_atoms]
-        else:
-            raise Exception("Argument direction must be either forward or reverse")
+
+        structure = parmed.openmm.load_topology(top_proposal.old_topology, top_proposal.old_system)
+        atoms_with_positions = [structure.atoms[atom_idx] for atom_idx in range(top_proposal.n_atoms_old) if atom_idx not in top_proposal.unique_old_atoms]
+        new_atoms = top_proposal.unique_old_atoms
         #maintain a running list of the atoms still needing logp
         while(len(new_atoms)>0):
             atoms_for_proposal = self._atoms_eligible_for_proposal(structure, atoms_with_positions)

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -138,9 +138,9 @@ class FFGeometryEngine(GeometryEngine):
                 #add new position to array of new positions
                 new_positions[atom.idx] = xyz
                 #accumulate logp
-                logp = logp + logp_choice + logp_r + logp_theta + logp_phi + np.log(detJ)
+                logp_proposal = logp_proposal + logp_choice + logp_r + logp_theta + logp_phi + np.log(detJ)
 
-        return new_positions, logp
+        return new_positions, logp_proposal
 
     def logp(self, top_proposal, new_coordinates, old_coordinates, direction='reverse'):
         """

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -446,7 +446,7 @@ class FFGeometryEngine(GeometryEngine):
         beta : float
             1/kT or inverse temperature
         """
-        k_eq = bond.type.k*units.kilojoule_per_mole/(units.nanometers**2)
+        k_eq = bond.type.k*units.kilocalories_per_mole_per_mole/(units.angstrom**2)
         r0 = bond.type.req*units.nanometers
         sigma = beta*2.0/np.sqrt(2.0*k_eq/k_eq.unit)
         logp = stats.distributions.norm.logpdf(r/r.unit, r0/r0.unit, sigma)

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -46,7 +46,7 @@ class GeometryEngine(object):
         """
         return np.array([0.0,0.0,0.0])
 
-    def logp(self, top_proposal, new_coordinates, old_coordinates, direction='forward'):
+    def logp(self, top_proposal, new_coordinates, old_coordinates):
         """
         Calculate the logp for the given geometry proposal
 
@@ -121,7 +121,7 @@ class FFGeometryEngine(GeometryEngine):
 
         return np.array([0.0,0.0,0.0])
 
-    def logp(self, top_proposal, new_coordinates, old_coordinates, direction='forward'):
+    def logp(self, top_proposal, new_coordinates, old_coordinates):
         """
         Calculate the logp for the given geometry proposal
 
@@ -133,8 +133,6 @@ class FFGeometryEngine(GeometryEngine):
             The coordinates of the system after the proposal
         old_coordiantes : [n, 3] np.ndarray
             The coordinates of the system before the proposal
-        direction : str, either 'forward' or 'reverse'
-            whether the transformation is for the forward NCMC move or the reverse
 
         Returns
         -------

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -446,7 +446,7 @@ class FFGeometryEngine(GeometryEngine):
         beta : float
             1/kT or inverse temperature
         """
-        k_eq = bond.type.k*units.kilocalories_per_mole_per_mole/(units.angstrom**2)
+        k_eq = bond.type.k*units.kilocalories_per_mole/(units.angstrom**2)
         r0 = bond.type.req*units.nanometers
         sigma = beta*2.0/np.sqrt(2.0*k_eq/k_eq.unit)
         logp = stats.distributions.norm.logpdf(r/r.unit, r0/r0.unit, sigma)
@@ -622,7 +622,7 @@ class FFAllAngleGeometryEngine(FFGeometryEngine):
             ub[i] += self._torsion_and_angle_potential(xyz, atom, positions, involved_angles, involved_torsions, beta)
 
         #exponentiate to get the unnormalized probability
-        q = np.exp(ub)
+        q = np.exp(-ub)
 
         #estimate the normalizing constant
         Z = np.trapz(q, phis)
@@ -662,7 +662,7 @@ class FFAllAngleGeometryEngine(FFGeometryEngine):
         if not Z:
             p, Z = self._normalize_torsion_proposal(atom, internal_coordinates[0], internal_coordinates[1], bond_atom, angle_atom, torsion_atom, atoms_with_positions, positions, beta, n_divisions=60)
         ub_torsion = self._torsion_and_angle_potential(xyz, atom, positions, involved_angles, involved_torsions, beta)
-        p_torsion = np.exp(ub_torsion) / Z
+        p_torsion = np.exp(-ub_torsion) / Z
         return p_torsion
 
     def _propose_torsion(self, atom, r, theta, bond_atom, angle_atom, torsion_atom, torsion, atoms_with_positions, positions, beta):

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -583,20 +583,13 @@ class FFAllAngleGeometryEngine(FFGeometryEngine):
         log_ub_angles = np.zeros(n_divisions)
         for i, xyz in enumerate(xyzs):
             for angle in involved_angles:
-                if angle.atom1 == atom:
-                    atom_position = xyz
-                    bond_atom_position = positions[angle.atom2.idx]
-                    angle_atom_position = positions[angle.atom3.idx]
-                elif angle.atom2 == atom:
-                    atom_position = positions[angle.atom1.idx]
-                    bond_atom_position = xyz
-                    angle_atom_position = positions[angle.atom3.idx]
-                else:
-                    atom_position = positions[angle.atom1.idx]
-                    bond_atom_position = positions[angle.atom2.idx]
-                    angle_atom_position = xyz
+                atom_position = xyz if angle.atom1 == atom else positions[angle.atom1.idx]
+                bond_atom_position = xyz if angle.atom2 == atom else positions[angle.atom2.idx]
+                angle_atom_position = xyz if angle.atom2 == atom else positions[angle.atom3.idx]
                 theta = self._calculate_angle(atom_position, bond_atom_position, angle_atom_position)
                 log_ub_angles[i] += self._angle_logp(theta*units.radians, angle, beta)
+
+        #now the torsions
 
         return
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -169,8 +169,21 @@ class FFGeometryEngine(GeometryEngine):
         """
         structure = parmed.openmm.load_topology(app.Topology(), openmm.System())
         new_atom = structure.atoms[atom_index]
+        atoms_with_positions = set(atoms_with_positions)
+        eligible_angles = []
         angles = new_atom.angles
-        for
+        for angle in angles:
+            if angle.atom1 == new_atom:
+                if atoms_with_positions.issuperset(set([angle.atom2, angle.atom3])):
+                    eligible_angles.append(angle)
+            elif angle.atom2 == new_atom:
+                if atoms_with_positions.issuperset(set([angle.atom1, angle.atom3])):
+                    eligible_angles.append(angle)
+            else:
+                if atoms_with_positions.issuperset(set([angle.atom1, angle.atom2])):
+                    eligible_angles.append(angle)
+        return eligible_angles
+
 
 
 class FFGeometryEngineOld(GeometryEngine):

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -145,7 +145,6 @@ class FFGeometryEngine(GeometryEngine):
                 torsion_partners = [torsion.atom1.idx, torsion.atom2.idx, torsion.atom3.idx]
             else:
                 continue
-            torsion_partners = [torsion.atom2.idx, torsion.atom3.idx, torsion.atom4.idx]
             if set(atoms_with_positions).issuperset(set(torsion_partners)):
                 eligible_torsions.append(torsion)
         return torsions

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -76,7 +76,7 @@ class TopologyProposal(object):
     """
 
     def __init__(self, new_topology=None, new_system=None, old_topology=None, old_system=None, old_positions=None,
-                 logp_proposal=None, new_to_old_atom_map=None, metadata=None):
+                 logp_proposal=None, new_to_old_atom_map=None, metadata=None, beta=None):
 
         self._new_topology = new_topology
         self._new_system = new_system
@@ -89,6 +89,7 @@ class TopologyProposal(object):
         self._unique_new_atoms = [atom for atom in range(self._new_system.getNumParticles()) if atom not in self._new_to_old_atom_map.keys()]
         self._unique_old_atoms = [atom for atom in range(self._old_system.getNumParticles()) if atom not in self._new_to_old_atom_map.values()]
         self._metadata = metadata
+        self._beta = beta
 
     @property
     def new_topology(self):
@@ -105,6 +106,9 @@ class TopologyProposal(object):
     @property
     def old_positions(self):
         return self._old_positions
+    @property
+    def beta(self):
+        return self._beta
     @property
     def logp_proposal(self):
         return self._logp_proposal

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -35,8 +35,8 @@ def oemol_to_openmm_system(oemol, molecule_name):
     """
 
     _ , tripos_mol2_filename = openmoltools.openeye.molecule_to_mol2(oemol, tripos_mol2_filename=molecule_name + '.tripos.mol2', conformer=0, residue_name='MOL')
-    gaff_mol2, frcmod = openmoltools.amber.run_antechamber(molecule_name, tripos_mol2_filename)
-    prmtop_file, inpcrd_file = openmoltools.amber.run_tleap(molecule_name, gaff_mol2, frcmod)
+    gaff_mol2, frcmod = openmoltools.openeye.run_antechamber(molecule_name, tripos_mol2_filename)
+    prmtop_file, inpcrd_file = run_tleap(molecule_name, gaff_mol2, frcmod)
     prmtop = app.AmberPrmtopFile(prmtop_file)
     system = prmtop.createSystem(implicitSolvent=app.OBC1)
     crd = app.AmberInpcrdFile(inpcrd_file)

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -1,8 +1,6 @@
 __author__ = 'Patrick B. Grinaway'
 
-#for now, just make the geometry engine run
 
-import simtk.openmm as openmm
 import openeye.oechem as oechem
 import openmoltools
 import openeye.oeiupac as oeiupac
@@ -10,7 +8,8 @@ import openeye.oeomega as oeomega
 import simtk.openmm.app as app
 import simtk.unit as units
 
-
+kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA
+beta = 1.0/ (300.0*units.kelvin*kB)
 def generate_initial_molecule(iupac_name):
     """
     Generate an oemol with a geometry
@@ -97,8 +96,11 @@ def test_run_geometry_engine():
 
     sm_top_proposal = topology_proposal.SmallMoleculeTopologyProposal(new_topology=top2, new_system=sys2, old_topology=top1, old_system=sys1,
                                                                       old_positions=pos1, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_mapping, metadata={'test':0.0})
+    sm_top_proposal._beta = beta
+    geometry_engine = geometry.FFAllAngleGeometryEngine({'test': 'true'})
 
-    geometry_engine = geometry.FFGeometryEngine({'test': 'true'})
 
-    for i in range(10):
-        geometry_engine.propose(sm_top_proposal)
+    geometry_engine.propose(sm_top_proposal)
+
+if __name__=="__main__":
+    test_run_geometry_engine()

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -1,6 +1,6 @@
 __author__ = 'Patrick B. Grinaway'
 
-
+import simtk.openmm as openmm
 import openeye.oechem as oechem
 import openmoltools
 import openeye.oeiupac as oeiupac
@@ -90,7 +90,6 @@ def test_run_geometry_engine():
         pos2[index, 1] = y * units.angstrom
         pos2[index, 2] = z * units.angstrom
 
-    #propose(self, new_to_old_atom_map, new_system, old_system, old_positions)
     import perses.rjmc.geometry as geometry
     import perses.rjmc.topology_proposal as topology_proposal
 
@@ -99,8 +98,18 @@ def test_run_geometry_engine():
     sm_top_proposal._beta = beta
     geometry_engine = geometry.FFAllAngleGeometryEngine({'test': 'true'})
 
+    integrator = openmm.VerletIntegrator(1*units.femtoseconds)
+    context = openmm.Context(sys2, integrator)
+    context.setPositions(pos2)
+    state = context.getState(getEnergy=True)
+    print("Energy before proposal is: %s" % str(state.getPotentialEnergy()))
 
-    geometry_engine.propose(sm_top_proposal)
+    new_positions, logp_proposal = geometry_engine.propose(sm_top_proposal)
+    context.setPositions(new_positions)
+    state2 = context.getState(getEnergy=True)
+    print("Energy after proposal is: %s" %str(state2.getPotentialEnergy()))
+
+
 
 if __name__=="__main__":
     test_run_geometry_engine()

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -35,8 +35,8 @@ def oemol_to_openmm_system(oemol, molecule_name):
     """
 
     _ , tripos_mol2_filename = openmoltools.openeye.molecule_to_mol2(oemol, tripos_mol2_filename=molecule_name + '.tripos.mol2', conformer=0, residue_name='MOL')
-    gaff_mol2, frcmod = openmoltools.openeye.run_antechamber(molecule_name, tripos_mol2_filename)
-    prmtop_file, inpcrd_file = run_tleap(molecule_name, gaff_mol2, frcmod)
+    gaff_mol2, frcmod = openmoltools.amber.run_antechamber(molecule_name, tripos_mol2_filename)
+    prmtop_file, inpcrd_file = openmoltools.amber.run_tleap(molecule_name, gaff_mol2, frcmod)
     prmtop = app.AmberPrmtopFile(prmtop_file)
     system = prmtop.createSystem(implicitSolvent=app.OBC1)
     crd = app.AmberInpcrdFile(inpcrd_file)

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -75,21 +75,6 @@ def test_run_geometry_engine():
     sys1, pos1, top1 = oemol_to_openmm_system(molecule1, molecule_name_1)
     sys2, pos2, top2 = oemol_to_openmm_system(molecule2, molecule_name_2)
 
-    #copy the positions to openmm manually (not sure what happens to units otherwise)
-    for atom in molecule1.GetAtoms():
-        (x, y, z) = molecule1.GetCoords(atom)
-        index = atom.GetIdx()
-        pos1[index, 0] = x * units.angstrom
-        pos1[index, 1] = y * units.angstrom
-        pos1[index, 2] = z * units.angstrom
-
-    for atom in molecule2.GetAtoms():
-        (x, y, z) = molecule1.GetCoords(atom)
-        index = atom.GetIdx()
-        pos2[index, 0] = x * units.angstrom
-        pos2[index, 1] = y * units.angstrom
-        pos2[index, 2] = z * units.angstrom
-
     import perses.rjmc.geometry as geometry
     import perses.rjmc.topology_proposal as topology_proposal
 


### PR DESCRIPTION
In the early stages of refactoring the geometry engine stuff. The plan thus far is:

* Modularize more (subclass of the general `GeometryEngine` that handles stuff required for all forcefield-based geometry engines, then a subclass of that for the specific idea we discussed)

* New implementation where `p(rho`) is calculated from `p(rho| thetas, rhos)` as discussed in #9 

* Calculate `logp` separately from proposal to allow schemes discussed in #43 

* Switch to using `parmed` to sort through the `system` and `topologies`
