### PR TITLE
Fix SmallMoleculeProposalEngine

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1049,6 +1049,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
                         newAtom = receptor_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
                         newAtoms[atom] = newAtom
         for bond in topology.bonds():
+            if bond[0].residue.name==self._residue_name or bond[1].residue.name==self._residue_name:
+                continue
             receptor_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
         return receptor_topology
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1005,7 +1005,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             The first index of the small molecule
         """
         mol_topology = forcefield_generators.generateTopologyFromOEMol(oemol_proposed)
-
+        new_topology = self._remove_small_molecule(current_topology)
         mol_start_index = 0
         newAtoms = {}
         for chain in mol_topology.chains():
@@ -1049,6 +1049,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
                         newAtom = receptor_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
                         newAtoms[atom] = newAtom
         for bond in topology.bonds():
+            receptor_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
+        return receptor_topology
 
 
     def _smiles_to_oemol(self, smiles_string):

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -81,7 +81,7 @@ def test_small_molecule_proposals():
     gaff_xml_filename = get_data_filename('data/gaff.xml')
     stats_dict = {smiles : 0 for smiles in list_of_smiles}
     system_generator = topology_proposal.SystemGenerator([gaff_xml_filename])
-    proposal_engine = topology_proposal.SmallMoleculeSetProposalEngine(list_of_smiles, app.Topology(), system_generator)
+    proposal_engine = topology_proposal.SmallMoleculeSetProposalEngine(list_of_smiles, system_generator)
     initial_molecule = generate_initial_molecule('CCC')
     initial_system, initial_positions, initial_topology = oemol_to_omm_ff(initial_molecule, "MOL")
     proposal = proposal_engine.propose(initial_system, initial_topology)
@@ -390,8 +390,8 @@ def test_run_peptide_library_engine():
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
 if __name__ == "__main__":
-    test_run_point_mutation_propose()
-    test_mutate_from_every_amino_to_every_other()
-    test_specify_allowed_mutants()
-    test_run_peptide_library_engine()
+    #test_run_point_mutation_propose()
+    #test_mutate_from_every_amino_to_every_other()
+    #test_specify_allowed_mutants()
+    #test_run_peptide_library_engine()
     test_small_molecule_proposals()

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -390,8 +390,8 @@ def test_run_peptide_library_engine():
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
 if __name__ == "__main__":
-    #test_run_point_mutation_propose()
-    #test_mutate_from_every_amino_to_every_other()
-    #test_specify_allowed_mutants()
-    #test_run_peptide_library_engine()
+    test_run_point_mutation_propose()
+    test_mutate_from_every_amino_to_every_other()
+    test_specify_allowed_mutants()
+    test_run_peptide_library_engine()
     test_small_molecule_proposals()


### PR DESCRIPTION
It no longer requires a `receptor_topology`, instead removing the small molecule by the name set in the constructor (default MOL) each time to get the appropriate environment.