### PR TITLE
Sanitize SMILES strings used in testsystems

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -335,7 +335,7 @@ class NCMCEngine(object):
             integrator.step(1)
         except Exception as e:
             # Trap NaNs as a special exception (allowing us to reject later, if desired)
-            if e.msg == "Particle coordinate is nan":
+            if str(e) == "Particle coordinate is nan":
                 raise NaNException(str(e))
             else:
                 raise e

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -265,7 +265,8 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
     """
     def __init__(self):
         super(SmallMoleculeLibraryTestSystem, self).__init__()
-        molecules = self.molecules # Currently only SMILES is supported
+        # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
+        molecules = sanitizeSMILES(self.molecules)
         environments = ['explicit', 'vacuum']
 
         # Create a system generator for our desired forcefields.
@@ -362,7 +363,7 @@ class AlkanesTestSystem(SmallMoleculeLibraryTestSystem):
     Library of small alkanes in various solvent environments.
     """
     def __init__(self):
-        self.molecules = sanitizeSMILES(['CC', 'CCC', 'CCCC', 'CCCCC', 'CCCCCC'])
+        self.molecules = ['CC', 'CCC', 'CCCC', 'CCCCC', 'CCCCCC']
         super(AlkanesTestSystem, self).__init__()
 
 class KinaseInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
@@ -381,7 +382,7 @@ class KinaseInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
                 name = row[0]
                 smiles = row[1]
                 molecules.append(smiles)
-        self.molecules = sanitizeSMILES(molecules)
+        self.molecules = molecules
         # Intialize
         super(KinaseInhibitorsTestSystem, self).__init__()
 
@@ -407,8 +408,7 @@ class T4LysozymeInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
         molecules = list()
         molecules += self.read_smiles(resource_filename('perses', 'data/L99A-binders.txt'))
         molecules += self.read_smiles(resource_filename('perses', 'data/L99A-non-binders.txt'))
-        # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
-        self.molecules = sanitizeSMILES(molecules)
+        self.molecules = molecules
         # Intialize
         super(T4LysozymeInhibitorsTestSystem, self).__init__()
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -33,6 +33,7 @@ from functools import partial
 from pkg_resources import resource_filename
 from openeye import oechem
 from openmmtools import testsystems
+from perses.tests.utils import sanitizeSMILES
 
 ################################################################################
 # CONSTANTS
@@ -360,8 +361,8 @@ class AlkanesTestSystem(SmallMoleculeLibraryTestSystem):
     """
     Library of small alkanes in various solvent environments.
     """
-    molecules = ['CC', 'CCC', 'CCCC', 'CCCCC', 'CCCCCC']
     def __init__(self):
+        self.molecules = sanitizeSMILES(['CC', 'CCC', 'CCCC', 'CCCCC', 'CCCCCC'])
         super(AlkanesTestSystem, self).__init__()
 
 class KinaseInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
@@ -380,7 +381,7 @@ class KinaseInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
                 name = row[0]
                 smiles = row[1]
                 molecules.append(smiles)
-        self.molecules = molecules
+        self.molecules = sanitizeSMILES(molecules)
         # Intialize
         super(KinaseInhibitorsTestSystem, self).__init__()
 
@@ -388,23 +389,26 @@ class T4LysozymeInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
     """
     Library of T4 lysozyme L99A inhibitors in various solvent environments.
     """
-    molecules = list()
-
     def read_smiles(self, filename):
         import csv
+        molecules = list()
         with open(filename, 'r') as csvfile:
             csvreader = csv.reader(csvfile, delimiter='\t', quotechar='"')
             for row in csvreader:
                 name = row[0]
                 smiles = row[1]
                 reference = row[2]
-                self.molecules.append(smiles)
+                molecules.append(smiles)
+        return molecules
 
     def __init__(self):
         # Read SMILES from CSV file of clinical kinase inhibitors.
         from pkg_resources import resource_filename
-        self.read_smiles(resource_filename('perses', 'data/L99A-binders.txt'))
-        self.read_smiles(resource_filename('perses', 'data/L99A-non-binders.txt'))
+        molecules = list()
+        molecules += self.read_smiles(resource_filename('perses', 'data/L99A-binders.txt'))
+        molecules += self.read_smiles(resource_filename('perses', 'data/L99A-non-binders.txt'))
+        # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
+        self.molecules = sanitizeSMILES(molecules)
         # Intialize
         super(T4LysozymeInhibitorsTestSystem, self).__init__()
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -347,6 +347,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         designer = MultiTargetDesign(target_samplers)
 
         # Store things.
+        self.molecules = molecules
         self.environments = environments
         self.topologies = topologies
         self.positions = positions

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -50,7 +50,7 @@ def show_topology(topology):
                 output += " %8d" % bond[0].index
         output += '\n'
     print(output)
-    
+
 def extractPositionsFromOEMOL(molecule):
     positions = unit.Quantity(np.zeros([molecule.NumAtoms(), 3], np.float32), unit.angstroms)
     coords = molecule.GetCoords()
@@ -218,3 +218,214 @@ def createSystemFromIUPAC(iupac_name):
     positions = extractPositionsFromOEMOL(molecule)
 
     return (molecule, system, positions, topology)
+
+def get_atoms_with_undefined_stereocenters(molecule, verbose=False):
+    """
+    Return list of atoms with undefined stereocenters.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule to check.
+    verbose : bool, optional, default=False
+        If True, will print verbose output about undefined stereocenters.
+
+    Returns
+    -------
+    atoms : list of openeye.oechem.OEAtom
+        List of atoms with undefined stereochemistry.
+
+    """
+    from openeye.oechem import OEAtomStereo_Undefined, OEAtomStereo_Tetrahedral
+    undefined_stereocenters = list()
+    for atom in molecule.GetAtoms():
+        chiral = atom.IsChiral()
+        stereo = OEAtomStereo_Undefined
+        if atom.HasStereoSpecified(OEAtomStereo_Tetrahedral):
+            v = list()
+            for nbr in atom.GetAtoms():
+                v.append(nbr)
+            stereo = atom.GetStereo(v, OEAtomStereo_Tetrahedral)
+
+        if chiral and (stereo == OEAtomStereo_Undefined):
+            undefined_stereocenters.append(atom)
+            if verbose:
+                print("Atom %d (%s) of molecule '%s' has undefined stereochemistry (chiral=%s, stereo=%s)." % (atom.GetIdx(), atom.GetName(), molecule.GetTitle(), str(chiral), str(stereo)))
+
+    return undefined_stereocenters
+
+def has_undefined_stereocenters(molecule, verbose=False):
+    """
+    Check if given molecule has undefined stereocenters.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule to check.
+    verbose : bool, optional, default=False
+        If True, will print verbose output about undefined stereocenters.
+
+    Returns
+    -------
+    result : bool
+        True if molecule has undefined stereocenters.
+
+    Examples
+    --------
+    Enumerate undefined stereocenters
+    >>> smiles = "[H][C@]1(NC[C@@H](CC1CO[C@H]2CC[C@@H](CC2)O)N)[H]"
+    >>> from openeye.oechem import OEGraphMol, OESmilesToMol
+    >>> molecule = OEGraphMol()
+    >>> OESmilesToMol(molecule, smiles)
+    >>> print has_undefined_stereocenters(smiles)
+    True
+
+    """
+    atoms = get_atoms_with_undefined_stereocenters(molecule, verbose=verbose)
+    if len(atoms) > 0:
+        return True
+
+    return False
+
+def enumerate_undefined_stereocenters(molecule, verbose=False):
+    """
+    Check if given molecule has undefined stereocenters.
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol
+        The molecule whose stereocenters are to be expanded.
+    verbose : bool, optional, default=False
+        If True, will print verbose output about undefined stereocenters.
+
+    Returns
+    -------
+    molecules : list of OEMol
+        The molecules with fully defined stereocenters.
+
+    Examples
+    --------
+    Enumerate undefined stereocenters
+    >>> smiles = "[H][C@]1(NC[C@@H](CC1CO[C@H]2CC[C@@H](CC2)O)N)[H]"
+    >>> from openeye.oechem import OEGraphMol, OESmilesToMol
+    >>> molecule = OEGraphMol()
+    >>> OESmilesToMol(molecule, smiles)
+    >>> molecules = enumerate_undefined_stereocenters(smiles)
+    >>> len(molecules)
+    2
+
+    """
+    from openeye.oechem import OEAtomStereo_RightHanded, OEAtomStereo_LeftHanded, OEAtomStereo_Tetrahedral
+    from itertools import product
+
+    molecules = list()
+    atoms = get_atoms_with_undefined_stereocenters(molecule, verbose=verbose)
+    for stereocenters in product([OEAtomStereo_RightHanded, OEAtomStereo_LeftHanded], repeat=len(atoms)):
+        molecule = molecule.CreateCopy()
+        for (index,atom) in enumerate(atoms):
+            neighbors = list()
+            for neighbor in atom.GetAtoms():
+                neighbors.append(neighbor)
+            atom.SetStereo(neighbors, OEAtomStereo_Tetrahedral, stereocenters[index])
+        molecules.append(molecule)
+
+    return molecules
+
+def sanitizeSMILES(smiles_list, mode='drop', verbose=False):
+    """
+    Sanitize set of SMILES strings by ensuring all are canonical isomeric SMILES.
+
+    Parameters
+    ----------
+    smiles_list : iterable of str
+        The set of SMILES strings to sanitize.
+    mode : str, optional, default='drop'
+        When a SMILES string that does not correspond to canonical isomeric SMILES is found, select the action to be performed.
+        'exception' : raise an `Exception`
+        'drop' : drop the SMILES string
+        'expand' : expand all stereocenters into multiple molecules
+    verbose : bool, optional, default=False
+        If True, print verbose output.
+
+    Returns
+    -------
+    sanitized_smiles_list : list of str
+         Sanitized list of canonical isomeric SMILES strings.
+
+    This function uses `oeomega` to ensure SMILES strings can be round-tripped.
+
+    Examples
+    --------
+
+    Sanitize a simple list.
+    >>> smiles_list = ['CC', 'CCC', '[H][C@]1(NC[C@@H](CC1CO[C@H]2CC[C@@H](CC2)O)N)[H]']
+
+    Throw an exception if undefined stereochemistry is present.
+    >>> sanitized_smiles_list = sanitizeSMILES(smiles_list, mode='exception')
+    Traceback (most recent call last):
+      ...
+    Exception: Molecule '[H][C@]1(NC[C@@H](CC1CO[C@H]2CC[C@@H](CC2)O)N)[H]' has undefined stereocenters
+
+    Drop molecules iwth undefined stereochemistry.
+    >>> sanitized_smiles_list = sanitizeSMILES(smiles_list, mode='drop')
+    >>> len(sanitized_smiles_list)
+    2
+
+    Expand molecules iwth undefined stereochemistry.
+    >>> sanitized_smiles_list = sanitizeSMILES(smiles_list, mode='expand')
+    >>> len(sanitized_smiles_list)
+    4
+
+    """
+    from openeye.oechem import OEGraphMol, OESmilesToMol, OECreateIsoSmiString
+    sanitized_smiles_list = list()
+    for smiles in smiles_list:
+        molecule = OEGraphMol()
+        OESmilesToMol(molecule, smiles)
+
+        # DEBUG
+        molecule.SetTitle(smiles)
+        oechem.OEAssignAromaticFlags(molecule, oechem.OEAroModelOpenEye)
+        oechem.OEAddExplicitHydrogens(molecule)
+        oechem.OETriposAtomNames(molecule)
+
+        if has_undefined_stereocenters(molecule, verbose=verbose):
+            if mode == 'drop':
+                continue
+            elif mode == 'exception':
+                raise Exception("Molecule '%s' has undefined stereocenters" % smiles)
+            elif mode == 'expand':
+                molecules = enumerate_undefined_stereocenters(molecule, verbose=verbose)
+                for molecule in molecules:
+                    isosmiles = OECreateIsoSmiString(molecule)
+                    sanitized_smiles_list.append(isosmiles)
+        else:
+            # Convert to OpenEye's canonical isomeric SMILES.
+            isosmiles = OECreateIsoSmiString(molecule)
+            sanitized_smiles_list.append(isosmiles)
+
+    return sanitized_smiles_list
+
+
+def test_sanitizeSMILES():
+    """
+    Test SMILES sanitization.
+    """
+    smiles_list = ['CC', 'CCC', '[H][C@]1(NC[C@@H](CC1CO[C@H]2CC[C@@H](CC2)O)N)[H]']
+    sanitized_smiles_list = sanitizeSMILES(smiles_list, mode='drop')
+
+    if len(sanitized_smiles_list) != 2:
+        raise Exception("Molecules with undefined stereochemistry are not being properly dropped.")
+
+    sanitized_smiles_list = sanitizeSMILES(smiles_list, mode='expand')
+    if len(sanitized_smiles_list) != 4:
+        raise Exception("Molecules with undefined stereochemistry are not being properly expanded.")
+
+    # Check that all molecules can be round-tripped.
+    from openeye.oechem import OEGraphMol, OESmilesToMol, OECreateIsoSmiString
+    for smiles in sanitized_smiles_list:
+        molecule = OEGraphMol()
+        OESmilesToMol(molecule, smiles)
+        isosmiles = OECreateIsoSmiString(molecule)
+        if (smiles != isosmiles):
+            raise Exception("Molecule '%s' was not properly round-tripped (result was '%s')" % (smiles, isosmiles))


### PR DESCRIPTION
SMILES strings in all `testsystems` now
* expand all unspecified stereocenters into all possible chiral variant molecules
* convert all molecules to canonical isomeric SMILES so they can be round-tripped to get identical SMILES strings

This is handled through new functions in `perses.tests.utils` that will eventually get moved to `openmoltools`:
* `sanitizeSMILES(molecule_list)` handles the sanitization (in a fast manner that doesn't involve `OEOmega`)
* `enumerate_undefined_stereocenters(molecule)` expands molecules with undefined stereocenters
* `has_undefined_stereocenters(molecule)` returns `True` if `molecule` has undefined stereocenters

Addresses #120