### PR TITLE
Fix bond constraint reverse logp

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -293,6 +293,8 @@ class FFAllAngleGeometryEngine(GeometryEngine):
             else:
                 if direction == 'forward':
                     constraint = self._get_bond_constraint(atom, bond_atom, top_proposal.new_system)
+                    if constraint is None:
+                        raise ValueError("Structure contains a topological bond [%s - %s] with no constraint or bond information." % (str(atom), str(bond_atom)))
                     r = constraint #set bond length to exactly constraint
                 logp_r = 0.0
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -291,8 +291,9 @@ class FFAllAngleGeometryEngine(GeometryEngine):
                 logZ_r = np.log((np.sqrt(2*np.pi)*(sigma_r/units.angstroms))) # CHECK DOMAIN AND UNITS
                 logp_r = self._bond_logq(r, bond, beta) - logZ_r
             else:
-                constraint = self._get_bond_constraint(atom, bond_atom, top_proposal.new_system)
-                r = constraint #set bond length to exactly constraint
+                if direction == 'forward':
+                    constraint = self._get_bond_constraint(atom, bond_atom, top_proposal.new_system)
+                    r = constraint #set bond length to exactly constraint
                 logp_r = 0.0
 
             #propose an angle and calculate its probability

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -307,7 +307,7 @@ class AlanineDipeptideValenceTestSystem(PersesTestSystem):
         from pkg_resources import resource_filename
         valence_xml_filename = resource_filename('perses', 'data/amber99sbildn-valence-only.xml')
         system_generators['vacuum'] = SystemGenerator([valence_xml_filename],
-            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None },
+            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : app.HBonds },
             use_antechamber=False)
 
         # Create peptide in solvent.

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1672,7 +1672,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
     >>> sams_sampler = testsystem.sams_samplers['explicit']
 
     """
-    def __init__(self, **kwargs):
+    def __init__(self, constraints=app.HBonds, **kwargs):
         super(SmallMoleculeLibraryTestSystem, self).__init__(**kwargs)
         # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
         molecules = sanitizeSMILES(self.molecules)
@@ -1684,9 +1684,9 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         from pkg_resources import resource_filename
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'tip3p.xml'],
-            forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None })
+            forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints })
         system_generators['vacuum'] = SystemGenerator([gaff_xml_filename],
-            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None })
+            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : constraints })
 
         #
         # Create topologies and positions

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -307,7 +307,7 @@ class AlanineDipeptideValenceTestSystem(PersesTestSystem):
         from pkg_resources import resource_filename
         valence_xml_filename = resource_filename('perses', 'data/amber99sbildn-valence-only.xml')
         system_generators['vacuum'] = SystemGenerator([valence_xml_filename],
-            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : app.HBonds },
+            forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None },
             use_antechamber=False)
 
         # Create peptide in solvent.


### PR DESCRIPTION
This allows `GeometryEngine` to properly handle bond constraints while calculating the `logp_reverse`. We assume that constraints have been satisfied.