### PR TITLE
Creating chemical_state_key for PolymerMutationEngines (and other minor fixes)

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -27,7 +27,7 @@ class NCMCEngine(object):
     >>> testsystem = testsystems.AlanineDipeptideVacuum()
     >>> from perses.rjmc.topology_proposal import TopologyProposal
     >>> new_to_old_atom_map = { index : index for index in range(testsystem.system.getNumParticles()) if (index > 3) } # all atoms but N-methyl
-    >>> topology_proposal = TopologyProposal(old_system=testsystem.system, old_topology=testsystem.topology, old_positions=testsystem.positions, new_system=testsystem.system, new_topology=testsystem.topology, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=dict())
+    >>> topology_proposal = TopologyProposal(old_system=testsystem.system, old_topology=testsystem.topology, old_chemical_state_key='AA', new_chemical_state_key='AA', new_system=testsystem.system, new_topology=testsystem.topology, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=dict())
     >>> ncmc_engine = NCMCEngine(temperature=300.0*unit.kelvin, functions=default_functions, nsteps=50, timestep=1.0*unit.femtoseconds)
     >>> positions = testsystem.positions
     >>> [positions, logP_delete, potential_delete] = ncmc_engine.integrate(topology_proposal, positions, direction='delete')

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -632,36 +632,9 @@ class PointMutationEngine(PolymerProposalEngine):
         return modeller
 
     def compute_state_key(self, topology):
-        one_letter_code = {
-            'ALA': 'A',
-            'ARG': 'R',
-            'ASN': 'N',
-            'ASP': 'D',
-            'CYS': 'C',
-            'GLN': 'Q',
-            'GLU': 'E',
-            'GLY': 'G',
-            'HID': 'H',
-            'HIE': 'H',
-            'HIS': 'H',
-            'ILE': 'I',
-            'LEU': 'L',
-            'LYS': 'K',
-            'MET': 'M',
-            'PHE': 'F',
-            'PRO': 'P',
-            'SER': 'S',
-            'THR': 'T',
-            'TRP': 'W',
-            'TYR': 'Y',
-            'VAL': 'V'
-        }
         chemical_state_key = ''
         for res in topology.residues():
-            try:
-                chemical_state_key+=one_letter_code[res.name]
-            except KeyError:
-                chemical_state_key+='X'
+            chemical_state_key+=res.name
 
         return chemical_state_key
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -658,7 +658,10 @@ class PointMutationEngine(PolymerProposalEngine):
         }
         chemical_state_key = ''
         for res in topology.residues():
-            chemical_state_key+=one_letter_code[res.name]
+            try:
+                chemical_state_key+=one_letter_code[res.name]
+            except KeyError:
+                chemical_state_key+='X'
 
         return chemical_state_key
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -195,11 +195,15 @@ class ProposalEngine(object):
         pass
 
 class PolymerProposalEngine(ProposalEngine):
-    def __init__(self, system_generator, proposal_metadata=None):
+    def __init__(self, system_generator, chain_id, proposal_metadata=None):
         super(PolymerProposalEngine,self).__init__(system_generator, proposal_metadata=proposal_metadata)
+        self._chain_id = chain_id
 
     def propose(self, current_system, current_topology, current_metadata=None):
         return TopologyProposal(new_topology=app.Topology(), old_topology=app.Topology(), old_system=current_system, old_chemical_state_key="C", new_chemical_state_key="C", logp_proposal=0.0, new_to_old_atom_map={0 : 0}, metadata=current_metadata)
+
+    def compute_state_key(self, topology):
+        return ''
 
 class PointMutationEngine(PolymerProposalEngine):
     """
@@ -219,12 +223,11 @@ class PointMutationEngine(PolymerProposalEngine):
     """
 
     def __init__(self, system_generator, max_point_mutants, chain_id, proposal_metadata=None, allowed_mutations=None):
-        super(PointMutationEngine,self).__init__(system_generator, proposal_metadata=proposal_metadata)
+        super(PointMutationEngine,self).__init__(system_generator, chain_id, proposal_metadata=proposal_metadata)
         self._max_point_mutants = max_point_mutants
         self._ff = system_generator.forcefield 
         self._templates = self._ff._templates
         self._allowed_mutations = allowed_mutations
-        self._chain_id = chain_id
 
     def propose(self, current_system, current_topology, current_metadata=None):
         """

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -196,7 +196,7 @@ class ProposalEngine(object):
 
 class PolymerProposalEngine(ProposalEngine):
     def __init__(self, system_generator, proposal_metadata=None):
-        super(PolymerProposalEngine,self).__init__(system_generator, proposal_metadata)
+        super(PolymerProposalEngine,self).__init__(system_generator, proposal_metadata=proposal_metadata)
 
     def propose(self, current_system, current_topology, current_metadata=None):
         return TopologyProposal(new_topology=app.Topology(), old_topology=app.Topology(), old_system=current_system, old_chemical_state_key="C", new_chemical_state_key="C", logp_proposal=0.0, new_to_old_atom_map={0 : 0}, metadata=current_metadata)
@@ -730,7 +730,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         self._n_molecules = len(list_of_smiles)
         self._generated_systems = dict()
         self._generated_topologies = dict()
-        super(SmallMoleculeSetProposalEngine, self).__init__(system_generator, proposal_metadata)
+        super(SmallMoleculeSetProposalEngine, self).__init__(system_generator, proposal_metadata=proposal_metadata)
 
     def propose(self, current_system, current_topology, current_metadata=None):
         """

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -68,7 +68,7 @@ def simulate(system, positions, nsteps=500, timestep=1.0*unit.femtoseconds, temp
     velocities = context.getState(getVelocities=True).getVelocities(asNumpy=True)
     return [positions, velocities]
 
-def check_alchemical_null_elimination(topology_proposal, ncmc_nsteps=50, NSIGMA_MAX=6.0):
+def check_alchemical_null_elimination(topology_proposal, positions, ncmc_nsteps=50, NSIGMA_MAX=6.0):
     """
     Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
 
@@ -98,7 +98,6 @@ def check_alchemical_null_elimination(topology_proposal, ncmc_nsteps=50, NSIGMA_
     logP_insert_n = np.zeros([niterations], np.float64)
     logP_delete_n = np.zeros([niterations], np.float64)
     logP_switch_n = np.zeros([niterations], np.float64)
-    positions = topology_proposal.old_positions
     print("")
     for iteration in range(nequil):
         [positions, velocities] = simulate(topology_proposal.old_system, positions)
@@ -184,7 +183,7 @@ def test_alchemical_elimination_mutation():
                 old_chemical_state_key='AA', new_chemical_state_key='AG', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=topology_proposal.metadata)
 
     for ncmc_nsteps in [0, 1, 2, 50]:
-        f = partial(check_alchemical_null_elimination, topology_proposal, ncmc_nsteps=ncmc_nsteps)
+        f = partial(check_alchemical_null_elimination, topology_proposal, positions, ncmc_nsteps=ncmc_nsteps)
         f.description = "Testing alchemical null transformation of ALA sidechain in alanine dipeptide with %d NCMC steps" % ncmc_nsteps
         yield f
 
@@ -249,7 +248,7 @@ def test_ncmc_engine_molecule():
             new_topology=topology, new_system=system, old_topology=topology, old_system=system,
             old_chemical_state_key='', new_chemical_state_key='', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata={'test':0.0})
         for ncmc_nsteps in [0, 1, 2, 50]:
-            f = partial(check_alchemical_null_elimination, topology_proposal, ncmc_nsteps=ncmc_nsteps)
+            f = partial(check_alchemical_null_elimination, topology_proposal, positions, ncmc_nsteps=ncmc_nsteps)
             f.description = "Testing alchemical null elimination for '%s' with %d NCMC steps" % (molecule_name, ncmc_nsteps)
             yield f
 
@@ -269,7 +268,7 @@ def test_alchemical_elimination_peptide():
         logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=dict())
 
     for ncmc_nsteps in [0, 1, 2, 50]:
-        f = partial(check_alchemical_null_elimination, topology_proposal, ncmc_nsteps=ncmc_nsteps)
+        f = partial(check_alchemical_null_elimination, topology_proposal, testsystem.positions, ncmc_nsteps=ncmc_nsteps)
         f.description = "Testing alchemical elimination using alanine dipeptide with %d NCMC steps" % ncmc_nsteps
         yield f
 

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -165,7 +165,7 @@ def test_alchemical_elimination_mutation():
 
     # Create forcefield.
     ff = app.ForceField(ff_filename)
-    metadata = {'chain_id' : ' '}
+    chain_id = ' '
     allowed_mutations = [[('2','GLY')]]
 
     from perses.rjmc.topology_proposal import SystemGenerator
@@ -173,15 +173,15 @@ def test_alchemical_elimination_mutation():
 
     # Create a topology proposal fro mutating ALA -> GLY
     from perses.rjmc.topology_proposal import PointMutationEngine
-    proposal_engine = PointMutationEngine(system_generator, max_point_mutants, proposal_metadata, allowed_mutations=allowed_mutations)
-    topology_proposal = proposal_engine.propose(system, topology, positions, metadata)
+    proposal_engine = PointMutationEngine(system_generator, max_point_mutants, chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+    topology_proposal = proposal_engine.propose(system, topology)
 
     # Modify atom mapping to get a null transformation.
     from perses.rjmc.topology_proposal import TopologyProposal
     new_to_old_atom_map = { atom1 : atom1 for atom1 in topology_proposal.new_to_old_atom_map }
     topology_proposal = TopologyProposal(
                 new_topology=topology_proposal.old_topology, new_system=topology_proposal.old_system, old_topology=topology_proposal.old_topology, old_system=topology_proposal.old_system,
-                old_positions=positions, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=topology_proposal.metadata)
+                old_chemical_state_key='AA', new_chemical_state_key='AG', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=topology_proposal.metadata)
 
     for ncmc_nsteps in [0, 1, 2, 50]:
         f = partial(check_alchemical_null_elimination, topology_proposal, ncmc_nsteps=ncmc_nsteps)
@@ -244,10 +244,10 @@ def test_ncmc_engine_molecule():
         # TODO: Use a more rigorous scheme to make sure we are really cutting the molecule in half and not just eliminating hydrogens or something.
         new_to_old_atom_map = { index : index for index in range(int(natoms/2)) }
 
-        from perses.rjmc.topology_proposal import SmallMoleculeTopologyProposal
-        topology_proposal = SmallMoleculeTopologyProposal(
+        from perses.rjmc.topology_proposal import TopologyProposal
+        topology_proposal = TopologyProposal(
             new_topology=topology, new_system=system, old_topology=topology, old_system=system,
-            old_positions=positions, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata={'test':0.0})
+            old_chemical_state_key='', new_chemical_state_key='', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata={'test':0.0})
         for ncmc_nsteps in [0, 1, 2, 50]:
             f = partial(check_alchemical_null_elimination, topology_proposal, ncmc_nsteps=ncmc_nsteps)
             f.description = "Testing alchemical null elimination for '%s' with %d NCMC steps" % (molecule_name, ncmc_nsteps)
@@ -263,7 +263,8 @@ def test_alchemical_elimination_peptide():
     from perses.rjmc.topology_proposal import TopologyProposal
     new_to_old_atom_map = { index : index for index in range(testsystem.system.getNumParticles()) if (index > 3) } # all atoms but N-methyl
     topology_proposal = TopologyProposal(
-        old_system=testsystem.system, old_topology=testsystem.topology, old_positions=testsystem.positions,
+        old_system=testsystem.system, old_topology=testsystem.topology,
+        old_chemical_state_key='AA', new_chemical_state_key='AA',
         new_system=testsystem.system, new_topology=testsystem.topology,
         logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata=dict())
 

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -98,8 +98,8 @@ def test_run_geometry_engine():
     import perses.rjmc.geometry as geometry
     import perses.rjmc.topology_proposal as topology_proposal
 
-    sm_top_proposal = topology_proposal.SmallMoleculeTopologyProposal(new_topology=top2, new_system=sys2, old_topology=top1, old_system=sys1,
-                                                                      old_positions=pos1, logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_mapping, metadata={'test':0.0})
+    sm_top_proposal = topology_proposal.TopologyProposal(new_topology=top2, new_system=sys2, old_topology=top1, old_system=sys1,
+                                                                      old_chemical_state_key='',new_chemical_state_key='', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_mapping, metadata={'test':0.0})
     sm_top_proposal._beta = beta
     geometry_engine = geometry.FFAllAngleGeometryEngine({'test': 'true'})
     test_pdb_file = open("output.pdb", 'w')

--- a/perses/tests/test_sampler.py
+++ b/perses/tests/test_sampler.py
@@ -141,7 +141,7 @@ def test_run_example():
 
         # Propose a transformation from one chemical species to another.
         state_metadata = {'molecule_smiles' : smiles}
-        top_proposal = transformation.propose(system, topology, metadata=state_metadata) # get a new molecule
+        top_proposal = transformation.propose(system, topology, current_metadata=state_metadata) # get a new molecule
 
         # QUESTION: What about instead initializing StateWeight once, and then using
         # log_state_weight = state_weight.computeLogStateWeight(new_topology, new_system, new_metadata)?

--- a/perses/tests/test_sampler.py
+++ b/perses/tests/test_sampler.py
@@ -141,7 +141,7 @@ def test_run_example():
 
         # Propose a transformation from one chemical species to another.
         state_metadata = {'molecule_smiles' : smiles}
-        top_proposal = transformation.propose(system, topology, positions, state_metadata) # get a new molecule
+        top_proposal = transformation.propose(system, topology, metadata=state_metadata) # get a new molecule
 
         # QUESTION: What about instead initializing StateWeight once, and then using
         # log_state_weight = state_weight.computeLogStateWeight(new_topology, new_system, new_metadata)?

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -163,17 +163,16 @@ def test_specify_allowed_mutants():
 
     ff_filename = "amber99sbildn.xml"
     max_point_mutants = 1
-    proposal_metadata = {'ffxmls':[ff_filename]}
 
     ff = app.ForceField(ff_filename)
     system = ff.createSystem(modeller.topology)
-    metadata = {'chain_id' : 'A'}
+    chain_id = 'A'
     allowed_mutations = [[('5','GLU')],[('5','ASN'),('14','PHE')]]
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants,proposal_metadata, allowed_mutations=allowed_mutations)
-    pm_top_proposal = pm_top_engine.propose(system, modeller.topology, modeller.positions, metadata)
+    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants, chain_id, allowed_mutations=allowed_mutations)
+    pm_top_proposal = pm_top_engine.propose(system, modeller.topology)
 
 
 def test_run_point_mutation_propose():
@@ -192,16 +191,15 @@ def test_run_point_mutation_propose():
 
     ff_filename = "amber99sbildn.xml"
     max_point_mutants = 1
-    proposal_metadata = {'ffxmls':[ff_filename]}
 
     ff = app.ForceField(ff_filename)
     system = ff.createSystem(modeller.topology)
-    metadata = {'chain_id' : 'A'}
+    chain_id = 'A'
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants,proposal_metadata)
-    pm_top_proposal = pm_top_engine.propose(system, modeller.topology, modeller.positions, metadata)
+    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants, chain_id)
+    pm_top_proposal = pm_top_engine.propose(system, modeller.topology)
 
 
 def test_mutate_from_every_amino_to_every_other():
@@ -226,15 +224,14 @@ def test_mutate_from_every_amino_to_every_other():
 
     ff_filename = "amber99sbildn.xml"
     max_point_mutants = 1
-    proposal_metadata = {'ffxmls':[ff_filename]}
 
     ff = app.ForceField(ff_filename)
     system = ff.createSystem(modeller.topology)
-    metadata = {'chain_id' : 'A'}
+    chain_id = 'A'
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants,proposal_metadata)
+    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, max_point_mutants, chain_id)
 
     current_system = system
     current_topology = modeller.topology
@@ -242,7 +239,7 @@ def test_mutate_from_every_amino_to_every_other():
 
     old_topology = copy.deepcopy(current_topology)
 
-    chain_id = metadata['chain_id']
+    metadata = dict()
     for atom in modeller.topology.atoms():
         atom.old_index = atom.index
 
@@ -294,6 +291,7 @@ def test_mutate_from_every_amino_to_every_other():
 
     old_topology = copy.deepcopy(current_topology)
 
+    old_chemical_state_key = pm_top_engine.compute_state_key(old_topology)
 
     for chain in modeller.topology.chains():
         if chain.id == chain_id:
@@ -349,8 +347,9 @@ def test_mutate_from_every_amino_to_every_other():
             templates = pm_top_engine._ff.getMatchingTemplates(new_topology)
             assert [templates[index].name == residue.name for index, (residue, name) in enumerate(residue_map)]
 
+            new_chemical_state_key = pm_top_engine.compute_state_key(new_topology)
             new_system = pm_top_engine._system_generator.build_system(new_topology)
-            pm_top_proposal = topology_proposal.PolymerTopologyProposal(new_topology=new_topology, new_system=new_system, old_topology=old_topology, old_system=current_system, old_positions=current_positions, logp_proposal=0.0, new_to_old_atom_map=atom_map, metadata=metadata)
+            pm_top_proposal = topology_proposal.TopologyProposal(new_topology=new_topology, new_system=new_system, old_topology=old_topology, old_system=current_system, old_chemical_state_key=old_chemical_state_key, new_chemical_state_key=new_chemical_state_key, logp_proposal=0.0, new_to_old_atom_map=atom_map, metadata=metadata)
         assert matching_amino_found == 1
 
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -84,10 +84,10 @@ def test_small_molecule_proposals():
     proposal_engine = topology_proposal.SmallMoleculeSetProposalEngine(list_of_smiles, app.Topology(), system_generator)
     initial_molecule = generate_initial_molecule('CCC')
     initial_system, initial_positions, initial_topology = oemol_to_omm_ff(initial_molecule, "MOL")
-    proposal = proposal_engine.propose(initial_system, initial_topology, initial_positions, beta)
+    proposal = proposal_engine.propose(initial_system, initial_topology)
     for i in range(50):
         #positions are ignored here, and we don't want to run the geometry engine
-        new_proposal = proposal_engine.propose(proposal.old_system, proposal.old_topology, initial_positions, beta)
+        new_proposal = proposal_engine.propose(proposal.old_system, proposal.old_topology)
         stats_dict[new_proposal.molecule_smiles] += 1
         #check that the molecule it generated is actually the smiles we expect
         matching_molecules = [res for res in proposal.new_topology.residues() if res.name=='MOL']
@@ -358,6 +358,6 @@ if __name__ == "__main__":
     test_run_point_mutation_propose()
     test_mutate_from_every_amino_to_every_other()
     test_specify_allowed_mutants()
-    test_small_molecule_proposals()
+#    test_small_molecule_proposals()
 
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -358,6 +358,6 @@ if __name__ == "__main__":
     test_run_point_mutation_propose()
     test_mutate_from_every_amino_to_every_other()
     test_specify_allowed_mutants()
-#    test_small_molecule_proposals()
+    test_small_molecule_proposals()
 
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -88,7 +88,7 @@ def test_small_molecule_proposals():
     for i in range(50):
         #positions are ignored here, and we don't want to run the geometry engine
         new_proposal = proposal_engine.propose(proposal.old_system, proposal.old_topology)
-        stats_dict[new_proposal.molecule_smiles] += 1
+        stats_dict[new_proposal._smiles_list] += 1
         #check that the molecule it generated is actually the smiles we expect
         matching_molecules = [res for res in proposal.new_topology.residues() if res.name=='MOL']
         if len(matching_molecules) != 1:

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -88,7 +88,7 @@ def test_small_molecule_proposals():
     for i in range(50):
         #positions are ignored here, and we don't want to run the geometry engine
         new_proposal = proposal_engine.propose(proposal.old_system, proposal.old_topology)
-        stats_dict[new_proposal._smiles_list] += 1
+        stats_dict[new_proposal.new_chemical_state_key] += 1
         #check that the molecule it generated is actually the smiles we expect
         matching_molecules = [res for res in proposal.new_topology.residues() if res.name=='MOL']
         if len(matching_molecules) != 1:


### PR DESCRIPTION
Changes:
* turned ```proposal_metadata``` and ```current_metadata``` into optional arguments
* removed ```current_positions``` from ```PointMutationEngine.propose()``` -- generating ```np.zeros``` for ```Modeller``` input instead, can later eliminate ```Modeller``` altogether but not currently a priority
* ```chain_id``` is input to ```PointMutationEngine``` constructor
* ```PointMutationEngine._ff``` obtained from ```SystemGenerator```
* added method ```compute_state_key(self, topology)```
* returning ```old_chemical_state_key``` and ```new_chemical_state_key```