### PR TITLE
Canonicalize input smiles

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ script:
   - conda remove --yes parmed parmed-dev && conda install --yes parmed-dev
   - conda remove --yes openmm openmm-dev && conda install --yes openmm-dev
   # Run tests
-  - cd devtools && nosetests --processes=-1 --process-timeout=1800 $PACKAGENAME --nocapture --verbosity=3 --with-doctest --with-timer && cd ..
+  - cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=3 --with-doctest --with-timer && cd ..
 env:
   matrix:
     - python=2.7  CONDA_PY=27 OPENEYE_CHANNEL="-i https://pypi.anaconda.org/openeye/channel/main/simple"

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -885,7 +885,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
     """
 
     def __init__(self, list_of_smiles, system_generator, residue_name='MOL', proposal_metadata=None):
-        self._smiles_list = list_of_smiles
+        self._smiles_list = [self._canonicalize_smiles(smiles) for smiles in list_of_smiles]
         self._n_molecules = len(list_of_smiles)
         self._residue_name = residue_name
         self._generated_systems = dict()

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -885,6 +885,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
     """
 
     def __init__(self, list_of_smiles, system_generator, residue_name='MOL', proposal_metadata=None):
+        list_of_smiles = list(set(list_of_smiles))
         self._smiles_list = [self._canonicalize_smiles(smiles) for smiles in list_of_smiles]
         self._n_molecules = len(list_of_smiles)
         self._residue_name = residue_name

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -940,6 +940,25 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
                                                  new_to_old_atom_map=adjusted_atom_map, old_chemical_state_key=current_mol_smiles, new_chemical_state_key=proposed_mol_smiles)
         return proposal
 
+    def _canonicalize_smiles(self, smiles):
+        """
+        Convert a SMILES string into canonical isomeric smiles
+
+        Parameters
+        ----------
+        smiles : str
+            Any valid SMILES for a molecule
+
+        Returns
+        -------
+        iso_can_smiles : str
+            OpenEye isomeric canonical smiles corresponding to the input
+        """
+        mol = oechem.OEMol()
+        oechem.OESmilesToMol(mol, smiles)
+        iso_can_smiles = oechem.OECreateIsoSmiString(mol)
+        return iso_can_smiles
+
     def _topology_to_smiles(self, topology):
         """
         Get the smiles string corresponding to a specific residue in an


### PR DESCRIPTION
Makes sure that the input smiles strings are canonical isomeric smiles in the openeye flavor by taking the input library and converting each to an `OEMol` then to canonical isomeric SMILES.