### PR TITLE
Fix travis after change to 'conda build'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
 
 script:
   - conda config --add channels ${ORGNAME}
-  - conda build devtools/conda-recipe
+  - conda build  --keep-old-work devtools/conda-recipe
   - source activate _test
   # Install test dependencies in test environment.
   - conda install --yes --quiet pip nose nose-timer

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,16 +27,16 @@ install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == false ]; then echo "OpenEye license will not be installed in forks."; fi
 
 script:
+  # Add channels
   - conda config --add channels ${ORGNAME}
-  - conda build  --keep-old-work devtools/conda-recipe
-  - source activate _test
-  # Install test dependencies in test environment.
+  # Build recipe
+  - conda build devtools/conda-recipe
+  # Install locally-built package
+  - conda install --use-local perses-dev
+  # Install test dependencies
   - conda install --yes --quiet pip nose nose-timer
-  #- pip install --upgrade pip
+  # Install and test openeye tools
   - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
-  # Fix openmm and parmed double dependencies
-  #- conda remove --yes parmed parmed-dev && conda install --yes parmed-dev
-  #- conda remove --yes openmm openmm-dev && conda install --yes openmm-dev
   # Run tests
   #- cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=3 --with-doctest --with-timer && cd ..
   - cd devtools && nosetests $NOSETESTS --nocapture --verbosity=3 --with-timer && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   # Build recipe
   - conda build devtools/conda-recipe
   # Install locally-built package
-  - conda install --use-local perses-dev
+  - conda install --yes --use-local perses-dev
   # Install test dependencies
   - conda install --yes --quiet pip nose nose-timer
   # Install and test openeye tools

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - openmoltools
     - alchemy >=1.2.0
     - openmmtools
-    - numba
+    - numba ==0.27.0
     - netcdf4
     - matplotlib
     - seaborn
@@ -42,7 +42,7 @@ requirements:
     - openmoltools
     - alchemy >=1.2.0
     - openmmtools
-    - numba
+    - numba ==0.27.0
     - netcdf4
     - matplotlib
     - seaborn

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ setup(name='perses',
       zip_safe=False,
       ext_modules=extensions,
       install_requires=[
-        'openmm >=7.0.1',
+        #'openmm >=7.0.1', # This fails if the omnia 'dev' channel is included (JDC)
+        'openmm',
         'numpy',
         'scipy',
         'numexpr',


### PR DESCRIPTION
The failures we've suddenly started seeing are all due to:
```
$ source activate _test
could not find environment: _test
```
Suspiciously, `conda build` now gives this error:
```
INFO:/home/travis/miniconda/lib/python2.7/site-packages/conda_build/config.pyc:--keep-old-work flag not specified. Removing source and build files.
```
I've added `--keep-old-work` with the idea that this will restore the ability for us to test from the `_test` environment created by `conda build`.