### PR TITLE
Geometry engine bugfixes

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1792,12 +1792,6 @@ class GeometrySystemGenerator(object):
         modified_torsion_force.addPerTorsionParameter("growth_idx")
         modified_torsion_force.addGlobalParameter(parameter_name, 0)
 
-        modified_sterics_force = openmm.CustomNonbondedForce(self._stericsNonbondedEnergy.format(parameter_name))
-        modified_sterics_force.addPerParticleParameter("sigma")
-        modified_sterics_force.addPerParticleParameter("epsilon")
-        modified_sterics_force.addPerParticleParameter("growth_idx")
-        modified_sterics_force.addGlobalParameter(parameter_name, 0)
-
         growth_system.addForce(modified_bond_force)
         growth_system.addForce(modified_angle_force)
         growth_system.addForce(modified_torsion_force)

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1926,7 +1926,7 @@ class GeometrySystemGenerator(object):
             growth_idx = self._calculate_growth_idx(atom_indices, growth_indices)
             atom_names = [torsion.a.GetName(), torsion.b.GetName(), torsion.c.GetName(), torsion.d.GetName()]
             #print("Adding torsion with atoms %s and growth index %d" %(str(atom_names), growth_idx))
-            torsion_force.addTorsion(atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3], [periodicity, phase, k, 0])
+            torsion_force.addTorsion(atom_indices[0], atom_indices[1], atom_indices[2], atom_indices[3], [periodicity, phase, k, growth_idx])
 
         return torsion_force
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1730,9 +1730,9 @@ class GeometrySystemGenerator(object):
     with only valence terms and special parameters to assist in
     geometry proposals.
     """
-    _HarmonicBondForceEnergy = "select(step({} - growth_idx), (K/2)*(r-r0)^2, 0);"
-    _HarmonicAngleForceEnergy = "select(step({} - growth_idx), (K/2)*(theta-theta0)^2, 0);"
-    _PeriodicTorsionForceEnergy = "select(step({} - growth_idx), k*(1+cos(periodicity*theta-phase)), 0);"
+    _HarmonicBondForceEnergy = "select(step({}+0.5 - growth_idx), (K/2)*(r-r0)^2, 0);"
+    _HarmonicAngleForceEnergy = "select(step({}+0.5 - growth_idx), (K/2)*(theta-theta0)^2, 0);"
+    _PeriodicTorsionForceEnergy = "select(step({}+0.5 - growth_idx), k*(1+cos(periodicity*theta-phase)), 0);"
 
     def __init__(self):
         self._stericsNonbondedEnergy = "select(step({}-max(growth_idx1, growth_idx2)), U_sterics_active, 0);"
@@ -1901,6 +1901,7 @@ class GeometrySystemGenerator(object):
         omega(oemol)
 
         #get the list of torsions in the molecule that are not about a rotatable bond
+        # Note that only torsions involving heavy atoms are enumerated here.
         rotor = oechem.OEIsRotor()
         torsion_predicate = oechem.OENotBond(rotor)
         non_rotor_torsions = list(oechem.OEGetTorsions(oemol, torsion_predicate))
@@ -1916,7 +1917,7 @@ class GeometrySystemGenerator(object):
             atom_indices = [torsion.a.GetData("topology_index"), torsion.b.GetData("topology_index"), torsion.c.GetData("topology_index"), torsion.d.GetData("topology_index")]
             # Determine phase in [-pi,+pi) interval
             #phase = (np.pi)*units.radians+angle
-            phase = torsion.radians + np.pi
+            phase = torsion.radians + np.pi # TODO: Check that this is the correct convention?
             while (phase >= np.pi):
                 phase -= 2*np.pi
             while (phase < -np.pi):

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1845,7 +1845,9 @@ class GeometrySystemGenerator(object):
                 growth_idx_1 = growth_indices.index(particle_index_1) + 1 if particle_index_1 in growth_indices else 0
                 growth_idx_2 = growth_indices.index(particle_index_2) + 1 if particle_index_2 in growth_indices else 0
                 growth_idx = max(growth_idx_1, growth_idx_2)
-                custom_bond_force.addBond(particle_index_1, particle_index_2, [chargeprod, sigma, epsilon, growth_idx])
+                # Only need to add terms that are nonzero
+                if (chargeprod.value_in_unit_system(units.md_unit_system) != 0.0) or (epsilon.value_in_unit_system(units.md_unit_system) != 0.0):
+                    custom_bond_force.addBond(particle_index_1, particle_index_2, [chargeprod, sigma, epsilon, growth_idx])
 
         #copy parameters for sterics parameters in nonbonded force
         if 'NonbondedForce' in reference_forces.keys() and use_sterics:

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1739,8 +1739,11 @@ class GeometrySystemGenerator(object):
         self._stericsNonbondedEnergy += "U_sterics_active = 4*epsilon*x*(x-1.0); x = (sigma/r)^6;"
         self._stericsNonbondedEnergy += "epsilon = sqrt(epsilon1*epsilon2); sigma = 0.5*(sigma1 + sigma2);"
 
+        ONE_4PI_EPS0 = 138.935456 # OpenMM constant for Coulomb interactions (openmm/platforms/reference/include/SimTKOpenMMRealType.h) in OpenMM units
+                                  # TODO: Replace this with an import from simtk.openmm.constants once these constants are available there
 
-
+        self._nonbondedExceptionEnergy = "select(step({}-growth_idx), U_exception, 0);"
+        self._nonbondedExceptionEnergy += "U_exception = ONE_4PI_EPS0*chargeprod/r + 4*epsilon*x*(x-1.0); x = (sigma/r)^6;"
 
     def create_modified_system(self, reference_system, growth_indices, parameter_name, add_extra_torsions=True, reference_topology=None, use_sterics=False, force_names=None, force_parameters=None):
         """
@@ -1830,6 +1833,26 @@ class GeometrySystemGenerator(object):
                 continue
             modified_torsion_force.addTorsion(torsion_parameters[0], torsion_parameters[1], torsion_parameters[2], torsion_parameters[3], [torsion_parameters[4], torsion_parameters[5], torsion_parameters[6], growth_idx])
 
+        # Add (1,4) exceptions, regardless of whether 'use_sterics' is specified, because these are part of the valence forces.
+        if 'NonbondedForce' in reference_forces.keys():
+            custom_bond_force = openmm.CustomBondForce(self._nonbondedExceptionEnergy.format(parameter_name))
+            custom_bond_force.addPerParticleParameter("chargeprod")
+            custom_bond_force.addPerParticleParameter("sigma")
+            custom_bond_force.addPerParticleParameter("epsilon")
+            custom_bond_force.addPerParticleParameter("growth_idx")
+            custom_bond_force.addGlobalParameter(parameter_name, 0)
+            growth_system.addForce(custom_bond_force)
+            reference_nonbonded_force = reference_forces['NonbondedForce']
+            # Add exclusions, which are active at all times.
+            # (1,4) exceptions are always included, since they are part of the valence terms.
+            reference_nonbonded_force = reference_forces['NonbondedForce']
+            for exception_index in range(reference_nonbonded_force.getNumExceptions()):
+                [particle_index_1, particle_index_2, chargeprod, sigma, epsilon] = reference_nonbonded_force.getExceptionParameters(exception_index)
+                growth_idx_1 = growth_indices.index(particle_index_1) + 1 if particle_index_1 in growth_indices else 0
+                growth_idx_2 = growth_indices.index(particle_index_2) + 1 if particle_index_2 in growth_indices else 0
+                growth_idx = max(growth_idx_1, growth_idx_2)
+                custom_bond_force.addBond(particle_index_1, particle_index_2, [chargeprod, sigma, epsilon])
+
         #copy parameters for sterics parameters in nonbonded force
         if 'NonbondedForce' in reference_forces.keys() and use_sterics:
             modified_sterics_force = openmm.CustomNonbondedForce(self._stericsNonbondedEnergy.format(parameter_name))
@@ -1839,10 +1862,16 @@ class GeometrySystemGenerator(object):
             modified_sterics_force.addGlobalParameter(parameter_name, 0)
             growth_system.addForce(modified_sterics_force)
             reference_nonbonded_force = reference_forces['NonbondedForce']
+            # Add particle parameters.
             for particle_index in range(reference_nonbonded_force.getNumParticles()):
                 [charge, sigma, epsilon] = reference_nonbonded_force.getParticleParameters(particle_index)
                 growth_idx = growth_indices.index(particle_index) + 1 if particle_index in growth_indices else 0
                 modified_sterics_force.addParticle([sigma, epsilon, growth_idx])
+            # Add exclusions, which are active at all times.
+            # (1,4) exceptions are always included, since they are part of the valence terms.
+            for exception_index in range(reference_nonbonded_force.getNumExceptions()):
+                [particle_index_1, particle_index_2, chargeprod, sigma, epsilon] = reference_nonbonded_force.getExceptionParameters(exception_index)
+                modified_sterics_force.addExclusion(particle_index_1, particle_index_2)
             new_particle_indices = [atom.idx for atom in growth_indices]
             old_particle_indices = [idx for idx in range(reference_nonbonded_force.getNumParticles()) if idx not in new_particle_indices]
             modified_sterics_force.addInteractionGroup(set(new_particle_indices), set(old_particle_indices))

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -143,6 +143,67 @@ def align_molecules(mol1, mol2):
         new_to_old_atom_mapping[new_index] = old_index
     return new_to_old_atom_mapping
 
+def test_mutate_quick():
+    """
+    Abbreviated version of test_mutate_all for travis.
+    """
+    import perses.rjmc.topology_proposal as topology_proposal
+    import perses.rjmc.geometry as geometry
+    from perses.tests.utils import compute_potential_components
+    from openmmtools import testsystems as ts
+    geometry_engine = geometry.FFAllAngleGeometryEngine()
+
+    aminos = ['ALA','VAL','GLY','PHE','PRO','TRP']
+
+    for aa in aminos:
+        topology, positions = _get_capped_amino_acid(amino_acid=aa)
+        modeller = app.Modeller(topology, positions)
+
+        ff_filename = "amber99sbildn.xml"
+        max_point_mutants = 1
+
+        ff = app.ForceField(ff_filename)
+        system = ff.createSystem(modeller.topology)
+        chain_id = '1'
+
+        system_generator = topology_proposal.SystemGenerator([ff_filename])
+
+        pm_top_engine = topology_proposal.PointMutationEngine(modeller.topology, system_generator, chain_id, max_point_mutants=max_point_mutants)
+
+        current_system = system
+        current_topology = modeller.topology
+        current_positions = modeller.positions
+        minimize_integrator = openmm.VerletIntegrator(1.0*unit.femtosecond)
+        platform = openmm.Platform.getPlatformByName("Reference")
+        minimize_context = openmm.Context(current_system, minimize_integrator, platform)
+        minimize_context.setPositions(current_positions)
+        initial_state = minimize_context.getState(getEnergy=True)
+        initial_potential = initial_state.getPotentialEnergy()
+        openmm.LocalEnergyMinimizer.minimize(minimize_context)
+        final_state = minimize_context.getState(getEnergy=True, getPositions=True)
+        final_potential = final_state.getPotentialEnergy()
+        current_positions = final_state.getPositions()
+        print("Minimized initial structure from %s to %s" % (str(initial_potential), str(final_potential)))
+
+        for k, proposed_amino in enumerate(aminos):
+            pm_top_engine._allowed_mutations = [[('2',proposed_amino)]]
+            pm_top_proposal = pm_top_engine.propose(current_system, current_topology)
+            new_positions, logp = geometry_engine.propose(pm_top_proposal, current_positions, beta)
+            new_system = pm_top_proposal.new_system
+            if np.isnan(logp):
+                raise Exception("NaN in the logp")
+            integrator = openmm.VerletIntegrator(1*unit.femtoseconds)
+            platform = openmm.Platform.getPlatformByName("Reference")
+            context = openmm.Context(new_system, integrator, platform)
+            context.setPositions(new_positions)
+            state = context.getState(getEnergy=True)
+            print(compute_potential_components(context))
+            potential = state.getPotentialEnergy()
+            potential_without_units = potential / potential.unit
+            print(str(potential))
+            if np.isnan(potential_without_units):
+                raise Exception("Energy after proposal is NaN")
+
 @skipIf(os.environ.get("TRAVIS", None) == 'true', "Skip expensive test on travis")
 def test_mutate_from_all_to_all():
     """
@@ -167,7 +228,7 @@ def test_mutate_from_all_to_all():
 
         ff = app.ForceField(ff_filename)
         system = ff.createSystem(modeller.topology)
-        chain_id = 'A'
+        chain_id = '1'
 
         system_generator = topology_proposal.SystemGenerator([ff_filename])
 


### PR DESCRIPTION
This PR fixes three important bugs in the geometry engine:
* The correct growth index was not always being used in the valence `System` because of rounding errors
* Ring-closing torsions were not being added with their appropriate growth index
* Hydrogen atoms were being grown before heavy atoms, causing rings to sometimes not close
