### PR TITLE
Fix geometry engine torsion biases and MCSS overlap criteria

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -76,7 +76,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
     def __init__(self, metadata=None):
         self._metadata = metadata
         self.write_proposal_pdb = False # if True, will write PDB for sequential atom placements
-        self.pdb_filename_prefix = None # PDB file prefix for writing sequential atom placements
+        self.pdb_filename_prefix = 'geometry-proposal' # PDB file prefix for writing sequential atom placements
         self.nproposed = 0 # number of times self.propose() has been called
 
     def propose(self, top_proposal, current_positions, beta):

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -298,6 +298,12 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         if self.write_proposal_pdb:
             pdbfile.close()
 
+            prefix = '%s-%d-%s' % (self.pdb_filename_prefix, self.nproposed, direction)
+            if direction == 'forward':
+                pdbfile = open('%s-final.pdb' % prefix, 'w')
+                PDBFile.writeFile(top_proposal.new_topology, new_positions, file=pdbfile)
+                pdbfile.close()
+
         return logp_proposal, new_positions
 
     @staticmethod

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -976,10 +976,17 @@ class GeometrySystemGenerator(object):
         k = 10.0*units.kilojoule_per_mole
         print([atom.name for atom in growth_indices])
         for torsion in relevant_torsion_list:
-            angle = torsion.radians*units.radian
             #make sure to get the atom index that corresponds to the topology
             atom_indices = [torsion.a.GetData("topology_index"), torsion.b.GetData("topology_index"), torsion.c.GetData("topology_index"), torsion.d.GetData("topology_index")]
-            phase = (np.pi)*units.radians+angle
+            # Determine phase in [-pi,+pi) interval
+            #phase = (np.pi)*units.radians+angle
+            phase = torsion.radians + np.pi
+            while (phase >= np.pi):
+                phase -= 2*np.pi
+            while (phase < -np.pi):
+                phase += 2*np.pi
+            phase *= units.radian
+            print('PHASE>>>> ' + str(phase)) # DEBUG
             growth_idx = self._calculate_growth_idx(atom_indices, growth_indices)
             atom_names = [torsion.a.GetName(), torsion.b.GetName(), torsion.c.GetName(), torsion.d.GetName()]
             print("Adding torsion with atoms %s and growth index %d" %(str(atom_names), growth_idx))

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1190,9 +1190,12 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         oegraphmol_current = oechem.OEGraphMol(current_molecule)
         oegraphmol_proposed = oechem.OEGraphMol(proposed_molecule)
         mcs = oechem.OEMCSSearch(oechem.OEMCSType_Exhaustive)
-        #atomexpr = oechem.OEExprOpts_AtomicNumber
+        # Experimental tinkering with options for MCSS:
+        #atomexpr = oechem.OEExprOpts_AutomorphAtoms | oechem.OEExprOpts_EqCAliphaticONS | oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqCHalogen | oechem.OEExprOpts_EqHalogen | oechem.OEExprOpts_EqCPSAcidRoot | oechem.OEExprOpts_EqNotAromatic
+        #bondexpr = oechem.OEExprOpts_AutomorphBonds | oechem.OEExprOpts_EqDoubleTriple
+        # This seems to work reasonably well:
         atomexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember | oechem.OEExprOpts_HvyDegree
-        bondexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember 
+        bondexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember
         mcs.Init(oegraphmol_current, atomexpr, bondexpr)
         mcs.SetMCSFunc(oechem.OEMCSMaxBondsCompleteCycles())
         unique = True

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1190,8 +1190,9 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         oegraphmol_current = oechem.OEGraphMol(current_molecule)
         oegraphmol_proposed = oechem.OEGraphMol(proposed_molecule)
         mcs = oechem.OEMCSSearch(oechem.OEMCSType_Exhaustive)
-        atomexpr = oechem.OEExprOpts_AtomicNumber
-        bondexpr = oechem.OEExprOpts_BondOrder
+        #atomexpr = oechem.OEExprOpts_AtomicNumber
+        atomexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember | oechem.OEExprOpts_HvyDegree
+        bondexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember 
         mcs.Init(oegraphmol_current, atomexpr, bondexpr)
         mcs.SetMCSFunc(oechem.OEMCSMaxBondsCompleteCycles())
         unique = True

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -720,15 +720,18 @@ class ExpandedEnsembleSampler(object):
             if self.verbose: print("Geometry engine proposal...")
             # Generate coordinates for new atoms and compute probability ratio of old and new probabilities.
             geometry_old_positions = ncmc_old_positions
-            geometry_new_positions, geometry_logp_propose  = self.geometry_engine.propose(topology_proposal, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            geometry_logp = geometry_logp_reverse - geometry_logp_propose
+            geometry_new_positions, geometry_logp_propose = self.geometry_engine.propose(topology_proposal, geometry_old_positions, self.sampler.thermodynamic_state.beta)
 
             if self.geometry_pdbfile is not None:
                 print("Writing proposed geometry...")
+                self.geometry_pdbfile.write('MODEL %5d\n' % (self.iteration+1))
                 from simtk.openmm.app import PDBFile
-                PDBFile.writeModel(topology_proposal.new_topology, geometry_new_positions, self.geometry_pdbfile, self.iteration)
+                PDBFile.writeFile(topology_proposal.new_topology, geometry_new_positions, file=self.geometry_pdbfile)
+                self.geometry_pdbfile.write('ENDMDL\n')
                 self.geometry_pdbfile.flush()
+
+            geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)
+            geometry_logp = geometry_logp_reverse - geometry_logp_propose
 
             if self.verbose: print("Performing NCMC insertion")
             # Alchemically introduce new atoms.

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -724,10 +724,10 @@ class ExpandedEnsembleSampler(object):
 
             if self.geometry_pdbfile is not None:
                 print("Writing proposed geometry...")
-                self.geometry_pdbfile.write('MODEL %5d\n' % (self.iteration+1))
+                #self.geometry_pdbfile.write('MODEL     %4d\n' % (self.iteration+1)) # PyMOL doesn't render connectivity correctly this way
                 from simtk.openmm.app import PDBFile
                 PDBFile.writeFile(topology_proposal.new_topology, geometry_new_positions, file=self.geometry_pdbfile)
-                self.geometry_pdbfile.write('ENDMDL\n')
+                #self.geometry_pdbfile.write('ENDMDL\n')
                 self.geometry_pdbfile.flush()
 
             geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -990,6 +990,7 @@ def run_kinase_inhibitors():
     testsystem.exen_samplers[environment].geometry_pdbfile = open('kinase-inhibitors-%s-geometry-proposals.pdb' % environment, 'w')
     testsystem.exen_samplers[environment].options={'nsteps':0}
     testsystem.mcmc_samplers[environment].nsteps = 50
+    testsystem.exen_samplers[environment].geometry_engine.write_proposal_pdb = True # write proposal PDBs
     testsystem.sams_samplers[environment].run(niterations=100)
 
 def run_valence_system():


### PR DESCRIPTION
I've turned on writing of atom-by-atom PDBs for geometry proposals to debug what is going wrong with kinase inhibitors.

It looks like the torsion restraints are not actually biasing the placement of closed rings.  I don't know if there was somehow a reversion somewhere, since this was working before.