### PR TITLE
Modify chemical_state_keys from PointMutationEngine

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -715,8 +715,6 @@ class PointMutationEngine(PolymerProposalEngine):
         else:
             # index_to_new_residues : dict, key : int (index) , value : str (three letter residue name)
             index_to_new_residues = self._propose_mutations(modeller, chain_id, index_to_new_residues)
-        for key, value in index_to_new_residues.items():
-            if value == 
         # metadata['mutations'] : list(str (three letter WT residue name - index - three letter MUT residue name) )
         metadata['mutations'] = self._save_mutations(modeller, index_to_new_residues)
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -769,7 +769,7 @@ class PointMutationEngine(PolymerProposalEngine):
                 break
         residue_id_to_index = [residue.id for residue in chain._residues]
         # location_prob : np.array, probability value for each residue location (uniform)
-        if self._metadata.has_key('always_change') and self._metadata['always_change']:
+        if 'always_change' in self._metadata and self._metadata['always_change']:
             old_key = self.compute_state_key(modeller.topology)
             location_prob = np.array([1.0/len(allowed_mutations) for i in range(len(allowed_mutations)+1)])
             if old_key == '':
@@ -850,7 +850,7 @@ class PointMutationEngine(PolymerProposalEngine):
             if original_residue.name in ['HIE','HID']:
                 original_residue.name = 'HIS'
             # amino_prob : np.array, probability value for each amino acid option (uniform)
-            if self._metadata.has_key('always_change') and self._metadata['always_change']:
+            if 'always_change' in self._metadata and self._metadata['always_change']:
                 amino_prob = np.array([1.0/(len(aminos)-1) for i in range(len(aminos))])
                 amino_prob[aminos.index(original_residue.name)] = 0.0
             else:

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -723,6 +723,8 @@ class PointMutationEngine(PolymerProposalEngine):
                 break
         residue_id_to_index = [residue.id for residue in chain._residues]
         old_key = self.compute_state_key(modeller.topology)
+        if old_key == '':
+            return index_to_new_residues
         for mutant in old_key.split('-'):
             old_res = mutant[:3]
             residue_id = mutant[3:-3]

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -259,6 +259,11 @@ class PolymerProposalEngine(ProposalEngine):
             atom.old_index = atom.index
 
         index_to_new_residues, metadata = self._choose_mutant(modeller, metadata)
+        # residue_map : list(tuples : simtk.openmm.app.topology.Residue (existing residue), str (three letter residue name of proposed residue))
+        residue_map = self._generate_residue_map(modeller, index_to_new_residues)
+        for (res, new_name) in residue_map:
+            if res.name == new_name:
+                del(index_to_new_residues[res.index])
         if len(index_to_new_residues) == 0:
             atom_map = dict()
             for atom in modeller.topology.atoms():
@@ -710,7 +715,8 @@ class PointMutationEngine(PolymerProposalEngine):
         else:
             # index_to_new_residues : dict, key : int (index) , value : str (three letter residue name)
             index_to_new_residues = self._propose_mutations(modeller, chain_id, index_to_new_residues)
-
+        for key, value in index_to_new_residues.items():
+            if value == 
         # metadata['mutations'] : list(str (three letter WT residue name - index - three letter MUT residue name) )
         metadata['mutations'] = self._save_mutations(modeller, index_to_new_residues)
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -758,24 +758,28 @@ class PointMutationEngine(PolymerProposalEngine):
                 break
         residue_id_to_index = [residue.id for residue in chain._residues]
         # location_prob : np.array, probability value for each residue location (uniform)
-        location_prob = np.array([1.0/len(allowed_mutations) for i in range(len(allowed_mutations))])
-        proposed_location = np.random.choice(range(len(allowed_mutations)), p=location_prob)
-        for residue_id, residue_name in allowed_mutations[proposed_location]:
-            # original_residue : simtk.openmm.app.topology.Residue
-            original_residue = chain._residues[residue_id_to_index.index(residue_id)]
-            if original_residue.name in ['HID','HIE']:
-                original_residue.name = 'HIS'
-            if original_residue.name == residue_name:
-                continue
-            # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)
-            index_to_new_residues[residue_id_to_index.index(residue_id)] = residue_name
-            if residue_name == 'HIS':
-                his_state = ['HIE','HID']
-                his_prob = np.array([0.5 for i in range(len(his_state))])
-                his_choice = np.random.choice(range(len(his_state)),p=his_prob)
-                index_to_new_residues[residue_id_to_index.index(residue_id)] = his_state[his_choice]
-            # DEBUG
-            if self.verbose: print('Proposed mutation: %s %s %s' % (original_residue.name, residue_id, residue_name))
+        location_prob = np.array([1.0/(len(allowed_mutations)+1.0) for i in range(len(allowed_mutations)+1)])
+        proposed_location = np.random.choice(range(len(allowed_mutations)+1), p=location_prob)
+        if proposed_location == len(allowed_mutations):
+            # choose WT
+            pass
+        else:
+            for residue_id, residue_name in allowed_mutations[proposed_location]:
+                # original_residue : simtk.openmm.app.topology.Residue
+                original_residue = chain._residues[residue_id_to_index.index(residue_id)]
+                if original_residue.name in ['HID','HIE']:
+                    original_residue.name = 'HIS'
+                if original_residue.name == residue_name:
+                    continue
+                # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)
+                index_to_new_residues[residue_id_to_index.index(residue_id)] = residue_name
+                if residue_name == 'HIS':
+                    his_state = ['HIE','HID']
+                    his_prob = np.array([0.5 for i in range(len(his_state))])
+                    his_choice = np.random.choice(range(len(his_state)),p=his_prob)
+                    index_to_new_residues[residue_id_to_index.index(residue_id)] = his_state[his_choice]
+                # DEBUG
+                if self.verbose: print('Proposed mutation: %s %s %s' % (original_residue.name, residue_id, residue_name))
 
         # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)
         return index_to_new_residues

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -718,13 +718,13 @@ class PointMutationEngine(PolymerProposalEngine):
 
     def _undo_old_mutants(self, modeller, chain_id):
         index_to_new_residues = dict()
+        old_key = self.compute_state_key(modeller.topology)
+        if old_key == '':
+            return index_to_new_residues
         for chain in modeller.topology.chains():
             if chain.id == chain_id:
                 break
         residue_id_to_index = [residue.id for residue in chain._residues]
-        old_key = self.compute_state_key(modeller.topology)
-        if old_key == '':
-            return index_to_new_residues
         for mutant in old_key.split('-'):
             old_res = mutant[:3]
             residue_id = mutant[3:-3]
@@ -763,6 +763,8 @@ class PointMutationEngine(PolymerProposalEngine):
         for residue_id, residue_name in allowed_mutations[proposed_location]:
             # original_residue : simtk.openmm.app.topology.Residue
             original_residue = chain._residues[residue_id_to_index.index(residue_id)]
+            if original_residue.name in ['HID','HIE']:
+                original_residue.name = 'HIS'
             if original_residue.name == residue_name:
                 continue
             # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)
@@ -816,6 +818,8 @@ class PointMutationEngine(PolymerProposalEngine):
             proposed_location = np.random.choice(range(num_residues), p=location_prob)
             # original_residue : simtk.openmm.app.topology.Residue
             original_residue = chain_residues[proposed_location]
+            if original_residue.name in ['HIE','HID']:
+                original_residue.name = 'HIS'
             # amino_prob : np.array, probability value for each amino acid option (uniform, must choose different from current)
             amino_prob = np.array([1.0/(len(aminos)-1) for i in range(len(aminos))])
             amino_prob[aminos.index(original_residue.name)] = 0.0

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -830,9 +830,8 @@ class PointMutationEngine(PolymerProposalEngine):
             original_residue = chain_residues[proposed_location]
             if original_residue.name in ['HIE','HID']:
                 original_residue.name = 'HIS'
-            # amino_prob : np.array, probability value for each amino acid option (uniform, must choose different from current)
-            amino_prob = np.array([1.0/(len(aminos)-1) for i in range(len(aminos))])
-            amino_prob[aminos.index(original_residue.name)] = 0.0
+            # amino_prob : np.array, probability value for each amino acid option (uniform)
+            amino_prob = np.array([1.0/(len(aminos)) for i in range(len(aminos))])
             # proposed_amino_index : int, index of three letter residue name in aminos list
             proposed_amino_index = np.random.choice(range(len(aminos)), p=amino_prob)
             # index_to_new_residues : dict, key : int (index of residue, 0-indexed), value : str (three letter residue name)

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -557,7 +557,7 @@ class ExpandedEnsembleSampler(object):
     >>> # Create an Expanded Ensemble sampler
     >>> from perses.rjmc.topology_proposal import PointMutationEngine
     >>> allowed_mutations = [[('2','ALA')],[('2','VAL'),('2','LEU')]]
-    >>> proposal_engine = PointMutationEngine(system_generator, max_point_mutants=1, chain_id='1', proposal_metadata=None, allowed_mutations=allowed_mutations)
+    >>> proposal_engine = PointMutationEngine(test.topology, system_generator, max_point_mutants=1, chain_id='1', proposal_metadata=None, allowed_mutations=allowed_mutations)
     >>> exen_sampler = ExpandedEnsembleSampler(mcmc_sampler, test.topology, 'ACE-ALA-NME', proposal_engine)
     >>> # Run the sampler
     >>> exen_sampler.run()
@@ -872,7 +872,7 @@ class SAMSSampler(object):
     >>> # Create an Expanded Ensemble sampler
     >>> from perses.rjmc.topology_proposal import PointMutationEngine
     >>> allowed_mutations = [[('2','ALA')],[('2','VAL'),('2','LEU')]]
-    >>> proposal_engine = PointMutationEngine(system_generator, max_point_mutants=1, chain_id='1', proposal_metadata=None, allowed_mutations=allowed_mutations)
+    >>> proposal_engine = PointMutationEngine(test.topology, system_generator, max_point_mutants=1, chain_id='1', proposal_metadata=None, allowed_mutations=allowed_mutations)
     >>> exen_sampler = ExpandedEnsembleSampler(mcmc_sampler, test.topology, 'ACE-ALA-NME', proposal_engine)
     >>> # Create a SAMS sampler
     >>> sams_sampler = SAMSSampler(exen_sampler)

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -156,7 +156,7 @@ def test_alchemical_elimination_mutation():
 
     # Create a topology proposal fro mutating ALA -> GLY
     from perses.rjmc.topology_proposal import PointMutationEngine
-    proposal_engine = PointMutationEngine(system_generator, chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+    proposal_engine = PointMutationEngine(topology, system_generator, chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
     topology_proposal = proposal_engine.propose(system, topology)
 
     # Modify atom mapping to get a null transformation.

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -171,7 +171,7 @@ def test_mutate_from_all_to_all():
 
         system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-        pm_top_engine = topology_proposal.PointMutationEngine(system_generator, chain_id, max_point_mutants=max_point_mutants)
+        pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, max_point_mutants=max_point_mutants)
 
         current_system = system
         current_topology = modeller.topology

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -281,11 +281,13 @@ def test_mutate_from_every_amino_to_every_other():
     current_topology = modeller.topology
     current_positions = modeller.positions
 
+    pm_top_engine._allowed_mutations = [list()]
     for k, proposed_amino in enumerate(aminos):
-        pm_top_engine._allowed_mutations = [[(str(k+2),proposed_amino)]]
-        pm_top_proposal = pm_top_engine.propose(current_system, current_topology)
-        current_system = pm_top_proposal.new_system
-        current_topology = pm_top_proposal.new_topology
+        pm_top_engine._allowed_mutations[0].append((str(k+2),proposed_amino))
+    print(pm_top_engine._allowed_mutations)
+    pm_top_proposal = pm_top_engine.propose(current_system, current_topology)
+    current_system = pm_top_proposal.new_system
+    current_topology = pm_top_proposal.new_topology
 
     for chain in current_topology.chains():
         if chain.id == chain_id:
@@ -299,15 +301,13 @@ def test_mutate_from_every_amino_to_every_other():
         if residue.index == (num_residues -1):
             continue
         new_sequence.append(residue.name)
+    print(new_sequence)
     assert [new_sequence[i] == aminos[i] for i in range(len(aminos))]
 
-    new_topology = modeller.topology
-    new_system = pm_top_engine._ff.createSystem(new_topology)
+    pm_top_engine = topology_proposal.PointMutationEngine(current_topology, system_generator, chain_id, max_point_mutants=max_point_mutants)
 
-    current_system = new_system
-    modeller = app.Modeller(new_topology, modeller.positions)
-    current_topology = modeller.topology
-
+    current_positions = np.zeros((current_topology.getNumAtoms(), 3))
+    modeller = app.Modeller(current_topology, current_positions)
     old_topology = copy.deepcopy(current_topology)
 
     old_chemical_state_key = pm_top_engine.compute_state_key(old_topology)
@@ -437,11 +437,11 @@ def test_run_peptide_library_engine():
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
 if __name__ == "__main__":
-    #test_run_point_mutation_propose()
-    #test_mutate_from_every_amino_to_every_other()
-    #test_specify_allowed_mutants()
-    #test_propose_self()
-    #test_limiting_allowed_residues()
-    #test_run_peptide_library_engine()
-    test_small_molecule_proposals()
+#    test_run_point_mutation_propose()
+    test_mutate_from_every_amino_to_every_other()
+#    test_specify_allowed_mutants()
+#    test_propose_self()
+#    test_limiting_allowed_residues()
+#    test_run_peptide_library_engine()
+#    test_small_molecule_proposals()
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -166,7 +166,7 @@ def test_specify_allowed_mutants():
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, chain_id, allowed_mutations=allowed_mutations)
+    pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, allowed_mutations=allowed_mutations)
 
     ntrials = 10
     for trian in range(ntrials):
@@ -210,7 +210,7 @@ def test_propose_self():
     allowed_mutations = [[(mutant_res.id,mutant_res.name)]]
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, chain_id, allowed_mutations=allowed_mutations)
+    pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, allowed_mutations=allowed_mutations)
     print('Self mutation:')
     pm_top_proposal = pm_top_engine.propose(system, modeller.topology)
     assert pm_top_proposal.old_topology == pm_top_proposal.new_topology
@@ -240,7 +240,7 @@ def test_run_point_mutation_propose():
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, chain_id, max_point_mutants=max_point_mutants)
+    pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, max_point_mutants=max_point_mutants)
     pm_top_proposal = pm_top_engine.propose(system, modeller.topology)
 
 
@@ -275,7 +275,7 @@ def test_mutate_from_every_amino_to_every_other():
 
     system_generator = topology_proposal.SystemGenerator([ff_filename])
 
-    pm_top_engine = topology_proposal.PointMutationEngine(system_generator, chain_id, max_point_mutants=max_point_mutants)
+    pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, max_point_mutants=max_point_mutants)
 
     current_system = system
     current_topology = modeller.topology
@@ -399,7 +399,7 @@ def test_limiting_allowed_residues():
     max_point_mutants = 1
     residues_allowed_to_mutate = ['903','904','905']
 
-    pl_top_library = topology_proposal.PointMutationEngine(system_generator, chain_id, max_point_mutants=max_point_mutants, residues_allowed_to_mutate=residues_allowed_to_mutate)
+    pl_top_library = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, max_point_mutants=max_point_mutants, residues_allowed_to_mutate=residues_allowed_to_mutate)
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -253,7 +253,6 @@ def test_mutate_from_every_amino_to_every_other():
     import perses.rjmc.topology_proposal as topology_proposal
 
     aminos = ['ALA','ARG','ASN','ASP','CYS','GLN','GLU','GLY','HIS','ILE','LEU','LYS','MET','PHE','PRO','SER','THR','TRP','TYR','VAL']
-    print(aminos)
 
     failed_mutants = 0
 
@@ -304,9 +303,7 @@ def test_mutate_from_every_amino_to_every_other():
         if residue.name in ['HID','HIE']:
             residue.name = 'HIS'
         new_sequence.append(residue.name)
-    print(new_sequence)
     for i in range(len(aminos)):
-        print(new_sequence[i], aminos[i])
         assert new_sequence[i] == aminos[i]
 
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -168,7 +168,7 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
         chain_id = '1'
         allowed_mutations = [[('2','ALA')],[('2','VAL')],[('2','LEU')],[('2','PHE')]]
         for environment in environments:
-            proposal_engines[environment] = PointMutationEngine(system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+            proposal_engines[environment] = PointMutationEngine(topologies[environment],system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
 
         # Generate systems
         systems = dict()
@@ -393,7 +393,7 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
         proposal_engines = dict()
         chain_id = 'A'
         for environment in environments:
-            proposal_engines[environment] = PointMutationEngine(system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+            proposal_engines[environment] = PointMutationEngine(topologies[environment], system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
 
         # Generate systems
         systems = dict()
@@ -550,7 +550,7 @@ class MybTestSystem(PersesTestSystem):
         proposal_engines = dict()
         chain_id
         for environment in environments:
-            proposal_engines[environment] = PointMutationEngine(system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+            proposal_engines[environment] = PointMutationEngine(topologies[environment], system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
 
         # Generate systems
         systems = dict()
@@ -720,7 +720,7 @@ class AblImatinibResistanceTestSystem(PersesTestSystem):
         for solvent in solvents:
             for component in ['complex', 'receptor']: # Mutations only apply to components that contain the kinase
                 environment = solvent + '-' + component
-                proposal_engines[environment] = PointMutationEngine(system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
+                proposal_engines[environment] = PointMutationEngine(topologies[environment], system_generators[environment], chain_id, proposal_metadata=proposal_metadata, allowed_mutations=allowed_mutations)
 
         # Generate systems ror all environments
         systems = dict()


### PR DESCRIPTION
Addresses https://github.com/choderalab/perses/issues/190

The IP part is that I'm pretty sure I've altered the intended behavior of ```test_mutate_from_every_amino_to_every_other``` because I was previous taking advantage of the fact that I didn't actually go back to wildtype before making a new mutation, and now when I try to initiate my little protein with 20 different amino acids to start, it will actually only change 1 away from the wildtype (I think).