### PR TITLE
Fix hybrid ncmc case with 0 steps

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -695,13 +695,12 @@ class NCMCHybridEngine(NCMCEngine):
         direction = 'insert'
         if (self.nsteps == 0):
             # Special case of instantaneous insertion/deletion.
-            logP = 0.0
             final_positions = copy.deepcopy(proposed_positions)
             from perses.tests.utils import compute_potential
-            potential_del = self.beta * compute_potential(topology_proposal.old_system, initial_positions, platform=self.platform)
-            potential_ins = self.beta * compute_potential(topology_proposal.new_system, proposed_positions, platform=self.platform)
-            potential = potential_del - potential_ins
-            return [final_positions, logP, potential]
+            potential_del = -self.beta * compute_potential(topology_proposal.old_system, initial_positions, platform=self.platform)
+            potential_ins = -self.beta * compute_potential(topology_proposal.new_system, proposed_positions, platform=self.platform)
+            potential = potential_ins - potential_del
+            return [final_positions, initial_positions, potential]
 
 ########################################################################
         # Create alchemical system.


### PR DESCRIPTION
Hybrid ncmc engine returns different values than the regular one, but previously the special case of 0 ncmc steps was not altered from the parent class.  The expanded ensemble sampler will expect initial positions returned instead of logp_ncmc.