### PR TITLE
Correct behavior for always_change

### DIFF
--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -450,11 +450,11 @@ def test_limiting_allowed_residues():
 
 def test_always_change():
     """
-    Test example system with certain mutations allowed to mutate
+    Test 'always_change' argument in topology proposal
+    Allowing one residue to mutate, must change to a different residue each
+    of 50 iterations
     """
     import perses.rjmc.topology_proposal as topology_proposal
-
-    failed_mutants = 0
 
     pdbid = "1G3F"
     topology, positions = load_pdbid_to_openmm(pdbid)


### PR DESCRIPTION
Addressing bug https://github.com/choderalab/perses/issues/244 for cases where `allowed_mutations` have not been specified.  Previously, would have prevented moves back to WT, after a move away from WT has been accepted.  Now, requires every mutation from the previous state to be different.

For instance, if your WT sequence is:
`1MET-2TYR-3ILE-4PHE-5SER` and `max_allowed_mutants = 2`
the first proposal will choose 2 locations at random, and change them to anything other than the WT residues, possibly:
```
locations = [2, 5]
1MET-2GLN-3ILE-4PHE-5LEU
chemical_state_key = 'TYR2GLN-SER5LEU'
```

The next proposal first chooses 2 locations at random, then changes those residues to anything other than what they were previously (therefore allowing a return to WT in the event that the same locations are chosen again). Some possibilities:
```
locations = [2, 5]
1MET-2TYR-3ILE-4PHE-5SER
chemical_state_key = 'WT'
```
OR
```
locations = [2, 5]
1MET-2PRO-3ILE-4PHE-5HIS
chemical_state_key = 'TYR2PRO-SER5HIS'
```
OR
```
locations = [2, 3]
1MET-2TYR-3ALA-4PHE-5SER
chemical_state_key = 'ILE3ALA'
```
But NOT a possibility would be:
```
locations = [2, 3]
1MET-2GLN-3ALA-4PHE-5SER
chemical_state_key = 'TYR2GLN-ILE3ALA'
```
because the `TYR2GLN` mutant from the previous iteration has to change.