### PR TITLE
Eliminate KeyError in _propose_mutations

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -888,10 +888,7 @@ class PointMutationEngine(PolymerProposalEngine):
             # amino_prob : np.array, probability value for each amino acid option (uniform)
             if self._always_change:
                 amino_prob = np.array([1.0/(len(aminos)-1) for l in range(len(aminos))])
-                if proposed_location in [residue_id_to_index[residue_id] for residue_id in current_mutation]:
-                    amino_prob[aminos.index(current_mutation[proposed_location])] = 0.0
-                else:
-                    amino_prob[aminos.index(original_residue.name)] = 0.0
+                amino_prob[aminos.index(original_residue.name)] = 0.0
             else:
                 amino_prob = np.array([1.0/(len(aminos)) for k in range(len(aminos))])
             # proposed_amino_index : int, index of three letter residue name in aminos list


### PR DESCRIPTION
With `_always_change`, `_propose_mutations()` chooses a location to make a mutation, and is then supposed to make the probability of the chosen residue staying the same = 0.

Previously, an `if` statement gave different behavior if the proposed residue to change was either the WT residue or already mutated.  The `if` statement contained a bug (improperly using `proposed_location` as the residue index, when it is actually the index in the list of `_residues_allowed_to_mutate` if that has been specified), but also was unnecessary, because `original_residue` refers to the residue in the `old_topology`, whether or not that is the WT residue.