### PR TITLE
New atoms for OEMol purpose get -1 index

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -75,7 +75,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
     """
     def __init__(self, metadata=None):
         self._metadata = metadata
-        self.write_proposal_pdb = True # if True, will write PDB for sequential atom placements
+        self.write_proposal_pdb = False # if True, will write PDB for sequential atom placements
         self.pdb_filename_prefix = 'geometry-proposal' # PDB file prefix for writing sequential atom placements
         self.nproposed = 0 # number of times self.propose() has been called
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -75,7 +75,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
     """
     def __init__(self, metadata=None):
         self._metadata = metadata
-        self.write_proposal_pdb = False # if True, will write PDB for sequential atom placements
+        self.write_proposal_pdb = True # if True, will write PDB for sequential atom placements
         self.pdb_filename_prefix = 'geometry-proposal' # PDB file prefix for writing sequential atom placements
         self.nproposed = 0 # number of times self.propose() has been called
 
@@ -347,17 +347,17 @@ class FFAllAngleGeometryEngine(GeometryEngine):
                 highest_index += 1
                 if internal_atom.name=='N':
                     print('Adding H to N')
-                    new_atom = new_topology.addAtom("H2", app.Element.getByAtomicNumber(1), new_res, highest_index)
-                    new_atom.index = highest_index
+                    new_atom = new_topology.addAtom("H2", app.Element.getByAtomicNumber(1), new_res, -1)
+                    new_atom.index = -1
                     new_topology.addBond(new_atoms[internal_atom], new_atom)
                 if internal_atom.name=='C':
                     print('Adding OH to C')
-                    new_atom = new_topology.addAtom("O2", app.Element.getByAtomicNumber(8), new_res, highest_index)
-                    new_atom.index = highest_index
+                    new_atom = new_topology.addAtom("O2", app.Element.getByAtomicNumber(8), new_res, -1)
+                    new_atom.index = -1
                     new_topology.addBond(new_atoms[internal_atom], new_atom)
                     highest_index += 1
-                    new_hydrogen = new_topology.addAtom("HO", app.Element.getByAtomicNumber(1), new_res, highest_index)
-                    new_hydrogen.index = highest_index
+                    new_hydrogen = new_topology.addAtom("HO", app.Element.getByAtomicNumber(1), new_res, -1)
+                    new_hydrogen.index = -1
                     new_topology.addBond(new_hydrogen, new_atom)
             res_to_use = new_res
             external_bonds = list(res_to_use.external_bonds())
@@ -1012,8 +1012,6 @@ class GeometrySystemGenerator(object):
         -------
         heavy_torsions : list of oechem.OETorsion
         """
-
-
         heavy_torsions = []
         for torsion in torsion_list:
             is_h_present = torsion.a.IsHydrogen() + torsion.b.IsHydrogen() + torsion.c.IsHydrogen() + torsion.d.IsHydrogen()


### PR DESCRIPTION
This PR is done. All it does is assign an "index" of -1 for the atoms that we add to make an `OEMol`. This doesn't impact anything else, but will make it easy for @juliebehr to distinguish these atoms when making an atom map between protein residues.