### PR TITLE
Ensure travis tests actually run on correct python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,19 +27,26 @@ install:
   - if [ "$TRAVIS_SECURE_ENV_VARS" == false ]; then echo "OpenEye license will not be installed in forks."; fi
 
 script:
-  # Add channels
+  # Create a test environment
+  - conda create --yes -n test python=$python
+  # Activate the test environment
+  - source activate test
+  # Add org channel
   - conda config --add channels ${ORGNAME}
-  # Build recipe
-  - conda build devtools/conda-recipe
-  # Install locally-built package
-  - conda install --yes --use-local perses-dev
-  # Install test dependencies
-  - conda install --yes --quiet pip nose nose-timer
-  # Install and test openeye tools
+  # Add omnia dev channels
+  - conda config --add channels https://conda.anaconda.org/omnia/label/dev
+  # Install OpenEye toolkit
+  - conda install --yes --quiet pip
   - pip install $OPENEYE_CHANNEL openeye-toolkits && python -c "import openeye; print(openeye.__version__)"
+  # Build the recipe
+  - conda build devtools/conda-recipe
+  # Install the package
+  - conda install --yes --use-local ${PACKAGENAME}-dev
+  # Install testing dependencies
+  - conda install --yes --quiet nose nose-timer
   # Run tests
-  #- cd devtools && nosetests $PACKAGENAME --nocapture --verbosity=3 --with-doctest --with-timer && cd ..
   - cd devtools && nosetests $NOSETESTS --nocapture --verbosity=3 --with-timer && cd ..
+
 env:
   matrix:
     # Allfast tests for python 2.7


### PR DESCRIPTION
This PR fixes a bug where all travis testing was done with python 2.7, despite the value assigned to the `python` environment variable.

Even worse, it looks like sometimes the anaconda cloud version of `perses-dev` was being tested instead of the current source version, which could cause lots of confusion and lost debugging time.