### PR TITLE
[WIP] Fix ImidazoleProtonationStateTestSystem test failures

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1189,8 +1189,9 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         -------
         proposal : TopologyProposal object
            topology proposal object
-        """
+        """        
         current_mol_smiles, current_mol = self._topology_to_smiles(current_topology)
+        print('current_mol_smiles = %s' % current_mol_smiles) # DEBUG
 
         current_receptor_topology = self._remove_small_molecule(current_topology)
         old_mol_start_index, len_old_mol = self._find_mol_start_index(current_topology)
@@ -1303,7 +1304,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         Returns
         -------
         smiles_string : string
-            an isomeric canonicalized SMILES string representing the molecule
+            an isomeric canonicalized SMILES string with explicit hydrogens representing the molecule
         oemol : oechem.OEMol object
             molecule
         """
@@ -1313,7 +1314,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             raise ValueError("More than one residue with the same name!")
         mol_res = matching_molecules[0]
         oemol = forcefield_generators.generateOEMolFromTopologyResidue(mol_res)
-        smiles_string = oechem.OECreateIsoSmiString(oemol)
+        smiles_string = oechem.OECreateSmiString(oemol, oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_Hydrogens)
         return smiles_string, oemol
 
     def compute_state_key(self, topology):

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1190,9 +1190,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         proposal : TopologyProposal object
            topology proposal object
         """        
-        current_mol_smiles, current_mol = self._topology_to_smiles(current_topology)
-        print('current_mol_smiles = %s' % current_mol_smiles) # DEBUG
-
+        current_mol_smiles, current_mol = self._topology_to_smiles(current_topology)        
         current_receptor_topology = self._remove_small_molecule(current_topology)
         old_mol_start_index, len_old_mol = self._find_mol_start_index(current_topology)
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -496,7 +496,7 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
                 break
 
         from openmoltools import forcefield_generators
-        from utils import extractPositionsFromOEMOL, giveOpenmmPositionsToOEMOL
+        from perses.tests.utils import extractPositionsFromOEMOL, giveOpenmmPositionsToOEMOL
         import perses.rjmc.geometry as geometry
         from perses.rjmc.topology_proposal import TopologyProposal
         # create OEMol version of benzene
@@ -1456,15 +1456,10 @@ class ImidazoleProtonationStateTestSystem(PersesTestSystem):
         state_penalties_filename = resource_filename('perses', os.path.join(setup_path, 'imidazole/imidazole-state-penalties.out'))
         for (smiles, log_state_penalty) in zip(molecules, np.fromfile(state_penalties_filename, sep='\n')):
             log_state_penalties[smiles] = log_state_penalty
-
-        # Add current molecule
-        smiles = 'C1=CN=CN1'
-        molecules.append(smiles)
-        self.molecules = molecules
-        log_state_penalties[smiles] = 0.0
+        molecules = molecules
 
         # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
-        molecules = sanitizeSMILES(self.molecules)
+        molecules = sanitizeSMILES(molecules)
 
         # Create a system generator for desired forcefields
         print('Creating system generators...')

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -420,11 +420,12 @@ def sanitizeSMILES(smiles_list, mode='drop', verbose=False):
     4
 
     """
-    from openeye.oechem import OEGraphMol, OESmilesToMol, OECreateIsoSmiString
+    from openeye.oechem import OEGraphMol, OESmilesToMol, OECreateIsoSmiString, OEAddExplicitHydrogens
     sanitized_smiles_set = set()
     for smiles in smiles_list:
         molecule = OEGraphMol()
         OESmilesToMol(molecule, smiles)
+        OEAddExplicitHydrogens(molecule)
 
         if verbose:
             molecule.SetTitle(smiles)
@@ -447,8 +448,8 @@ def sanitizeSMILES(smiles_list, mode='drop', verbose=False):
                     if verbose: print('expanded: %s', isosmiles)
                     sanitized_smiles_set.add(isosmiles)
         else:
-            # Convert to OpenEye's canonical isomeric SMILES.
-            isosmiles = OECreateIsoSmiString(molecule)
+            # Convert to OpenEye's canonical isomeric SMILES with explicit hydrogens.
+            isosmiles = oechem.OECreateSmiString(molecule, oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_Hydrogens)
             sanitized_smiles_set.add(isosmiles)
 
     sanitized_smiles_list = list(sanitized_smiles_set)


### PR DESCRIPTION
As discussed in #277, the issue with the `ImidazoleProtonationStateTestSystem` was not that the test was flawed, but that `SmallMoleculeSetProposalEngine` does not property represent molecules differing only in protonation states. The use of canonical isomeric SMILES did not appear sufficient to unambiguously identify distinct protonation states of imidazole---or more precisely, the same protonation state was represented by multiple distinct canonical isomeric SMILES strings, which seems incorrect. Using canonical isomeric SMILES with explicit hydrogens appears to work, though I have only currently verified that the `ImidazoleProtonationStateTestSystem` sampling works. 

Will run the tests on travis to see if this breaks anything.