### PR TITLE
Make it easy to write out PDB files for proposed kinase inhibitors

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -636,10 +636,8 @@ class PointMutationEngine(PolymerProposalEngine):
                 his_prob = np.array([0.5 for i in range(len(his_state))])
                 his_choice = np.random.choice(range(len(his_state)),p=his_prob)
                 index_to_new_residues[residue_id_to_index.index(residue_id)] = his_state[his_choice]
-
-        # DEBUG
-        print('Proposed mutation:')
-        print(allowed_mutations[proposed_location])
+            # DEBUG        
+            print('Proposed mutation: %s %s %s' % (original_residue.name, residue_id, residue_name))
 
         # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)
         return index_to_new_residues

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -612,6 +612,7 @@ class ExpandedEnsembleSampler(object):
         self.number_of_state_visits = dict()
         self.verbose = False
         self.pdbfile = None # if not None, write PDB file
+        self.geometry_pdbfile = None # if not None, write PDB file of geometry proposals
         self.accept_everything = False # if True, will accept anything that doesn't lead to NaNs
 
 
@@ -723,6 +724,12 @@ class ExpandedEnsembleSampler(object):
             geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)
             geometry_logp = geometry_logp_reverse - geometry_logp_propose
 
+            if self.geometry_pdbfile is not None:
+                print("Writing proposed geometry...")
+                from simtk.openmm.app import PDBFile
+                PDBFile.writeModel(topology_proposal.new_topology, geometry_new_positions, self.geometry_pdbfile, self.iteration)
+                self.geometry_pdbfile.flush()
+
             if self.verbose: print("Performing NCMC insertion")
             # Alchemically introduce new atoms.
             [ncmc_new_positions, ncmc_introduction_logp, potential_insert] = self.ncmc_engine.integrate(topology_proposal, geometry_new_positions, direction='insert')
@@ -790,6 +797,7 @@ class ExpandedEnsembleSampler(object):
             print("Writing frame...")
             from simtk.openmm.app import PDBFile
             PDBFile.writeModel(self.topology, self.sampler.sampler_state.positions, self.pdbfile, self.iteration)
+            self.pdbfile.flush()
 
     def run(self, niterations=1):
         """

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -987,9 +987,10 @@ def run_kinase_inhibitors():
     testsystem = KinaseInhibitorsTestSystem()
     environment = 'vacuum'
     testsystem.exen_samplers[environment].pdbfile = open('kinase-inhibitors-vacuum.pdb', 'w')
+    testsystem.exen_samplers[environment].geometry_pdbfile = open('kinase-inhibitors-%s-geometry-proposals.pdb' % environment, 'w')
     testsystem.exen_samplers[environment].options={'nsteps':0}
     testsystem.mcmc_samplers[environment].nsteps = 50
-    testsystem.sams_samplers[environment].run(niterations=5)
+    testsystem.sams_samplers[environment].run(niterations=100)
 
 def run_valence_system():
     """
@@ -1004,5 +1005,5 @@ def run_valence_system():
 
 if __name__ == '__main__':
     #run_valence_system()
-    #run_kinase_inhibitors()
-    run_abl_imatinib()
+    run_kinase_inhibitors()
+    #run_abl_imatinib()

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -966,9 +966,10 @@ def run_abl_imatinib():
     for environment in ['vacuum-complex']:
         print environment
         testsystem.exen_samplers[environment].pdbfile = open('abl-imatinib-%s.pdb' % environment, 'w')
-        testsystem.exen_samplers[environment].options={'nsteps':5000, 'timestep' : 1.0 * unit.femtoseconds}
+        testsystem.exen_samplers[environment].geometry_pdbfile = open('abl-imatinib-%s-geometry-proposals.pdb' % environment, 'w')
+        testsystem.exen_samplers[environment].options={'nsteps':20000, 'timestep' : 1.0 * unit.femtoseconds}
         testsystem.exen_samplers[environment].accept_everything = False # accept everything that doesn't lead to NaN for testing
-        testsystem.mcmc_samplers[environment].nsteps = 5000
+        testsystem.mcmc_samplers[environment].nsteps = 20000
         testsystem.mcmc_samplers[environment].timestep = 1.0 * unit.femtoseconds
         #testsystem.mcmc_samplers[environment].run(niterations=5)
         testsystem.exen_samplers[environment].run(niterations=100)


### PR DESCRIPTION
@pgrinaway: Try out 
```
python perses/tests/testsystems.pdb
```
and look at the generated `kinase-inhibitors-vacuum-geometry-proposals.pdb`, which writes out the geometry proposals.  Is this just the ring fusion problem?