### PR TITLE
Fix bug in small molecule topology proposal

### DIFF
--- a/perses/analysis/analysis.py
+++ b/perses/analysis/analysis.py
@@ -141,8 +141,8 @@ class Analysis(object):
                 col = spot%2
                 plt.subplot2grid((nrows,ncols),(row,col))
                 plt.hist(logps[component])
-                plt.title("Contribution of {0} to log acceptance probability in ExpandedEnsembleSampler".format(component))
-                plt.xlabel(component)
+                plt.title(component)
+                #plt.xlabel(component)
             pdf.savefig()
             plt.close()
 

--- a/perses/analysis/analysis.py
+++ b/perses/analysis/analysis.py
@@ -50,6 +50,7 @@ class Analysis(object):
         """
         # TODO: Replace this with calls to storage API
         self._ncfile = netcdf.Dataset(storage_filename, 'r')
+        self.storage_filename = storage_filename
 
     def get_environments(self):
         """Return a list of environments in storage file.
@@ -79,7 +80,7 @@ class Analysis(object):
         # TODO
         pass
 
-    def plot_exen_logp_components(self):
+    def plot_exen_logp_components(self, filename_prefix=None):
         """
         Generate histograms of each component of Expanded Ensemble log acceptance probability
         Components may include:
@@ -94,6 +95,10 @@ class Analysis(object):
             new_log_weight
             old_log_weight
 
+        Arguments:
+        ----------
+        filename_prefix : str, OPTIONAL, default = None
+            if specified, each plot is saved as '{0}-{1}'.format(filename_prefix, component)
         Each histogram will be saved to {component name}.png
         TODO: include input filename
             storage ncfile has different hierarchy depending on which samplers are defined;
@@ -115,19 +120,31 @@ class Analysis(object):
         ]
 
         ee_sam = self._ncfile.groups['ExpandedEnsembleSampler']
-        for component in components:
-            try:
-                niterations = ee_sam.variables[component].shape[0]
-            except:
-                continue
-            logps = np.zeros(niterations, np.float64)
-            for n in range(niterations):
-                logps[n] = ee_sam.variables[component][n]
-            plt.hist(logps)
-            plt.title("Contribution of {0} to log acceptance probability in ExpandedEnsembleSampler".format(component))
-            plt.xlabel(component)
-            plt.savefig(component)
-            plt.clf()
+        if filename_prefix is None:
+            filename_prefix = self.storage_filename.split('.')[0]
+        filename = '{0}-logP-components.pdf'.format(filename_prefix)
+        with PdfPages(filename) as pdf:
+            logps = dict()
+            for component in components:
+                try:
+                    niterations = ee_sam.variables[component].shape[0]
+                except:
+                    continue
+                logps[component] = np.zeros(niterations, np.float64)
+                for n in range(niterations):
+                    logps[component][n] = ee_sam.variables[component][n]
+            plt.figure(figsize=(8,12))
+            nrows = len(logps.keys())/2 + len(logps.keys())%2
+            ncols = 2
+            for spot, component in enumerate(logps.keys()):
+                row = spot/2
+                col = spot%2
+                plt.subplot2grid((nrows,ncols),(row,col))
+                plt.hist(logps[component])
+                plt.title("Contribution of {0} to log acceptance probability in ExpandedEnsembleSampler".format(component))
+                plt.xlabel(component)
+            pdf.savefig()
+            plt.close()
 
 
     def plot_ncmc_work(self, filename):

--- a/perses/analysis/analysis.py
+++ b/perses/analysis/analysis.py
@@ -89,11 +89,11 @@ class Analysis(object):
 
         """
         with PdfPages(filename) as pdf:
-            for envname in self.get_environments():
-                modname = 'NCMCEngine'
+            for envname in ['NCMCEngine', 'NCMCHybridEngine']: #self.get_environments():
+                modname = envname
                 work = dict()
                 for direction in ['delete', 'insert']:
-                    varname = '/' + envname + '/' + modname + '/' + 'work_' + direction
+                    varname = '/' + modname + '/' + 'work_' + direction
                     try:
                         # TODO: For now, we analyze all but the last sample, so that this can be run on active simulations.
                         # Later, we should find some way to omit the last sample only if it is nonsensical.
@@ -107,10 +107,10 @@ class Analysis(object):
                     """
                     plt.figure(figsize=(12, 8))
 
-                    nrows = 2
+                    nrows = len(work.keys())
                     ncols = 6
                     workcols = 2
-                    for (row, direction) in enumerate(['delete', 'insert']):
+                    for (row, direction) in enumerate(work.keys()):
                         #
                         # Plot work vs step
                         #

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -585,7 +585,7 @@ class NCMCHybridEngine(NCMCEngine):
                  nsteps=default_nsteps, timestep=default_timestep, 
                  constraint_tolerance=None, platform=None, 
                  write_ncmc_interval=None, integrator_type='GHMC',
-                 softening=0.1):
+                 storage=None, softening=0.1):
         """
         Subclass of NCMCEngine which switches directly between two different
         systems using an alchemical hybrid topology.
@@ -625,7 +625,7 @@ class NCMCHybridEngine(NCMCEngine):
         super(NCMCHybridEngine, self).__init__(temperature=temperature, functions=functions, nsteps=nsteps,
                                                timestep=timestep, constraint_tolerance=constraint_tolerance,
                                                platform=platform, write_ncmc_interval=write_ncmc_interval,
-                                               integrator_type=integrator_type)
+                                               storage=storage, integrator_type=integrator_type)
 
     def _computeAlchemicalCorrection(self, integrator, context,
                                      unmodified_old_system, unmodified_new_system,
@@ -659,8 +659,8 @@ class NCMCHybridEngine(NCMCEngine):
             The log acceptance probability of the switch
         """
         from perses.tests.utils import compute_potential
-        initial_logP_correction = (self.beta * integrator.getGlobalVariableByName("Einitial") * unit.kilojoules_per_mole) - compute_potential(unmodified_old_system, initial_positions, platform=self.platform)
-        final_logP_correction = self.compute_potential(unmodified_new_system, final_positions, platform=self.platform) - (self.beta * context.getState(getEnergy=True).getPotentialEnergy())
+        initial_logP_correction = (self.beta * integrator.getGlobalVariableByName("Einitial") * unit.kilojoules_per_mole) - self.beta * compute_potential(unmodified_old_system, initial_positions, platform=self.platform)
+        final_logP_correction = self.beta * compute_potential(unmodified_new_system, final_positions, platform=self.platform) - (self.beta * context.getState(getEnergy=True).getPotentialEnergy())
 
         logP_alchemical_correction = initial_logP_correction + final_logP_correction
         return logP_alchemical_correction
@@ -761,7 +761,7 @@ class NCMCHybridEngine(NCMCEngine):
         potential = potential_ins - potential_del
         return [final_positions, initial_positions, potential]
 
-    def integrate(self, topology_proposal, initial_positions, proposed_positions, platform=None):
+    def integrate(self, topology_proposal, initial_positions, proposed_positions, platform=None, iteration=None):
         """
         Performs NCMC switching to either delete or insert atoms according to the provided `topology_proposal`.
         The contribution of transforming the real system to/from an alchemical system is included.
@@ -805,7 +805,7 @@ class NCMCHybridEngine(NCMCEngine):
         integrator = self._choose_integrator(alchemical_system, functions, direction)
         context = self._create_context(alchemical_system, integrator, alchemical_positions)
 
-        final_hybrid_positions, logP_NCMC = self._integrate_switching(integrator, context, alchemical_topology, indices, None, direction)
+        final_hybrid_positions, logP_NCMC = self._integrate_switching(integrator, context, alchemical_topology, indices, iteration, direction)
         final_positions = self._convert_hybrid_positions_to_final(final_hybrid_positions, final_to_hybrid_atom_map)
         new_old_positions = self._convert_hybrid_positions_to_final(final_hybrid_positions, initial_to_hybrid_atom_map)
 

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -35,7 +35,7 @@ default_hybrid_functions = {
 
 default_temperature = 300.0*unit.kelvin
 default_nsteps = 1
-default_timestep = 1.0 * unit.femtoseconds
+default_timestep = 0.5 * unit.femtoseconds
 default_steps_per_propagation = 1
 
 class NaNException(Exception):

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -707,9 +707,6 @@ class NCMCHybridEngine(NCMCEngine):
         logP_alchemical_correction = initial_logP_correction + final_logP_correction
         return logP_alchemical_correction
 
-    def _compute_switch_logP(self, unmodified_old_system, unmodified_new_system, initial_positions, final_positions):
-        return self.compute_logP(unmodified_new_system, final_positions) - self.compute_logP(unmodified_old_system, initial_positions)
-
     def make_alchemical_system(self, topology_proposal, old_positions,
                                new_positions):
         """

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -558,7 +558,7 @@ class NCMCEngine(object):
         logP_ncmc = self._clean_up_integration(logP_NCMC, logP_alchemical_correction, alchemical_system, context, integrator)
 
         # Return
-        return [final_positions, logP, switch_logp]
+        return [final_positions, logP_ncmc, switch_logp]
 
 class NCMCHybridEngine(NCMCEngine):
     """

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -25,6 +25,7 @@ functions_disable_all = {
     'lambda_torsions' : 'lambda'
     }
 
+# make something hyperbolic or something to go from on to off to on
 default_hybrid_functions = {
     'lambda_sterics' : 'lambda',
     'lambda_electrostatics' : 'lambda',
@@ -583,7 +584,8 @@ class NCMCHybridEngine(NCMCEngine):
     def __init__(self, temperature=default_temperature, functions=None, 
                  nsteps=default_nsteps, timestep=default_timestep, 
                  constraint_tolerance=None, platform=None, 
-                 write_ncmc_interval=None, integrator_type='GHMC'):
+                 write_ncmc_interval=None, integrator_type='GHMC',
+                 softening=0.1):
         """
         Subclass of NCMCEngine which switches directly between two different
         systems using an alchemical hybrid topology.
@@ -613,10 +615,13 @@ class NCMCHybridEngine(NCMCEngine):
             PDB file generated for each attempt.
         integrator_type : str, optional, default='GHMC'
             NCMC internal integrator type ['GHMC', 'VV']
+        softening : float, optional, default=0.1
+            lambda functions controlling interactions between unique atoms
+            will be scaled by ((1-softening)*lambda + softening)
         """
         if functions is None:
             functions = default_hybrid_functions
-
+        self.softening = softening
         super(NCMCHybridEngine, self).__init__(temperature=temperature, functions=functions, nsteps=nsteps,
                                                timestep=timestep, constraint_tolerance=constraint_tolerance,
                                                platform=platform, write_ncmc_interval=write_ncmc_interval,
@@ -716,13 +721,30 @@ class NCMCHybridEngine(NCMCEngine):
         ---------
         topology_proposal : TopologyProposal namedtuple
             Contains old topology, proposed new topology, and atom mapping
+        old_positions : simtk.unit.Quantity with dimension [natoms, 3] with units of distance.
+            Positions of the atoms at the beginning of the NCMC switching.
+        new_positions : simtk.unit.Quantity with dimension [natoms, 3] with units of distance.
+            Positions of the atoms proposed by geometry engine.
+
         Returns
         -------
-        unmodified_system : simtk.openmm.System
-            Unmodified real system corresponding to appropriate leg of
-            transformation.
+        unmodified_old_system : simtk.openmm.System
+            Unmodified real system corresponding to old chemical state.
+        unmodified_new_system : simtk.openmm.System
+            Unmodified real system corresponding to new chemical state.
         alchemical_system : simtk.openmm.System
             The system with appropriate atoms alchemically modified
+        alchemical_topology : openmm.app.Topology
+            Topology which includes unique atoms of old and new states.
+        alchemical_positions : simtk.unit.Quantity of dimensions [nparticles,3]
+            with units compatible with angstroms
+            Positions for the alchemical hybrid topology
+        final_atom_map : dict(int : int)
+            Dictionary mapping the index of every atom in the new topology
+            to its index in the hybrid topology
+        initial_atom_map : dict(int : int)
+            Dictionary mapping the index of every atom in the old topology
+            to its index in the hybrid topology
         """
 
         atom_map = topology_proposal.old_to_new_atom_map
@@ -739,7 +761,8 @@ class NCMCHybridEngine(NCMCEngine):
                                                    unmodified_new_system,
                                                    old_topology, new_topology,
                                                    old_positions,
-                                                   new_positions, atom_map)
+                                                   new_positions, atom_map,
+                                                   softening=self.softening)
 
         # Return the alchemically-modified system in fully-interacting form.
 #        alchemical_system, _, alchemical_positions, final_atom_map, initial_atom_map = alchemical_factory.createPerturbedSystem()
@@ -755,6 +778,28 @@ class NCMCHybridEngine(NCMCEngine):
         return final_positions
 
     def _zero_steps_return(self, initial_positions, proposed_positions, topology_proposal):
+        """
+        Handle the special case of instantaneous insertion / deletion
+
+        Parameters
+        ----------
+        initial_positions : simtk.unit.Quantity with dimension [natoms, 3] with units of distance.
+            Positions of the atoms at the beginning of the NCMC switching.
+        proposed_positions : simtk.unit.Quantity with dimension [natoms, 3] with units of distance.
+            Positions of the atoms proposed by geometry engine.
+        topology_proposal : TopologyProposal namedtuple
+            Contains old topology, proposed new topology, and atom mapping
+
+        Returns
+        -------
+        final_positions : simtk.unit.Quantity of dimensions [nparticles,3] with units compatible with angstroms
+            The final positions are equivalent to the proposed positions after 0 steps of alchemical switching
+        initial_positions : simtk.unit.Quantity of dimensions [nparticles,3] with units compatible with angstroms
+            Positions of the atoms at the beginning of the NCMC switching.
+        potential : float
+            The difference in potential energies between the old system and
+            positions and new system with proposed positions.
+        """
         # Special case of instantaneous insertion/deletion.
         final_positions = copy.deepcopy(proposed_positions)
         from perses.tests.utils import compute_potential

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -478,10 +478,10 @@ class NCMCEngine(object):
             and alchemical systems of the same chemical state
         alchemical_system : simtk.openmm.System
             The system with appropriate atoms alchemically modified
-        itegrator : NCMCAlchemicalIntegrator subclasses
-            NCMC switching integrator to annihilate or introduce particles alchemically.
         context : openmm.Context 
             Alchemical context
+        itegrator : NCMCAlchemicalIntegrator subclasses
+            NCMC switching integrator to annihilate or introduce particles alchemically.
 
         Returns
         -------
@@ -669,10 +669,9 @@ class NCMCHybridEngine(NCMCEngine):
         # Return potential energy.
         return -self.beta * potential
 
-    def _computeAlchemicalCorrection(self, unmodified_old_system,
-                                     unmodified_new_system, alchemical_system,
-                                     initial_positions, alchemical_positions,
-                                     final_hybrid_positions, final_positions,
+    def _computeAlchemicalCorrection(self, integrator, context,
+                                     unmodified_old_system, unmodified_new_system,
+                                     initial_positions, final_positions,
                                      direction='insert'):
         """
         Compute log probability for correction from transforming real system
@@ -680,21 +679,17 @@ class NCMCHybridEngine(NCMCEngine):
 
         Parameters
         ----------
+        itegrator : NCMCAlchemicalIntegrator subclasses
+            NCMC switching integrator to annihilate or introduce particles alchemically.
+        context : openmm.Context 
+            Alchemical context
         unmodified_old_system : simtk.unit.System
             Real fully-interacting system.
         unmodified_new_system : simtk.unit.System
             Real fully-interacting system.
-        alchemical_system : simtk.unit.System
-            Alchemically modified system in fully-interacting form.
         initial_positions : simtk.unit.Quantity of dimensions [nparticles,3]
             with units compatible with angstroms
             The initial positions before NCMC switching.
-        alchemical_positions : simtk.unit.Quantity of dimensions [nparticles,3]
-            with units compatible with angstroms
-            The initial positions of hybrid topology before NCMC switching.
-        final_hybrid_positions : simtk.unit.Quantity of dimensions
-            [nparticles,3] with units compatible with angstroms
-            The final positions of hybrid topology after NCMC switching.
         final_positions : simtk.unit.Quantity of dimensions [nparticles,3]
             with units compatible with angstroms
             The final positions after NCMC switching.
@@ -705,10 +700,13 @@ class NCMCHybridEngine(NCMCEngine):
         logP_alchemical_correction : float
             The log acceptance probability of the switch
         """
-
         # Compute correction from transforming real system to/from alchemical system
-        initial_logP_correction = self.compute_logP(alchemical_system, alchemical_positions, parameter=0) - self.compute_logP(unmodified_old_system, initial_positions)
-        final_logP_correction = self.compute_logP(unmodified_new_system, final_positions) - self.compute_logP(alchemical_system, final_hybrid_positions, parameter=1)
+#        initial_logP_correction = self.compute_logP(alchemical_system, alchemical_positions, parameter=0) - self.compute_logP(unmodified_old_system, initial_positions)
+#        final_logP_correction = self.compute_logP(unmodified_new_system, final_positions) - self.compute_logP(alchemical_system, final_hybrid_positions, parameter=1)
+
+        initial_logP_correction = (self.beta * integrator.getGlobalVariableByName("Einitial") * unit.kilojoules_per_mole) - self.compute_logP(unmodified_old_system, initial_positions)
+        final_logP_correction = self.compute_logP(unmodified_new_system, final_positions) - (self.beta * context.getState(getEnergy=True).getPotentialEnergy())
+
         logP_alchemical_correction = initial_logP_correction + final_logP_correction
         return logP_alchemical_correction
 
@@ -858,12 +856,11 @@ class NCMCHybridEngine(NCMCEngine):
 
         # Compute contribution from transforming real system to/from alchemical system.
         logP_alchemical_correction = self._computeAlchemicalCorrection(
+                                              integrator,
+                                              context,
                                               unmodified_old_system,
                                               unmodified_new_system,
-                                              alchemical_system,
                                               initial_positions,
-                                              alchemical_positions,
-                                              final_hybrid_positions,
                                               final_positions,
                                           )
 

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -623,13 +623,13 @@ class HybridTopologyFactory(object):
         for atom1 in self.unique_atoms1:
             index = sys1_indices_in_system[atom1] # index into system
             [charge1, sigma1, epsilon1] = force1.getParticleParameters(atom1)
-            sterics_custom_nonbonded_force.setParticleParameters(index, [sigma1, epsilon1, sigma1, 0*epsilon1])
-            electrostatics_custom_nonbonded_force.setParticleParameters(index, [charge1, 0*charge1])
+            sterics_custom_nonbonded_force.setParticleParameters(index, [sigma1, epsilon1, sigma1, self.softening*epsilon1])
+            electrostatics_custom_nonbonded_force.setParticleParameters(index, [charge1, self.softening*charge1])
         for atom2 in self.unique_atoms2:
             index = sys2_indices_in_system[atom2] # index into system
             [charge2, sigma2, epsilon2] = force2.getParticleParameters(atom2)
-            sterics_custom_nonbonded_force.setParticleParameters(index, [sigma2, 0*epsilon2, sigma2, epsilon2])
-            electrostatics_custom_nonbonded_force.setParticleParameters(index, [0*charge2, charge2])
+            sterics_custom_nonbonded_force.setParticleParameters(index, [sigma2, self.softening*epsilon2, sigma2, epsilon2])
+            electrostatics_custom_nonbonded_force.setParticleParameters(index, [self.softening*charge2, charge2])
         for index1 in unique_to_core_exceptions1:
             [atom1_i, atom1_j, chargeProd, sigma, epsilon] = force1.getExceptionParameters(index1)
             atom_i = sys1_indices_in_system[atom1_i]

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -60,10 +60,10 @@ class HybridTopologyFactory(object):
         for atom1idx, atom2idx in self.atom_mapping_1to2.items():
             atom1 = system1_atoms[atom1idx]
             atom2 = system2_atoms[atom2idx]
-            if not atom1.name == atom2.name:
-                if atom1.element == atom2.element and atom1.element == app.Element.getBySymbol('H'):
-                    continue
+            if not atom1.element == atom2.element:
                 keys_to_delete.append(atom1idx)
+        if len(keys_to_delete) == len(self.atom_mapping_1to2.keys()):
+            del(keys_to_delete[-1])
         for key in keys_to_delete:
             del(self.atom_mapping_1to2[key])
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1355,11 +1355,41 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         resname = self._residue_name
         mol_residues = [res for res in topology.residues() if res.name==resname]
         if len(mol_residues)!=1:
-            raise ValueError("There can only be one residue with a specific name in the topology.")
+            raise ValueError("There must be exactly one residue with a specific name in the topology. Found %d residues with name '%s'" % (len(mol_residues), resname))
         mol_residue = mol_residues[0]
         atoms = list(mol_residue.atoms())
         mol_start_idx = atoms[0].index
         return mol_start_idx, len(list(atoms))
+
+    def _append_topology(self, destination_topology, source_topology, exclude_residue_name=None):
+        """
+        Add the source OpenMM Topology to the destination Topology.
+
+        Parameters
+        ----------
+        destination_topology : simtk.openmm.app.Topology
+            The Topology to which the contents of `source_topology` are to be added.
+        source_topology : simtk.openmm.app.Topology
+            The Topology to be added.
+        exclude_residue_name : str, optional, default=None
+            If specified, any residues matching this name are excluded.
+
+        """
+        newAtoms = {}
+        for chain in source_topology.chains():
+            newChain = destination_topology.addChain(chain.id)
+            for residue in chain.residues():
+                if (residue.name == exclude_residue_name):
+                    continue
+                newResidue = destination_topology.addResidue(residue.name, newChain, residue.id)
+                for atom in residue.atoms():
+                    newAtom = destination_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
+                    newAtoms[atom] = newAtom
+        for bond in source_topology.bonds():
+            if (bond[0].residue.name==exclude_residue_name) or (bond[1].residue.name==exclude_residue_name):
+                continue
+            # TODO: Preserve bond order info using extended OpenMM API
+            destination_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
 
     def _build_new_topology(self, current_receptor_topology, oemol_proposed):
         """
@@ -1378,18 +1408,11 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         mol_start_index : int
             The first index of the small molecule
         """
+        oemol_proposed.SetTitle(self._residue_name)
         mol_topology = forcefield_generators.generateTopologyFromOEMol(oemol_proposed)
-        new_topology = copy.deepcopy(current_receptor_topology)
-        newAtoms = {}
-        for chain in mol_topology.chains():
-            newChain = new_topology.addChain(chain.id)
-            for residue in chain.residues():
-                newResidue = new_topology.addResidue(self._residue_name, newChain, residue.id)
-                for atom in residue.atoms():
-                    newAtom = new_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
-                    newAtoms[atom] = newAtom
-        for bond in mol_topology.bonds():
-            new_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
+        new_topology = app.Topology()
+        self._append_topology(new_topology, current_receptor_topology)
+        self._append_topology(new_topology, mol_topology)
         # Copy periodic box vectors.
         if current_receptor_topology._periodicBoxVectors != None:
             new_topology._periodicBoxVectors = copy.deepcopy(current_receptor_topology._periodicBoxVectors)
@@ -1413,19 +1436,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             Topology without small molecule
         """
         receptor_topology = app.Topology()
-        newAtoms = {}
-        for chain in topology.chains():
-            newChain = receptor_topology.addChain(chain.id)
-            for residue in chain.residues():
-                if residue.name != self._residue_name:
-                    newResidue = receptor_topology.addResidue(residue.name, newChain, residue.id)
-                    for atom in residue.atoms():
-                        newAtom = receptor_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
-                        newAtoms[atom] = newAtom
-        for bond in topology.bonds():
-            if bond[0].residue.name==self._residue_name or bond[1].residue.name==self._residue_name:
-                continue
-            receptor_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
+        self._append_topology(receptor_topology, topology, exclude_residue_name=self._residue_name)
+        # Copy periodic box vectors.
         if topology._periodicBoxVectors != None:
             receptor_topology._periodicBoxVectors = copy.deepcopy(topology._periodicBoxVectors)
         return receptor_topology
@@ -1956,4 +1968,3 @@ class PropaneProposalEngine(NullProposalEngine):
             if atom.residue != ccbond[0].residue:
                 atom_map[atom.index] = atom.index
         return atom_map
-

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1940,7 +1940,7 @@ class PropaneProposalEngine(NullProposalEngine):
                 break
         for bond in topology.bonds():
             if any([carbon in bond for carbon in ccbond]) and app.element.hydrogen in [atom.element for atom in bond]:
-                atom_map[bond[0]] = bond[0]
-                atom_map[bond[1]] = bond[1]
+                atom_map[bond[0].index] = bond[0].index
+                atom_map[bond[1].index] = bond[1].index
         return atom_map
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1782,6 +1782,11 @@ class NaphthaleneProposalEngine(NullProposalEngine):
 
         # map the ring flipped 180
         atom_map = {find_ring[i].index : find_ring[(i+3)%6].index for i in range(6)}
+
+        for atom in topology.atoms():
+            if atom.residue != find_ring[0].residue:
+                atom_map[atom.index] = atom.index
+
         return atom_map
 
 class ButaneProposalEngine(NullProposalEngine):
@@ -1865,6 +1870,11 @@ class ButaneProposalEngine(NullProposalEngine):
             hydrogen0.index : hydrogen1.index,
             hydrogen1.index : hydrogen0.index,
         }
+
+        for atom in topology.atoms():
+            if atom.residue != ccbond[0].residue:
+                atom_map[atom.index] = atom.index
+
         return atom_map
 
 class PropaneProposalEngine(NullProposalEngine):
@@ -1942,5 +1952,8 @@ class PropaneProposalEngine(NullProposalEngine):
             if any([carbon in bond for carbon in ccbond]) and app.element.hydrogen in [atom.element for atom in bond]:
                 atom_map[bond[0].index] = bond[0].index
                 atom_map[bond[1].index] = bond[1].index
+        for atom in topology.atoms():
+            if atom.residue != ccbond[0].residue:
+                atom_map[atom.index] = atom.index
         return atom_map
 

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -912,7 +912,7 @@ class ExpandedEnsembleSampler(object):
             raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
         return ncmc_new_positions, ncmc_old_positions, ncmc_logp
 
-    def _geometry_ncmc_geometry(self, topology_proposal, old_log_weight, new_log_weight):
+    def _geometry_ncmc_geometry(self, topology_proposal, positions, old_log_weight, new_log_weight):
         if self.verbose: print("Updating chemical state with geometry-ncmc-geometry scheme...")
 
         geometry_old_positions = positions
@@ -937,9 +937,10 @@ class ExpandedEnsembleSampler(object):
 
         return logp_accept, ncmc_new_positions
 
-    def _ncmc_geometry_ncmc(self, topology_proposal, old_log_weight, new_log_weight):
+    def _ncmc_geometry_ncmc(self, topology_proposal, positions, old_log_weight, new_log_weight):
         if self.verbose: print("Updating chemical state with ncmc-geometry-ncmc scheme...")
 
+        initial_time = time.time()
         ncmc_old_positions, ncmc_elimination_logp, potential_delete = self._ncmc_delete(topology_proposal, positions)
 
         geometry_old_positions = ncmc_old_positions
@@ -973,11 +974,12 @@ class ExpandedEnsembleSampler(object):
 
         return logp_accept, ncmc_new_positions
 
-    def _geometry_ncmc(self, topology_proposal, old_log_weight, new_log_weight):
+    def _geometry_ncmc(self, topology_proposal, positions, old_log_weight, new_log_weight):
         raise(NotImplementedError("ExpandedEnsembleSampler scheme 'geometry-ncmc' has not been statistically validated and should not be used."))
         from perses.tests.utils import compute_potential
         if self.verbose: print("Updating chemical state with geometry-ncmc scheme...")
 
+        initial_time = time.time()
         potential_delete = self.sampler.thermodynamic_state.beta * compute_potential(system, positions, platform=self.ncmc_engine.platform)
 
         geometry_old_positions = positions
@@ -1037,11 +1039,11 @@ class ExpandedEnsembleSampler(object):
         new_log_weight = self.get_log_weight(new_state_key)
 
         if self.scheme == 'ncmc-geometry-ncmc':
-            logp_accept, ncmc_new_positions = self._ncmc_geometry_ncmc(topology_proposal, old_log_weight, new_log_weight)
+            logp_accept, ncmc_new_positions = self._ncmc_geometry_ncmc(topology_proposal, positions, old_log_weight, new_log_weight)
         elif self.scheme == 'geometry-ncmc':
-            logp_accept, ncmc_new_positions = self._geometry_ncmc(topology_proposal, old_log_weight, new_log_weight)
+            logp_accept, ncmc_new_positions = self._geometry_ncmc(topology_proposal, positions, old_log_weight, new_log_weight)
         elif self.scheme == 'geometry-ncmc-geometry':
-            logp_accept, ncmc_new_positions = self._geometry_ncmc_geometry(topology_proposal, old_log_weight, new_log_weight)
+            logp_accept, ncmc_new_positions = self._geometry_ncmc_geometry(topology_proposal, positions, old_log_weight, new_log_weight)
         else:
             raise Exception("Expanded ensemble state proposal scheme '%s' unsupported" % self.scheme)
 

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -820,7 +820,7 @@ class ExpandedEnsembleSampler(object):
             self.ncmc_engine = NCMCEngine(temperature=self.sampler.thermodynamic_state.temperature, timestep=options['timestep'], nsteps=options['nsteps'], functions=options['functions'], platform=platform, storage=self.storage)
         elif scheme=='geometry-ncmc-geometry':
             from perses.annihilation.ncmc_switching import NCMCHybridEngine
-            self.ncmc_engine = NCMCHybridEngine(temperature=self.sampler.thermodynamic_state.temperature, timestep=options['timestep'], nsteps=options['nsteps'], functions=options['functions'], platform=platform)
+            self.ncmc_engine = NCMCHybridEngine(temperature=self.sampler.thermodynamic_state.temperature, timestep=options['timestep'], nsteps=options['nsteps'], functions=options['functions'], platform=platform, storage=self.storage)
         else:
             raise Exception("Expanded ensemble state proposal scheme '%s' unsupported" % self.scheme)
         self.geometry_engine = geometry_engine
@@ -905,7 +905,7 @@ class ExpandedEnsembleSampler(object):
     def _ncmc_hybrid(self, topology_proposal, old_positions, new_positions):
         if self.verbose: print("Performing NCMC switching")
         initial_time = time.time()
-        [ncmc_new_positions, ncmc_old_positions, ncmc_logp] = self.ncmc_engine.integrate(topology_proposal, old_positions, new_positions)
+        [ncmc_new_positions, ncmc_old_positions, ncmc_logp] = self.ncmc_engine.integrate(topology_proposal, old_positions, new_positions, iteration=self.iteration)
         if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
         # Check that positions are not NaN
         if np.any(np.isnan(ncmc_new_positions)):

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -831,6 +831,7 @@ class ExpandedEnsembleSampler(object):
         self.pdbfile = None # if not None, write PDB file
         self.geometry_pdbfile = None # if not None, write PDB file of geometry proposals
         self.accept_everything = False # if True, will accept anything that doesn't lead to NaNs
+        self.logPs = list()
 
     @property
     def state_keys(self):
@@ -859,6 +860,155 @@ class ExpandedEnsembleSampler(object):
             self.log_weights[state_key] = 0.0
         return self.log_weights[state_key]
 
+    def _geometry_forward(self, topology_proposal, old_positions):
+        if self.verbose: print("Geometry engine proposal...")
+        # Generate coordinates for new atoms and compute probability ratio of old and new probabilities.
+        initial_time = time.time()
+        new_positions, geometry_logp_propose = self.geometry_engine.propose(topology_proposal, old_positions, self.sampler.thermodynamic_state.beta)
+        if self.verbose: print('proposal took %.3f s' % (time.time() - initial_time))
+
+        if self.geometry_pdbfile is not None:
+            print("Writing proposed geometry...")
+            from simtk.openmm.app import PDBFile
+            PDBFile.writeFile(topology_proposal.new_topology, new_positions, file=self.geometry_pdbfile)
+            self.geometry_pdbfile.flush()
+
+        return new_positions, geometry_logp_propose
+
+    def _geometry_reverse(self, topology_proposal, new_positions, old_positions):
+        if self.verbose: print("Geometry engine logP_reverse calculation...")
+        initial_time = time.time()
+        geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, new_positions, old_positions, self.sampler.thermodynamic_state.beta)
+        if self.verbose: print('calculation took %.3f s' % (time.time() - initial_time))
+        return geometry_logp_reverse
+
+    def _ncmc_insert(self, topology_proposal, ncmc_old_positions):
+        if self.verbose: print("Performing NCMC insertion")
+        # Alchemically introduce new atoms.
+        initial_time = time.time()
+        [ncmc_new_positions, ncmc_introduction_logp, potential_insert] = self.ncmc_engine.integrate(topology_proposal, ncmc_old_positions, direction='insert', iteration=self.iteration)
+        if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
+        # Check that positions are not NaN
+        if np.any(np.isnan(ncmc_new_positions)):
+            raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
+        return ncmc_new_positions, ncmc_introduction_logp, potential_insert
+
+    def _ncmc_delete(self, topology_proposal, ncmc_old_positions):
+        if self.verbose: print("Performing NCMC annihilation")
+        # Alchemically eliminate atoms being removed.
+        [ncmc_old_positions, ncmc_elimination_logp, potential_delete] = self.ncmc_engine.integrate(topology_proposal, ncmc_old_positions, direction='delete', iteration=self.iteration)
+        # Check that positions are not NaN
+        if np.any(np.isnan(ncmc_old_positions)):
+            raise Exception("Positions are NaN after NCMC delete with %d steps" % self._switching_nsteps)
+        return ncmc_old_positions, ncmc_elimination_logp, potential_delete
+
+    def _ncmc_hybrid(self, topology_proposal, old_positions, new_positions):
+        if self.verbose: print("Performing NCMC switching")
+        initial_time = time.time()
+        [ncmc_new_positions, ncmc_old_positions, ncmc_logp] = self.ncmc_engine.integrate(topology_proposal, old_positions, new_positions)
+        if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
+        # Check that positions are not NaN
+        if np.any(np.isnan(ncmc_new_positions)):
+            raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
+        return ncmc_new_positions, ncmc_old_positions, ncmc_logp
+
+    def _geometry_ncmc_geometry(self, topology_proposal, old_log_weight, new_log_weight):
+        if self.verbose: print("Updating chemical state with geometry-ncmc-geometry scheme...")
+
+        geometry_old_positions = positions
+        geometry_new_positions, geometry_logp_propose = self._geometry_forward(topology_proposal, geometry_old_positions)
+
+        ncmc_new_positions, ncmc_old_positions, ncmc_logp = self._ncmc_hybrid(topology_proposal, positions, geometry_new_positions)
+
+        geometry_logp_reverse = self._geometry_reverse(topology_proposal, ncmc_new_positions, ncmc_old_positions)
+        geometry_logp = geometry_logp_reverse - geometry_logp_propose
+
+        # Compute total log acceptance probability, including all components.
+        logp_accept = topology_proposal.logp_proposal + geometry_logp + ncmc_logp + new_log_weight - old_log_weight
+        if self.verbose:
+            print("logp_accept = %+10.4e [logp_proposal = %+10.4e, geometry_logp = %+10.4e, ncmc_logp = %+10.4e, old_log_weight = %+10.4e, new_log_weight = %+10.4e]"
+                % (logp_accept, topology_proposal.logp_proposal, geometry_logp, ncmc_logp, old_log_weight, new_log_weight))
+        # Write to storage.
+        if self.storage:
+            self.storage.write_quantity('logp_ncmc', ncmc_logp, iteration=self.iteration)
+            self.storage.write_quantity('logp_geometry', geometry_logp, iteration=self.iteration)
+            self.storage.write_quantity('new_log_weight', new_log_weight, iteration=self.iteration)
+            self.storage.write_quantity('old_log_weight', old_log_weight, iteration=self.iteration)
+
+        return logp_accept, ncmc_new_positions
+
+    def _ncmc_geometry_ncmc(self, topology_proposal, old_log_weight, new_log_weight):
+        if self.verbose: print("Updating chemical state with ncmc-geometry-ncmc scheme...")
+
+        ncmc_old_positions, ncmc_elimination_logp, potential_delete = self._ncmc_delete(topology_proposal, positions)
+
+        geometry_old_positions = ncmc_old_positions
+        geometry_new_positions, geometry_logp_propose = self._geometry_forward(topology_proposal, geometry_old_positions)
+
+        geometry_logp_reverse = self._geometry_reverse(topology_proposal, geometry_new_positions, geometry_old_positions)
+        geometry_logp = geometry_logp_reverse - geometry_logp_propose
+
+        ncmc_new_positions, ncmc_introduction_logp, potential_insert = self._ncmc_insert(topology_proposal, geometry_new_positions)
+
+        # Compute change in eliminated potential contribution.
+        switch_logp = - (potential_insert - potential_delete)
+
+        # Compute total log acceptance probability, including all components.
+        logp_accept = topology_proposal.logp_proposal + geometry_logp + switch_logp + ncmc_elimination_logp + ncmc_introduction_logp + new_log_weight - old_log_weight
+        if self.verbose:
+            print("logp_accept = %+10.4e [logp_proposal %+10.4e geometry_logp %+10.4e switch_logp %+10.4e ncmc_elimination_logp %+10.4e ncmc_introduction_logp %+10.4e old_log_weight %+10.4e new_log_weight %+10.4e]"
+                % (logp_accept, topology_proposal.logp_proposal, geometry_logp, switch_logp, ncmc_elimination_logp, ncmc_introduction_logp, old_log_weight, new_log_weight))
+
+        elapsed_time = time.time() - initial_time
+
+        # Write to storage.
+        if self.storage:
+            self.storage.write_quantity('logp_ncmc_elimination', ncmc_elimination_logp, iteration=self.iteration)
+            self.storage.write_quantity('logp_ncmc_introduction', ncmc_introduction_logp, iteration=self.iteration)
+            self.storage.write_quantity('update_state_elapsed_time', elapsed_time, iteration=self.iteration)
+            self.storage.write_quantity('logp_switch', switch_logp, iteration=self.iteration)
+            self.storage.write_quantity('logp_geometry', geometry_logp, iteration=self.iteration)
+            self.storage.write_quantity('new_log_weight', new_log_weight, iteration=self.iteration)
+            self.storage.write_quantity('old_log_weight', old_log_weight, iteration=self.iteration)
+
+        return logp_accept, ncmc_new_positions
+
+    def _geometry_ncmc(self, topology_proposal, old_log_weight, new_log_weight):
+        raise(NotImplementedError("ExpandedEnsembleSampler scheme 'geometry-ncmc' has not been statistically validated and should not be used."))
+        from perses.tests.utils import compute_potential
+        if self.verbose: print("Updating chemical state with geometry-ncmc scheme...")
+
+        potential_delete = self.sampler.thermodynamic_state.beta * compute_potential(system, positions, platform=self.ncmc_engine.platform)
+
+        geometry_old_positions = positions
+        geometry_new_positions, geometry_logp_propose = self._geometry_forward(topology_proposal, geometry_old_positions)
+
+        geometry_logp_reverse = self._geometry_reverse(topology_proposal, geometry_new_positions, geometry_old_positions)
+        geometry_logp = geometry_logp_reverse - geometry_logp_propose
+
+        ncmc_new_positions, ncmc_introduction_logp, potential_insert = self._ncmc_insert(topology_proposal, geometry_new_positions)
+
+        # Compute change in eliminated potential contribution.
+        switch_logp = - (potential_insert - potential_delete)
+
+        # Compute total log acceptance probability, including all components.
+        logp_accept = topology_proposal.logp_proposal + geometry_logp + switch_logp + ncmc_introduction_logp + new_log_weight - old_log_weight
+        if self.verbose:
+            print("logp_accept = %+10.4e [logp_proposal %+10.4e geometry_logp %+10.4e switch_logp %+10.4e ncmc_introduction_logp %+10.4e old_log_weight %+10.4e new_log_weight %+10.4e]"
+                % (logp_accept, topology_proposal.logp_proposal, geometry_logp, switch_logp, ncmc_introduction_logp, old_log_weight, new_log_weight))
+        elapsed_time = time.time() - initial_time
+
+        # Write to storage.
+        if self.storage:
+            self.storage.write_quantity('logp_ncmc_introduction', ncmc_introduction_logp, iteration=self.iteration)
+            self.storage.write_quantity('update_state_elapsed_time', elapsed_time, iteration=self.iteration)
+            self.storage.write_quantity('logp_switch', switch_logp, iteration=self.iteration)
+            self.storage.write_quantity('logp_geometry', geometry_logp, iteration=self.iteration)
+            self.storage.write_quantity('new_log_weight', new_log_weight, iteration=self.iteration)
+            self.storage.write_quantity('old_log_weight', old_log_weight, iteration=self.iteration)
+
+        return logp_accept, ncmc_new_positions
+
     def update_positions(self):
         """
         Sample new positions.
@@ -872,319 +1022,51 @@ class ExpandedEnsembleSampler(object):
 
         initial_time = time.time()
 
-        # Check that system and topology have same number of atoms.
-        old_system = self.sampler.sampler_state.system
-        old_topology = self.topology
-        old_topology_natoms = sum([1 for atom in old_topology.atoms()]) # number of topology atoms
-        old_system_natoms = old_system.getNumParticles()
-        if old_topology_natoms != old_system_natoms:
-            msg = 'ExpandedEnsembleSampler: topology has %d atoms, while system has %d atoms' % (old_topology_natoms, old_system_natoms)
-            raise Exception(msg)
+        # Propose new chemical state.
+        if self.verbose: print("Proposing new topology...")
+        [system, topology, positions] = [self.sampler.thermodynamic_state.system, self.topology, self.sampler.sampler_state.positions]
+        topology_proposal = self.proposal_engine.propose(system, topology)
+        if self.verbose: print("Proposed transformation: %s => %s" % (topology_proposal.old_chemical_state_key, topology_proposal.new_chemical_state_key))
+
+        # Determine state keys
+        old_state_key = self.state_key
+        new_state_key = topology_proposal.new_chemical_state_key
+
+        # Determine log weight
+        old_log_weight = self.get_log_weight(old_state_key)
+        new_log_weight = self.get_log_weight(new_state_key)
 
         if self.scheme == 'ncmc-geometry-ncmc':
-            if self.verbose: print("Updating chemical state with ncmc-geometry-ncmc scheme...")
-
-            # Propose new chemical state.
-            if self.verbose: print("Proposing new topology...")
-            [system, topology, positions] = [self.sampler.thermodynamic_state.system, self.topology, self.sampler.sampler_state.positions]
-            topology_proposal = self.proposal_engine.propose(system, topology)
-            if self.verbose: print("Proposed transformation: %s => %s" % (topology_proposal.old_chemical_state_key, topology_proposal.new_chemical_state_key))
-
-            # Determine state keys
-            old_state_key = self.state_key
-            new_state_key = topology_proposal.new_chemical_state_key
-
-            # Determine log weight
-            old_log_weight = self.get_log_weight(old_state_key)
-            new_log_weight = self.get_log_weight(new_state_key)
-
-            if self.verbose: print("Performing NCMC annihilation")
-            # Alchemically eliminate atoms being removed.
-            [ncmc_old_positions, ncmc_elimination_logp, potential_delete] = self.ncmc_engine.integrate(topology_proposal, positions, direction='delete', iteration=self.iteration)
-            # Check that positions are not NaN
-            if np.any(np.isnan(ncmc_old_positions)):
-                raise Exception("Positions are NaN after NCMC delete with %d steps" % self._switching_nsteps)
-
-            if self.verbose: print("Geometry engine proposal...")
-            # Generate coordinates for new atoms and compute probability ratio of old and new probabilities.
-            initial_time = time.time()
-            geometry_old_positions = ncmc_old_positions
-            geometry_new_positions, geometry_logp_propose = self.geometry_engine.propose(topology_proposal, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            if self.verbose: print('proposal took %.3f s' % (time.time() - initial_time))
-
-            if self.geometry_pdbfile is not None:
-                print("Writing proposed geometry...")
-                #self.geometry_pdbfile.write('MODEL     %4d\n' % (self.iteration+1)) # PyMOL doesn't render connectivity correctly this way
-                from simtk.openmm.app import PDBFile
-                PDBFile.writeFile(topology_proposal.new_topology, geometry_new_positions, file=self.geometry_pdbfile)
-                #self.geometry_pdbfile.write('ENDMDL\n')
-                self.geometry_pdbfile.flush()
-
-            if self.verbose: print("Geometry engine logP_reverse calculation...")
-            initial_time = time.time()
-            geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            geometry_logp = geometry_logp_reverse - geometry_logp_propose
-            if self.verbose: print('calculation took %.3f s' % (time.time() - initial_time))
-
-            if self.verbose: print("Performing NCMC insertion")
-            # Alchemically introduce new atoms.
-            initial_time = time.time()
-            [ncmc_new_positions, ncmc_introduction_logp, potential_insert] = self.ncmc_engine.integrate(topology_proposal, geometry_new_positions, direction='insert', iteration=self.iteration)
-            if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
-            # Check that positions are not NaN
-            if np.any(np.isnan(ncmc_new_positions)):
-                raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
-
-            def print_energy_components(topology, system, positions):
-                from parmed.openmm import load_topology, energy_decomposition_system
-                structure = load_topology(topology, system=system, xyz=positions)
-                energies = energy_decomposition_system(structure, system, nrg=unit.kilocalories_per_mole)
-                for (name, energy) in energies:
-                    print('%40s %12.3f kcal/mol' % (name, energy))
-
-            # Compute change in eliminated potential contribution.
-            switch_logp = - (potential_insert - potential_delete)
-            if self.verbose:
-                print('potential before geometry  : %12.3f kT' % potential_delete)
-                print_energy_components(topology_proposal.old_topology, topology_proposal.old_system, geometry_old_positions)
-                print('potential after geometry   : %12.3f kT' % potential_insert)
-                print_energy_components(topology_proposal.new_topology, topology_proposal.new_system, geometry_new_positions)
-                print('  GEOMETRY ENERGY CHANGE   : %+12.3f kT' % (potential_insert - potential_delete))
-                print('---------------------------------------------------------')
-                print('switch_logp                : %12.3f' % switch_logp)
-                print('geometry_logp_propose      : %12.3f' % geometry_logp_propose)
-                print('geometry_logp_reverse      : %12.3f' % geometry_logp_reverse)
-
-            # Compute total log acceptance probability, including all components.
-            logp_accept = topology_proposal.logp_proposal + geometry_logp + switch_logp + ncmc_elimination_logp + ncmc_introduction_logp + new_log_weight - old_log_weight
-            if self.verbose:
-                print("logp_accept = %+10.4e [logp_proposal %+10.4e geometry_logp %+10.4e switch_logp %+10.4e ncmc_elimination_logp %+10.4e ncmc_introduction_logp %+10.4e old_log_weight %+10.4e new_log_weight %+10.4e]"
-                    % (logp_accept, topology_proposal.logp_proposal, geometry_logp, switch_logp, ncmc_elimination_logp, ncmc_introduction_logp, old_log_weight, new_log_weight))
-
-            # Accept or reject.
-            if np.isnan(logp_accept):
-                accept = False
-                print('logp_accept = NaN')
-            else:
-                accept = ((logp_accept>=0.0) or (np.random.uniform() < np.exp(logp_accept)))
-                if self.accept_everything:
-                    print('accept_everything option is turned on; accepting')
-                    accept = True
-
-            if accept:
-                self.sampler.thermodynamic_state.system = topology_proposal.new_system
-                self.sampler.sampler_state.system = topology_proposal.new_system
-                self.topology = topology_proposal.new_topology
-                self.sampler.sampler_state.positions = ncmc_new_positions
-                self.sampler.topology = topology
-                self.state_key = topology_proposal.new_chemical_state_key
-                self.naccepted += 1
-                if self.verbose: print("    accepted")
-            else:
-                self.nrejected += 1
-                if self.verbose: print("    rejected")
-
-            elapsed_time = time.time() - initial_time
-
-            # Write to storage.
-            if self.storage:
-                self.storage.write_quantity('logp_ncmc_elimination', ncmc_elimination_logp, iteration=self.iteration)
-                self.storage.write_quantity('logp_ncmc_introduction', ncmc_introduction_logp, iteration=self.iteration)
-                self.storage.write_quantity('update_state_elapsed_time', elapsed_time, iteration=self.iteration)
-                self.storage.write_quantity('logp_switch', switch_logp, iteration=self.iteration)
-
+            logp_accept, ncmc_new_positions = self._ncmc_geometry_ncmc(topology_proposal, old_log_weight, new_log_weight)
         elif self.scheme == 'geometry-ncmc':
-            raise(NotImplementedError("ExpandedEnsembleSampler scheme 'geometry-ncmc' has not been statistically validated and should not be used."))
-            from perses.tests.utils import compute_potential
-            if self.verbose: print("Updating chemical state with geometry-ncmc scheme...")
-            # Propose new chemical state.
-            if self.verbose: print("Proposing new topology...")
-            [system, topology, positions] = [self.sampler.thermodynamic_state.system, self.topology, self.sampler.sampler_state.positions]
-            topology_proposal = self.proposal_engine.propose(system, topology)
-            if self.verbose: print("Proposed transformation: %s => %s" % (topology_proposal.old_chemical_state_key, topology_proposal.new_chemical_state_key))
-
-            # Determine state keys
-            old_state_key = self.state_key
-            new_state_key = topology_proposal.new_chemical_state_key
-
-            # Determine log weight
-            old_log_weight = self.get_log_weight(old_state_key)
-            new_log_weight = self.get_log_weight(new_state_key)
-
-            potential_delete = self.sampler.thermodynamic_state.beta * compute_potential(system, positions, platform=self.ncmc_engine.platform)
-
-            if self.verbose: print("Geometry engine proposal...")
-            # Generate coordinates for new atoms and compute probability ratio of old and new probabilities.
-            initial_time = time.time()
-            geometry_old_positions = positions
-            geometry_new_positions, geometry_logp_propose = self.geometry_engine.propose(topology_proposal, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            if self.verbose: print('proposal took %.3f s' % (time.time() - initial_time))
-
-            if self.geometry_pdbfile is not None:
-                print("Writing proposed geometry...")
-                #self.geometry_pdbfile.write('MODEL     %4d\n' % (self.iteration+1)) # PyMOL doesn't render connectivity correctly this way
-                from simtk.openmm.app import PDBFile
-                PDBFile.writeFile(topology_proposal.new_topology, geometry_new_positions, file=self.geometry_pdbfile)
-                #self.geometry_pdbfile.write('ENDMDL\n')
-                self.geometry_pdbfile.flush()
-
-            if self.verbose: print("Geometry engine logP_reverse calculation...")
-            initial_time = time.time()
-            geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, geometry_new_positions, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            geometry_logp = geometry_logp_reverse - geometry_logp_propose
-            if self.verbose: print('calculation took %.3f s' % (time.time() - initial_time))
-
-            if self.verbose: print("Performing NCMC insertion")
-            # Alchemically introduce new atoms.
-            initial_time = time.time()
-            [ncmc_new_positions, ncmc_introduction_logp, potential_insert] = self.ncmc_engine.integrate(topology_proposal, geometry_new_positions, direction='insert', iteration=self.iteration)
-            if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
-            # Check that positions are not NaN
-            if np.any(np.isnan(ncmc_new_positions)):
-                raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
-
-            def print_energy_components(topology, system, positions):
-                from parmed.openmm import load_topology, energy_decomposition_system
-                structure = load_topology(topology, system=system, xyz=positions)
-                energies = energy_decomposition_system(structure, system, nrg=unit.kilocalories_per_mole)
-                for (name, energy) in energies:
-                    print('%40s %12.3f kcal/mol' % (name, energy))
-
-            # Compute change in eliminated potential contribution.
-            switch_logp = - (potential_insert - potential_delete)
-            if self.verbose:
-                print('potential before geometry  : %12.3f kT' % potential_delete)
-                print_energy_components(topology_proposal.old_topology, topology_proposal.old_system, geometry_old_positions)
-                print('potential after geometry   : %12.3f kT' % potential_insert)
-                print_energy_components(topology_proposal.new_topology, topology_proposal.new_system, geometry_new_positions)
-                print('---------------------------------------------------------')
-                print('switch_logp                : %12.3f' % switch_logp)
-                print('geometry_logp_propose      : %12.3f' % geometry_logp_propose)
-                print('geometry_logp_reverse      : %12.3f' % geometry_logp_reverse)
-
-            # Compute total log acceptance probability, including all components.
-            logp_accept = topology_proposal.logp_proposal + geometry_logp + switch_logp + ncmc_introduction_logp + new_log_weight - old_log_weight
-            if self.verbose:
-                print("logp_accept = %+10.4e [logp_proposal %+10.4e geometry_logp %+10.4e switch_logp %+10.4e ncmc_introduction_logp %+10.4e old_log_weight %+10.4e new_log_weight %+10.4e]"
-                    % (logp_accept, topology_proposal.logp_proposal, geometry_logp, switch_logp, ncmc_introduction_logp, old_log_weight, new_log_weight))
-
-            # Accept or reject.
-            if np.isnan(logp_accept):
-                accept = False
-                print('logp_accept = NaN')
-            else:
-                accept = ((logp_accept>=0.0) or (np.random.uniform() < np.exp(logp_accept)))
-                if self.accept_everything:
-                    print('accept_everything option is turned on; accepting')
-                    accept = True
-
-            if accept:
-                self.sampler.thermodynamic_state.system = topology_proposal.new_system
-                self.sampler.sampler_state.system = topology_proposal.new_system
-                self.topology = topology_proposal.new_topology
-                self.sampler.sampler_state.positions = ncmc_new_positions
-                self.sampler.topology = topology
-                self.state_key = topology_proposal.new_chemical_state_key
-                self.naccepted += 1
-                if self.verbose: print("    accepted")
-            else:
-                self.nrejected += 1
-                if self.verbose: print("    rejected")
-
-            elapsed_time = time.time() - initial_time
-
-            # Write to storage.
-            if self.storage:
-                self.storage.write_quantity('logp_ncmc_introduction', ncmc_introduction_logp, iteration=self.iteration)
-                self.storage.write_quantity('update_state_elapsed_time', elapsed_time, iteration=self.iteration)
-                self.storage.write_quantity('logp_switch', switch_logp, iteration=self.iteration)
-
+            logp_accept, ncmc_new_positions = self._geometry_ncmc(topology_proposal, old_log_weight, new_log_weight)
         elif self.scheme == 'geometry-ncmc-geometry':
-            if self.verbose: print("Updating chemical state with geometry-ncmc-geometry scheme...")
-
-            # Propose new chemical state.
-            if self.verbose: print("Proposing new topology...")
-            [system, topology, positions] = [self.sampler.thermodynamic_state.system, self.topology, self.sampler.sampler_state.positions]
-            topology_proposal = self.proposal_engine.propose(system, topology)
-            if self.verbose: print("Proposed transformation: %s => %s" % (topology_proposal.old_chemical_state_key, topology_proposal.new_chemical_state_key))
-
-            # Determine state keys
-            old_state_key = self.state_key
-            new_state_key = topology_proposal.new_chemical_state_key
-
-            # Determine log weight
-            old_log_weight = self.get_log_weight(old_state_key)
-            new_log_weight = self.get_log_weight(new_state_key)
-
-            if self.verbose: print("Geometry engine proposal...")
-            # Generate coordinates for new atoms and compute probability ratio of old and new probabilities.
-            initial_time = time.time()
-            geometry_old_positions = positions
-            geometry_new_positions, geometry_logp_propose = self.geometry_engine.propose(topology_proposal, geometry_old_positions, self.sampler.thermodynamic_state.beta)
-            if self.verbose: print('proposal took %.3f s' % (time.time() - initial_time))
-
-            if self.geometry_pdbfile is not None:
-                print("Writing proposed geometry...")
-                from simtk.openmm.app import PDBFile
-                PDBFile.writeFile(topology_proposal.new_topology, geometry_new_positions, file=self.geometry_pdbfile)
-                self.geometry_pdbfile.flush()
-
-            if self.verbose: print("Performing NCMC switching")
-            initial_time = time.time()
-            [ncmc_new_positions, ncmc_old_positions, ncmc_logp] = self.ncmc_engine.integrate(topology_proposal, positions, geometry_new_positions)
-            if self.verbose: print('NCMC took %.3f s' % (time.time() - initial_time))
-            # Check that positions are not NaN
-            if np.any(np.isnan(ncmc_new_positions)):
-                raise Exception("Positions are NaN after NCMC insert with %d steps" % self._switching_nsteps)
-
-            if self.verbose: print("Geometry engine logP_reverse calculation...")
-            initial_time = time.time()
-            geometry_logp_reverse = self.geometry_engine.logp_reverse(topology_proposal, ncmc_new_positions, ncmc_old_positions, self.sampler.thermodynamic_state.beta)
-            geometry_logp = geometry_logp_reverse - geometry_logp_propose
-            if self.verbose: print('calculation took %.3f s' % (time.time() - initial_time))
-
-            # Compute change in eliminated potential contribution.
-            if self.verbose:
-                #print('potential before geometry  : %12.3f kT' % potential_delete)
-                #print('potential after geometry   : %12.3f kT' % potential_insert)
-                print('---------------------------------------------------------')
-                print('ncmc_logp                  : %12.3f' % ncmc_logp)
-                print('geometry_logp_propose      : %12.3f' % geometry_logp_propose)
-                print('geometry_logp_reverse      : %12.3f' % geometry_logp_reverse)
-
-            # Compute total log acceptance probability, including all components.
-            logp_accept = topology_proposal.logp_proposal + geometry_logp + ncmc_logp + new_log_weight - old_log_weight
-            if self.verbose:
-                print("logp_accept = %+10.4e [logp_proposal = %+10.4e, geometry_logp = %+10.4e, ncmc_logp = %+10.4e, old_log_weight = %+10.4e, new_log_weight = %+10.4e]"
-                    % (logp_accept, topology_proposal.logp_proposal, geometry_logp, ncmc_logp, old_log_weight, new_log_weight))
-
-            # Accept or reject.
-            if np.isnan(logp_accept):
-                accept = False
-                print('logp_accept = NaN')
-            else:
-                accept = ((logp_accept>=0.0) or (np.random.uniform() < np.exp(logp_accept)))
-                if self.accept_everything:
-                    print('accept_everything option is turned on; accepting')
-                    accept = True
-
-            if accept:
-                self.sampler.thermodynamic_state.system = topology_proposal.new_system
-                self.sampler.sampler_state.system = topology_proposal.new_system
-                self.topology = topology_proposal.new_topology
-                self.sampler.sampler_state.positions = ncmc_new_positions
-                self.state_key = topology_proposal.new_chemical_state_key
-                self.naccepted += 1
-                if self.verbose: print("    accepted")
-            else:
-                self.nrejected += 1
-                if self.verbose: print("    rejected")
-            # Write to storage.
-            if self.storage:
-                self.storage.write_quantity('logp_ncmc', ncmc_logp, iteration=self.iteration)
-
+            logp_accept, ncmc_new_positions = self._geometry_ncmc_geometry(topology_proposal, old_log_weight, new_log_weight)
         else:
             raise Exception("Expanded ensemble state proposal scheme '%s' unsupported" % self.scheme)
+
+        # Accept or reject.
+        if np.isnan(logp_accept):
+            accept = False
+            print('logp_accept = NaN')
+        else:
+            accept = ((logp_accept>=0.0) or (np.random.uniform() < np.exp(logp_accept)))
+            if self.accept_everything:
+                print('accept_everything option is turned on; accepting')
+                accept = True
+
+        if accept:
+            self.sampler.thermodynamic_state.system = topology_proposal.new_system
+            self.sampler.sampler_state.system = topology_proposal.new_system
+            self.topology = topology_proposal.new_topology
+            self.sampler.sampler_state.positions = ncmc_new_positions
+            self.sampler.topology = self.topology
+            self.state_key = topology_proposal.new_chemical_state_key
+            self.naccepted += 1
+            if self.verbose: print("    accepted")
+        else:
+            self.nrejected += 1
+            if self.verbose: print("    rejected")
 
         if self.storage:
             self.storage.write_configuration('positions', self.sampler.sampler_state.positions, self.sampler.topology, iteration=self.iteration)
@@ -1194,9 +1076,6 @@ class ExpandedEnsembleSampler(object):
             self.storage.write_quantity('nrejected', self.nrejected, iteration=self.iteration)
             self.storage.write_quantity('logp_accept', logp_accept, iteration=self.iteration)
             self.storage.write_quantity('logp_topology_proposal', topology_proposal.logp_proposal, iteration=self.iteration)
-            self.storage.write_quantity('logp_geometry', geometry_logp, iteration=self.iteration)
-            self.storage.write_quantity('new_log_weight', new_log_weight, iteration=self.iteration)
-            self.storage.write_quantity('old_log_weight', old_log_weight, iteration=self.iteration)
 
 
         # Update statistics.

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -185,10 +185,12 @@ def check_alchemical_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6
 
 def plot_ncmc_logP(mol_name, ncmc_type, mean, sigma):
     x = mean.keys()
+    x.sort()
     y = [mean[steps] for steps in x]
     dy = [sigma[steps] for steps in x]
     plt.fill_between(x, [mean - dev for mean, dev in zip(y, dy)], [mean + dev for mean, dev in zip(y, dy)])
     plt.plot(x, y, 'k')
+    plt.xscale('log')
 
     plt.title("Log acceptance probability of {0} NCMC for {1}".format(ncmc_type, mol_name))
     plt.ylabel('logP NCMC')

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -44,257 +44,29 @@ functions_twostage = {
     'lambda_sterics' : '(2*lambda)^4 * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
     'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
     'lambda_bonds' : '1.0', # don't soften bonds
-    'lambda_angles' : '0.1*lambda+0.9', # don't soften angles
+    'lambda_angles' : '0.1*lambda+0.9',
     'lambda_torsions' : '0.7*lambda+0.3'
 }
 
-
-def check_hybrid_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
-    """
-    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
-
-    Parameters
-    ----------
-    NullProposal : class
-        subclass of testsystems.NullTestSystem
-    ncmc_nsteps : int, optional, default=50
-        Number of NCMC switching steps, or 0 for instantaneous switching.
-    NSIGMA_MAX : float, optional, default=6.0
-        Number of standard errors away from analytical solution tolerated before Exception is thrown
-    geometry : bool, optional, default=None
-        If True, will also use geometry engine in the middle of the null transformation.
-    """
-    functions = functions_hybrid
-
-    testsystem = NullProposal(storage_filename=None, scheme='geometry-ncmc-geometry',options={'functions': functions, 'nsteps': ncmc_nsteps})
-    for key in [ENV]: #testsystem.environments: # only one key: vacuum
-        # run a single iteration to generate item in number_of_state_visits dict
-        exen_sampler = testsystem.exen_samplers[key]
-        exen_sampler.verbose = False
-        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
-        exen_sampler.run(niterations=5)
-
-        topology = exen_sampler.topology
-        system = exen_sampler.sampler.sampler_state.system
-        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
-        positions = exen_sampler.sampler.sampler_state.positions
-
-    logP_n = np.zeros([niterations], np.float64)
-    for iteration in range(niterations):
-        # Check that positions are not NaN
-        if(np.any(np.isnan(positions / unit.angstroms))):
-            raise Exception("Positions became NaN during equilibration")
-
-        # Hybrid NCMC from old to new
-        [positions, new_old_positions, logP] = ncmc_engine.integrate(topology_proposal, positions, positions)
-
-        # Check that positions are not NaN
-        if(np.any(np.isnan(positions / unit.angstroms))):
-            raise Exception("Positions became NaN on Hybrid NCMC switch")
-
-        # Compute total probability
-        logP_n[iteration] = logP
-
-    work_n = - logP_n
-    print(work_n.mean(), work_n.std())
-    return work_n.mean(), work_n.std()
-
-def check_alchemical_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
-    """
-    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
-
-    Parameters
-    ----------
-    NullProposal : class
-        subclass of testsystems.NullTestSystem
-    ncmc_nsteps : int, optional, default=50
-        Number of NCMC switching steps, or 0 for instantaneous switching.
-    NSIGMA_MAX : float, optional, default=6.0
-        Number of standard errors away from analytical solution tolerated before Exception is thrown
-    geometry : bool, optional, default=None
-        If True, will also use geometry engine in the middle of the null transformation.
-    """
-    functions = functions_twostage
-    testsystem = NullProposal(storage_filename=None, scheme='ncmc-geometry-ncmc',options={'functions': functions, 'nsteps': ncmc_nsteps})
-
-    for key in [ENV]: #testsystem.environments: # only one key: vacuum
-        # run a single iteration to generate item in number_of_state_visits dict
-        exen_sampler = testsystem.exen_samplers[key]
-        exen_sampler.verbose = False
-        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
-        exen_sampler.run(niterations=5)
-
-        topology = exen_sampler.topology
-        system = exen_sampler.sampler.sampler_state.system
-        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
-        positions = exen_sampler.sampler.sampler_state.positions
-
-    logP_insert_n = np.zeros([niterations], np.float64)
-    logP_delete_n = np.zeros([niterations], np.float64)
-    logP_switch_n = np.zeros([niterations], np.float64)
-    for iteration in range(niterations):
-        # Check that positions are not NaN
-        if(np.any(np.isnan(positions / unit.angstroms))):
-            raise Exception("Positions became NaN during equilibration")
-
-        # Delete atoms
-        [positions, logP_delete, potential_delete] = ncmc_engine.integrate(topology_proposal, positions, direction='delete')
-
-        # Check that positions are not NaN
-        if(np.any(np.isnan(positions / unit.angstroms))):
-            raise Exception("Positions became NaN on NCMC deletion")
-
-        # Insert atoms
-        [positions, logP_insert, potential_insert] = ncmc_engine.integrate(topology_proposal, positions, direction='insert')
-
-        # Check that positions are not NaN
-        if(np.any(np.isnan(positions / unit.angstroms))):
-            raise Exception("Positions became NaN on NCMC insertion")
-
-        # Compute probability of switching geometries.
-        logP_switch = - (potential_insert - potential_delete)
-
-        # Compute total probability
-        logP_delete_n[iteration] = logP_delete
-        logP_insert_n[iteration] = logP_insert
-        logP_switch_n[iteration] = logP_switch
-
-    logP_n = logP_delete_n + logP_insert_n + logP_switch_n
-    work_n = - logP_n
-    print(work_n.mean(), work_n.std())
-    return work_n.mean(), work_n.std()
-
-def plot_ncmc_logP(mol_name, ncmc_type, mean, sigma):
-    x = mean.keys()
-    x.sort()
-    y = [mean[steps] for steps in x]
-    dy = [sigma[steps] for steps in x]
-    plt.fill_between(x, [mean - dev for mean, dev in zip(y, dy)], [mean + dev for mean, dev in zip(y, dy)])
-    plt.plot(x, y, 'k')
-    plt.xscale('log')
-
-    plt.title("Log acceptance probability of {0} NCMC for {1}".format(ncmc_type, mol_name))
-    plt.ylabel('logP NCMC')
-    plt.xlabel('ncmc steps')
-    plt.savefig('{0}_{1}_{2}NCMC_logP'.format(ENV, mol_name, ncmc_type))
-    print('Saved plot to {0}_{1}_{2}NCMC_logP.png'.format(ENV, mol_name, ncmc_type))
-    plt.clf()
-
-def plot_exen_logP(mol_name, ncmc_type, mean, sigma):
-    x = mean.keys()
-    x.sort()
-    y = [mean[steps] for steps in x]
-    dy = [sigma[steps] for steps in x]
-    plt.fill_between(x, [mean - dev for mean, dev in zip(y, dy)], [mean + dev for mean, dev in zip(y, dy)])
-    plt.plot(x, y, 'k')
-    plt.xscale('log')
-
-    plt.title("Log acceptance probability of {0} ExpandedEnsemble for {1}".format(ncmc_type, mol_name))
-    plt.ylabel('logP')
-    plt.xlabel('ncmc steps')
-    plt.savefig('{0}_{1}_{2}EXEN_logP'.format(ENV, mol_name, ncmc_type))
-    print('Saved plot to {0}_{1}_{2}EXEN_logP.png'.format(ENV, mol_name, ncmc_type))
-    plt.clf()
-
-def benchmark_ncmc_null_protocols():
-    """
-    Check convergence of logP for hybrid and delete/insert NCMC schemes for 3
-    small molecule null proposals
-
-    Does not run geometry engine
-
-    Plot mean and standard deviation of logP for 0, 1, 10, 100, 1000, 10000
-    ncmc steps.
-    """
-    from perses.tests.testsystems import NaphthaleneTestSystem, ButaneTestSystem, PropaneTestSystem
-    molecule_names = {
-        'naphthalene' : NaphthaleneTestSystem,
-        'butane' : ButaneTestSystem,
-        'propane' : PropaneTestSystem,
-    }
-    methods = {
-#        'hybrid' : check_hybrid_null_elimination,
-        'two-stage' : check_alchemical_null_elimination,
-    }
-    for molecule_name, NullProposal in molecule_names.items():
-        print('\nNow testing {0} null transformations'.format(molecule_name))
-        for scheme, method in methods.items():
-            mean = dict()
-            sigma = dict()
-            for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
-                print('Running {0} delete-insert NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
-                mean[ncmc_nsteps], sigma[ncmc_nsteps] = method(NullProposal, ncmc_nsteps=ncmc_nsteps)
-            plot_ncmc_logP(molecule_name, scheme, mean, sigma)
-
-def check_alchemical_exen(NullProposal, scheme, ncmc_nsteps, functions):
-    testsystem = NullProposal(storage_filename=None, scheme=scheme,options={'functions': functions, 'nsteps': ncmc_nsteps})
-    for key in [ENV]: #testsystem.environments: # only one key: vacuum
-        # run a single iteration to generate item in number_of_state_visits dict
-        exen_sampler = testsystem.exen_samplers[key]
-        exen_sampler.verbose = False
-        topology = testsystem.topologies[key]
-        system = testsystem.system_generators[key].build_system(topology)
-        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
-        positions = testsystem.positions[key]
-
-    testsystem.positions[ENV] = positions
-    return testsystem, exen_sampler
-
-def check_hybrid_exen(NullProposal, ncmc_nsteps=50):
-    functions = functions_hybrid
-    testsystem, exen_sampler = check_alchemical_exen(NullProposal, 'geometry-ncmc-geometry', ncmc_nsteps, functions)
-    logP_n = np.zeros([niterations], np.float64)
-    for iteration in range(niterations):
-        exen_sampler.update_positions()
-        logP, _ = exen_sampler._geometry_ncmc_geometry()
-        logP_n[iteration] = logP
-
-    print(logP_n.mean(), logP_n.std())
-    return logP_n.mean(), logP_n.std()
-
-def check_twostage_exen(NullProposal, ncmc_nsteps=50):
-    functions = functions_twostage
-    testsystem, exen_sampler = check_alchemical_exen(NullProposal, 'ncmc-geometry-ncmc', ncmc_nsteps, functions)
-    logP_n = np.zeros([niterations], np.float64)
-    for iteration in range(niterations):
-        exen_sampler.update_positions()
-        logP, _ = exen_sampler._ncmc_geometry_ncmc()
-        logP_n[iteration] = logP
-
-    print(logP_n.mean(), logP_n.std())
-    return logP_n.mean(), logP_n.std()
-
-def benchmark_exen_ncmc_null_protocols():
-    """
-    Relationship of overall ExpandedEnsemble logp_accept to n_ncmc_steps
-
-    Check convergence of logP for hybrid and delete/insert NCMC schemes for 3
-    small molecule null proposals
-
-    Plot mean and standard deviation of logP for 0, 1, 10, 100, 1000, 10000
-    ncmc steps.
-    """
-    from perses.tests.testsystems import NaphthaleneTestSystem, ButaneTestSystem, PropaneTestSystem
-    molecule_names = {
-        'naphthalene' : NaphthaleneTestSystem,
-        'butane' : ButaneTestSystem,
-        'propane' : PropaneTestSystem,
-    }
-    methods = {
-        'hybrid' : check_hybrid_exen,
-        'two-stage' : check_twostage_exen,
-    }
-    for molecule_name, NullProposal in molecule_names.items():
-        print('\nNow testing {0} null transformations'.format(molecule_name))
-        for scheme, method in methods.items():
-            mean = dict()
-            sigma = dict()
-            for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
-                print('Running {0} hybrid NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
-                mean[ncmc_nsteps], sigma[ncmc_nsteps] = method(NullProposal, ncmc_nsteps=ncmc_nsteps)
-            plot_exen_logP(molecule_name, scheme, mean, sigma)
-
 def plot_logPs(logps, molecule_name, scheme, component):
+    """
+    Create line plot of mean and standard deviation of given logPs.
+
+    Arguments:
+    ----------
+        logps: dict { int : np.ndarray }
+            key : number of total NCMC steps
+            value : array of `niterations` logP values
+        molecule_name : str
+            The molecule featured in the NullTestSystem being analyzed
+            in ['naphthalene','butane','propane']
+        scheme : str
+            Which NCMC scheme is being used
+            in ['hybrid','two-stage']
+        component : str
+            Which logP is being plotted
+            in ['NCMC','EXEN']
+    """
     x = logps.keys()
     x.sort()
     y = [logps[steps].mean() for steps in x]
@@ -311,6 +83,29 @@ def plot_logPs(logps, molecule_name, scheme, component):
     plt.clf()
 
 def benchmark_exen_ncmc_protocol(analyses, molecule_name, scheme):
+    """
+    For each combination of system and scheme, results are analyzed for
+    the following:
+    * Over the whole range of total steps:
+        * Plot mean and standard deviation of NCMC logP as a function of
+          total steps
+        * Plot mean and standard deviation of EXEN logP as a function of
+          total steps
+
+    Arguments:
+    ----------
+        analyses : dict { int : perses.Analysis }
+            key : number of total NCMC steps
+            value : analysis object contained stored information
+        molecule_name : str
+            The molecule featured in the NullTestSystem being analyzed
+            in ['naphthalene','butane','propane']
+        scheme : str
+            Which NCMC scheme is being used
+            in ['hybrid','two-stage']
+
+    Creates 2 plots every time it is called
+    """
     components = {
         'logp_accept' : 'EXEN',
         'logp_ncmc' : 'NCMC',
@@ -328,6 +123,26 @@ def benchmark_exen_ncmc_protocol(analyses, molecule_name, scheme):
         plot_logPs(logps, molecule_name, scheme, components[component])
 
 def benchmark_ncmc_work_during_protocol():
+    """
+    Run 50 iterations of ExpandedEnsembleSampler for NullTestSystems
+    over a range of total NCMC steps [0, 1, 10, 100, 1000, 10000].
+
+    Benchmark is repeated for Naphthalene, Butane, and Propane test
+    systems, using two-stage and hybrid NCMC.
+
+    For each combination of system and scheme, results are analyzed for
+    the following:
+    * For a given total number of steps:
+        * For NCMC steps 100 and above, plot work done by ncmc integrator
+          over the course of the protocol
+        * Plot histograms of the contributions of each component to the
+          overall log acceptance probability
+    * Over the whole range of total steps:
+        * Plot mean and standard deviation of NCMC logP as a function of
+          total steps
+        * Plot mean and standard deviation of EXEN logP as a function of
+          total steps
+    """
     from perses.tests.testsystems import NaphthaleneTestSystem, ButaneTestSystem, PropaneTestSystem
     from perses.analysis import Analysis
     import netCDF4 as netcdf
@@ -351,6 +166,7 @@ def benchmark_ncmc_work_during_protocol():
                 print('Running {0} {2} ExpandedEnsemble steps for {1} iterations'.format(ncmc_nsteps, niterations, name))
                 testsystem = NullProposal(storage_filename='{0}_{1}-{2}steps.nc'.format(molecule_name, name, ncmc_nsteps), scheme=scheme, options={'functions' : functions, 'nsteps' : ncmc_nsteps})
                 testsystem.exen_samplers['vacuum'].verbose = False
+                testsystem.exen_samplers['vacuum'].sampler.verbose = False
                 if name == 'hybrid':
                     testsystem.exen_samplers['vacuum'].ncmc_engine.softening = 0.0
                 testsystem.exen_samplers['vacuum'].run(niterations=niterations)

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -23,7 +23,7 @@ import matplotlib.pyplot as plt
 # NUMBER OF ATTEMPTS
 ################################################################################
 niterations = 50
-ENV = 'explicit'
+ENV = 'vacuum'
 ################################################################################
 # CONSTANTS
 ################################################################################
@@ -165,11 +165,11 @@ def benchmark_ncmc_work_during_protocol():
             for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
                 print('Running {0} {2} ExpandedEnsemble steps for {1} iterations'.format(ncmc_nsteps, niterations, name))
                 testsystem = NullProposal(storage_filename='{0}_{1}-{2}steps.nc'.format(molecule_name, name, ncmc_nsteps), scheme=scheme, options={'functions' : functions, 'nsteps' : ncmc_nsteps})
-                testsystem.exen_samplers['vacuum'].verbose = False
-                testsystem.exen_samplers['vacuum'].sampler.verbose = False
+                testsystem.exen_samplers[ENV].verbose = False
+                testsystem.exen_samplers[ENV].sampler.verbose = False
                 if name == 'hybrid':
-                    testsystem.exen_samplers['vacuum'].ncmc_engine.softening = 0.0
-                testsystem.exen_samplers['vacuum'].run(niterations=niterations)
+                    testsystem.exen_samplers[ENV].ncmc_engine.softening = 0.0
+                testsystem.exen_samplers[ENV].run(niterations=niterations)
 
                 analysis = Analysis(testsystem.storage_filename)
                 print(analysis.get_environments())

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -211,7 +211,7 @@ def benchmark_ncmc_null_protocols():
         print('Now testing {0} null transformations'.format(molecule_name))
         mean = dict()
         sigma = dict()
-        for ncmc_nsteps in [0, 1, 10, 100]:#, 1000, 10000]:
+        for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
             print('Running {0} hybrid NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
             mean[ncmc_nsteps], sigma[ncmc_nsteps] = check_hybrid_null_elimination(NullProposal, ncmc_nsteps=ncmc_nsteps)
         plot_ncmc_logP(molecule_name, 'hybrid', mean, sigma)

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -1,0 +1,228 @@
+from simtk import openmm, unit
+from simtk.openmm import app
+import os, os.path
+import sys, math
+from unittest import skipIf
+import numpy as np
+from functools import partial
+from pkg_resources import resource_filename
+from openeye import oechem
+if sys.version_info >= (3, 0):
+    from io import StringIO
+    from subprocess import getstatusoutput
+else:
+    from cStringIO import StringIO
+    from commands import getstatusoutput
+import matplotlib as mpl
+mpl.use('Agg')
+import seaborn as sns
+
+import matplotlib.pyplot as plt
+
+################################################################################
+# NUMBER OF ATTEMPTS
+################################################################################
+niterations = 50
+################################################################################
+# CONSTANTS
+################################################################################
+
+kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
+temperature = 300.0 * unit.kelvin
+kT = kB * temperature
+beta = 1.0/kT
+
+def simulate(system, positions, nsteps=500, timestep=1.0*unit.femtoseconds, temperature=temperature, collision_rate=5.0/unit.picoseconds, platform=None):
+    integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
+    if platform == None:
+        context = openmm.Context(system, integrator)
+    else:
+        context = openmm.Context(system, integrator, platform)
+    context.setPositions(positions)
+    context.setVelocitiesToTemperature(temperature)
+    integrator.step(nsteps)
+    positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+    velocities = context.getState(getVelocities=True).getVelocities(asNumpy=True)
+    return [positions, velocities]
+
+def check_hybrid_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
+    """
+    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
+
+    Parameters
+    ----------
+    NullProposal : class
+        subclass of testsystems.NullTestSystem
+    ncmc_nsteps : int, optional, default=50
+        Number of NCMC switching steps, or 0 for instantaneous switching.
+    NSIGMA_MAX : float, optional, default=6.0
+        Number of standard errors away from analytical solution tolerated before Exception is thrown
+    geometry : bool, optional, default=None
+        If True, will also use geometry engine in the middle of the null transformation.
+    """
+    functions = {
+        'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
+        'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
+        'lambda_bonds' : '1.0',  
+        'lambda_angles' : '0.5*lambda+0.5', 
+        'lambda_torsions' : '0.5*lambda+0.5'
+    }
+
+    testsystem = NullProposal(storage_filename=None, scheme='geometry-ncmc-geometry',options={'functions': functions, 'nsteps': ncmc_nsteps})
+    for key in testsystem.environments: # only one key: vacuum
+        # run a single iteration to generate item in number_of_state_visits dict
+        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
+
+        topology = testsystem.topologies[key]
+        system = testsystem.system_generators[key].build_system(topology)
+        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
+        positions = testsystem.positions[key]
+
+    nequil = 5 # number of equilibration iterations
+    logP_n = np.zeros([niterations], np.float64)
+    for iteration in range(nequil):
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+    for iteration in range(niterations):
+        # Equilibrate
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN during equilibration")
+
+        # Hybrid NCMC from old to new
+        [positions, new_old_positions, logP] = ncmc_engine.integrate(topology_proposal, positions, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on Hybrid NCMC switch")
+
+        # Compute total probability
+        logP_n[iteration] = logP
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    work_n = - logP_n
+    from pymbar import EXP
+    [df, ddf] = EXP(work_n)
+    return df, ddf
+
+def check_alchemical_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
+    """
+    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
+
+    Parameters
+    ----------
+    topology_proposal : TopologyProposal
+        The topology proposal to test.
+        This must be a null transformation, where topology_proposal.old_system == topology_proposal.new_system
+    ncmc_nsteps : int, optional, default=50
+        Number of NCMC switching steps, or 0 for instantaneous switching.
+    NSIGMA_MAX : float, optional, default=6.0
+        Number of standard errors away from analytical solution tolerated before Exception is thrown
+    geometry : bool, optional, default=None
+        If True, will also use geometry engine in the middle of the null transformation.
+    """
+    functions = {
+        'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
+        'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
+        'lambda_bonds' : '1.0', # don't soften bonds
+        'lambda_angles' : '1.0', # don't soften angles
+        'lambda_torsions' : 'lambda'
+    }
+    testsystem = NullProposal(storage_filename=None, scheme='ncmc-geometry-ncmc',options={'functions': functions, 'nsteps': ncmc_nsteps})
+
+    for key in testsystem.environments: # only one key: vacuum
+        # run a single iteration to generate item in number_of_state_visits dict
+        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
+
+        topology = testsystem.topologies[key]
+        system = testsystem.system_generators[key].build_system(topology)
+        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
+        positions = testsystem.positions[key]
+
+    nequil = 5 # number of equilibration iterations
+    logP_insert_n = np.zeros([niterations], np.float64)
+    logP_delete_n = np.zeros([niterations], np.float64)
+    logP_switch_n = np.zeros([niterations], np.float64)
+    for iteration in range(nequil):
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+    for iteration in range(niterations):
+        # Equilibrate
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN during equilibration")
+
+        # Delete atoms
+        [positions, logP_delete, potential_delete] = ncmc_engine.integrate(topology_proposal, positions, direction='delete')
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on NCMC deletion")
+
+        # Insert atoms
+        [positions, logP_insert, potential_insert] = ncmc_engine.integrate(topology_proposal, positions, direction='insert')
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on NCMC insertion")
+
+        # Compute probability of switching geometries.
+        logP_switch = - (potential_insert - potential_delete)
+
+        # Compute total probability
+        logP_delete_n[iteration] = logP_delete
+        logP_insert_n[iteration] = logP_insert
+        logP_switch_n[iteration] = logP_switch
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    logP_n = logP_delete_n + logP_insert_n + logP_switch_n
+    work_n = - logP_n
+    from pymbar import EXP
+    [df, ddf] = EXP(work_n)
+    return df, ddf
+
+def plot_ncmc_logP(mol_name, ncmc_type, mean, sigma):
+    x = mean.keys()
+    y = [mean[steps] for steps in x]
+    dy = [sigma[steps] for steps in x]
+    plt.fill_between(x, [mean - dev for mean, dev in zip(y, dy)], [mean + dev for mean, dev in zip(y, dy)])
+    plt.plot(x, y, 'k')
+
+    plt.title("Log acceptance probability of {0} NCMC for {1}".format(ncmc_type, mol_name))
+    plt.ylabel('logP NCMC')
+    plt.xlabel('ncmc steps')
+    plt.savefig('{0}_{1}NCMC_logP'.format(mol_name, ncmc_type))
+    print('Saved plot to {0}_{1}NCMC_logP.png'.format(mol_name, ncmc_type))
+    plt.clf()
+
+def benchmark_ncmc_null_protocols():
+    """
+    Check alchemical elimination for alanine dipeptide in vacuum with 0, 1, 2, and 50 switching steps.
+    """
+    from perses.tests.testsystems import NaphthaleneTestSystem, ButaneTestSystem, PropaneTestSystem
+    molecule_names = {
+        'naphthalene' : NaphthaleneTestSystem,
+        'butane' : ButaneTestSystem,
+        'propane' : PropaneTestSystem,
+    }
+    for molecule_name, NullProposal in molecule_names.items():
+        print('Now testing {0} null transformations'.format(molecule_name))
+        mean = dict()
+        sigma = dict()
+        for ncmc_nsteps in [0, 1, 10, 100]:#, 1000, 10000]:
+            print('Running {0} hybrid NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
+            mean[ncmc_nsteps], sigma[ncmc_nsteps] = check_hybrid_null_elimination(NullProposal, ncmc_nsteps=ncmc_nsteps)
+        plot_ncmc_logP(molecule_name, 'hybrid', mean, sigma)
+
+        mean = dict()
+        sigma = dict()
+        for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
+            print('Running {0} delete-insert NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
+            mean[ncmc_nsteps], sigma[ncmc_nsteps] = check_alchemical_null_elimination(NullProposal, ncmc_nsteps=ncmc_nsteps)
+        plot_ncmc_logP(molecule_name, 'two-stage', mean, sigma)
+
+if __name__ == "__main__":
+    benchmark_ncmc_null_protocols()
+

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -141,6 +141,74 @@ def check_alchemical_null_elimination(topology_proposal, positions, ncmc_nsteps=
         msg += str(logP_n) + '\n'
         raise Exception(msg)
 
+def check_hybrid_null_elimination(topology_proposal, positions, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
+    """
+    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
+
+    Parameters
+    ----------
+    topology_proposal : TopologyProposal
+        The topology proposal to test.
+        This must be a null transformation, where topology_proposal.old_system == topology_proposal.new_system
+    ncmc_steps : int, optional, default=50
+        Number of NCMC switching steps, or 0 for instantaneous switching.
+    NSIGMA_MAX : float, optional, default=6.0
+        Number of standard errors away from analytical solution tolerated before Exception is thrown
+    geometry : bool, optional, default=None
+        If True, will also use geometry engine in the middle of the null transformation.
+    """
+    functions = {
+        'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
+        'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
+        'lambda_bonds' : '1.0', # don't soften bonds
+        'lambda_angles' : '1.0', # don't soften angles
+        'lambda_torsions' : 'lambda'
+    }
+    # Initialize engine
+    from perses.annihilation.ncmc_switching import NCMCHybridEngine
+    ncmc_engine = NCMCHybridEngine(temperature=temperature, functions=functions, nsteps=ncmc_nsteps)
+
+    # Make sure that old system and new system are identical.
+    if not (topology_proposal.old_system == topology_proposal.new_system):
+        raise Exception("topology_proposal must be a null transformation for this test (old_system == new_system)")
+    for (k,v) in topology_proposal.new_to_old_atom_map.items():
+        if k != v:
+            raise Exception("topology_proposal must be a null transformation for this test (retailed atoms must map onto themselves)")
+
+    nequil = 5 # number of equilibration iterations
+    niterations = 50 # number of round-trip switching trials
+    logP_n = np.zeros([niterations], np.float64)
+    for iteration in range(nequil):
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+    for iteration in range(niterations):
+        # Equilibrate
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN during equilibration")
+
+        # Hybrid NCMC from old to new
+        [positions, new_old_positions, logP] = ncmc_engine.integrate(topology_proposal, positions, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on Hybrid NCMC switch")
+
+        # Compute total probability
+        logP_n[iteration] = logP
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    work_n = - logP_n
+    from pymbar import EXP
+    [df, ddf] = EXP(work_n)
+    #print("df = %12.6f +- %12.5f kT" % (df, ddf))
+    if (abs(df) > NSIGMA_MAX * ddf):
+        msg = 'Delta F (%d steps switching) = %f +- %f kT; should be within %f sigma of 0\n' % (ncmc_nsteps, df, ddf, NSIGMA_MAX)
+        msg += 'logP:\n'
+        msg += str(logP_n) + '\n'
+        raise Exception(msg)
+
 @skipIf(os.environ.get("TRAVIS", None) == 'true', "Skip expensive test on travis")
 def test_alchemical_elimination_mutation():
     """
@@ -246,8 +314,35 @@ def test_ncmc_engine_molecule():
         topology_proposal = TopologyProposal(
             new_topology=topology, new_system=system, old_topology=topology, old_system=system,
             old_chemical_state_key='', new_chemical_state_key='', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata={'test':0.0})
-        for ncmc_nsteps in [50]:#[0, 1, 50]:
+        for ncmc_nsteps in [0, 1, 50]:
             f = partial(check_alchemical_null_elimination, topology_proposal, positions, ncmc_nsteps=ncmc_nsteps)
+            f.description = "Testing alchemical null elimination for '%s' with %d NCMC steps" % (molecule_name, ncmc_nsteps)
+            yield f
+
+@skipIf(os.environ.get("TRAVIS", None) == 'true', "Skip expensive test on travis")
+def test_ncmc_hybrid_engine_molecule():
+    """
+    Check alchemical elimination for alanine dipeptide in vacuum with 0, 1, 2, and 50 switching steps.
+    """
+    molecule_names = ['imatinib', 'pentane', 'biphenyl']
+    molecule_names = ['pentane', 'biphenyl']
+    if os.environ.get("TRAVIS", None) == 'true':
+        molecule_names = ['pentane']
+
+    for molecule_name in molecule_names:
+        from perses.tests.utils import createSystemFromIUPAC
+        [molecule, system, positions, topology] = createSystemFromIUPAC(molecule_name)
+        natoms = system.getNumParticles()
+        # Eliminate half of the molecule
+        # TODO: Use a more rigorous scheme to make sure we are really cutting the molecule in half and not just eliminating hydrogens or something.
+        new_to_old_atom_map = { atom.index : atom.index for atom in topology.atoms() if str(atom.element.name) in ['carbon','nitrogen'] }
+
+        from perses.rjmc.topology_proposal import TopologyProposal
+        topology_proposal = TopologyProposal(
+            new_topology=topology, new_system=system, old_topology=topology, old_system=system,
+            old_chemical_state_key='', new_chemical_state_key='', logp_proposal=0.0, new_to_old_atom_map=new_to_old_atom_map, metadata={'test':0.0})
+        for ncmc_nsteps in [0, 1, 50]:
+            f = partial(check_hybrid_null_elimination, topology_proposal, positions, ncmc_nsteps=ncmc_nsteps)
             f.description = "Testing alchemical null elimination for '%s' with %d NCMC steps" % (molecule_name, ncmc_nsteps)
             yield f
 
@@ -273,7 +368,7 @@ def test_alchemical_elimination_peptide():
         yield f
 
 if __name__ == "__main__":
-    for x in test_ncmc_engine_molecule():
+    for x in test_ncmc_hybrid_engine_molecule():
         print(x.description)
         x()
 #    test_ncmc_alchemical_integrator_stability_molecules()

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -160,13 +160,13 @@ def check_hybrid_null_elimination(topology_proposal, positions, ncmc_nsteps=50, 
     functions = {
         'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
         'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
-        'lambda_bonds' : '1.0', # don't soften bonds
-        'lambda_angles' : '1.0', # don't soften angles
+        'lambda_bonds' : 'lambda', # don't soften bonds
+        'lambda_angles' : 'lambda', # don't soften angles
         'lambda_torsions' : 'lambda'
     }
     # Initialize engine
     from perses.annihilation.ncmc_switching import NCMCHybridEngine
-    ncmc_engine = NCMCHybridEngine(temperature=temperature, functions=functions, nsteps=ncmc_nsteps)
+    ncmc_engine = NCMCHybridEngine(temperature=temperature, functions=functions, nsteps=ncmc_nsteps, softening=0.7)
 
     # Make sure that old system and new system are identical.
     if not (topology_proposal.old_system == topology_proposal.new_system):

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2051,9 +2051,9 @@ class NullTestSystem(PersesTestSystem):
             if key == "vacuum":
                 forcefield_kwargs = {'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None}
                 ff_list = [gaff_xml_filename]
-            if key == "exlicit":
+            if key == "explicit":
                 ff_list = [gaff_xml_filename, 'tip3p.xml']
-                forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints }
+                forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : app.HBonds }
             system_generator = SystemGenerator(ff_list, forcefield_kwargs=forcefield_kwargs)
             system_generators[key] = system_generator
 
@@ -2061,12 +2061,14 @@ class NullTestSystem(PersesTestSystem):
             initial_molecule = createOEMolFromIUPAC(iupac_name=self.mol_name)
             initial_system, initial_positions, initial_topology = oemol_to_omm_ff(initial_molecule, self.mol_name)
 
-            if key == "exlicit":
+            if key == "explicit":
                 modeller = app.Modeller(initial_topology, initial_positions)
-                modeller.addSolvent(forcefield, model='tip3p', padding=9.0*unit.angstrom)
+                modeller.addSolvent(system_generators[key].getForceField(), model='tip3p', padding=9.0*unit.angstrom)
                 initial_topology = modeller.getTopology()
                 initial_positions = modeller.getPositions()
                 initial_system = system_generators[key].build_system(initial_topology)
+                with open('is_there_water.pdb', 'w') as fo:
+                    app.PDBFile.writeFile(initial_topology, initial_positions, fo)
 
             initial_topology._state_key = proposal_engine._fake_states[0]
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2013,12 +2013,17 @@ class NullTestSystem(PersesTestSystem):
             Default is None
             If value is not None, will write pdbfile after every ExpandedEnsemble
             iteration
+        scheme, OPTIONAL, string
+            Default is 'ncmc-geometry-ncmc'
+            Scheme to be used by ExpandedEnsembleSampler
+            Must be in ['geometry-ncmc-geometry','ncmc-geometry-ncmc','geometry-ncmc']
+            Default will run NCMC on old and new system separately
 
     Only one environment ('vacuum') is currently implemented; however all 
     samplers are saved in dictionaries for consistency with other testsystems
 
     """
-    def __init__(self, mol_name, storage_filename="null.nc", exen_pdb_filename=None):
+    def __init__(self, mol_name, storage_filename="null.nc", exen_pdb_filename=None, scheme='ncmc-geometry-ncmc'):
         if mol_name not in ['naphthalene', 'butane', 'propane']:
             raise(IOError("NullTestSystem molecule name can only be naphthalene, butane or propane, given {0}".format(mol_name)))
 
@@ -2074,7 +2079,7 @@ class NullTestSystem(PersesTestSystem):
             mcmc_sampler.timestep = 1.0*unit.femtosecond
             mcmc_sampler.verbose = True
 
-            exen_sampler = ExpandedEnsembleSampler(mcmc_sampler, initial_topology, chemical_state_key, proposal_engine, self.geometry_engine, scheme='ncmc-geometry-ncmc', options={'nsteps':0}, storage=self.storage)
+            exen_sampler = ExpandedEnsembleSampler(mcmc_sampler, initial_topology, chemical_state_key, proposal_engine, self.geometry_engine, scheme=scheme, options={'nsteps':0}, storage=self.storage)
             exen_sampler.verbose = True
             if exen_pdb_filename is not None:
                 exen_sampler.pdbfile = open(exen_pdb_filename,'w')
@@ -2186,16 +2191,21 @@ class PropaneTestSystem(NullTestSystem):
             Default is None
             If value is not None, will write pdbfile after every ExpandedEnsemble
             iteration
+        scheme, OPTIONAL, string
+            Default is 'geometry-ncmc-geometry'
+            Scheme to be used by ExpandedEnsembleSampler
+            Must be in ['geometry-ncmc-geometry','ncmc-geometry-ncmc','geometry-ncmc']
+            Default will use a hybrid NCMC method
 
     Only one environment ('vacuum') is currently implemented; however all 
     samplers are saved in dictionaries for consistency with other testsystems
     """
 
-    def __init__(self, storage_filename="propane.nc", exen_pdb_filename=None):
+    def __init__(self, storage_filename="propane.nc", exen_pdb_filename=None, scheme='geometry-ncmc-geometry'):
         """
-        __init__(self, storage_filename="propane.nc", exen_pdb_filename=None):
+        __init__(self, storage_filename="propane.nc", exen_pdb_filename=None, scheme='geometry-ncmc-geometry'):
         """
-        super(PropaneTestSystem, self).__init__('propane', storage_filename=storage_filename, exen_pdb_filename=exen_pdb_filename)
+        super(PropaneTestSystem, self).__init__('propane', storage_filename=storage_filename, exen_pdb_filename=exen_pdb_filename, scheme=scheme)
 
 
 def run_null_system(testsystem):

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2036,7 +2036,7 @@ class NullTestSystem(PersesTestSystem):
             smiles = 'CCCC'
             from perses.rjmc.topology_proposal import ButaneProposalEngine as NullProposal
         elif mol_name == 'propane':
-            smiles = 'CC'
+            smiles = 'CCC'
             from perses.rjmc.topology_proposal import PropaneProposalEngine as NullProposal
 
         environments = ['vacuum']

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2174,7 +2174,7 @@ class ButaneTestSystem(NullTestSystem):
             Must be in ['geometry-ncmc-geometry','ncmc-geometry-ncmc','geometry-ncmc']
             Default will use a hybrid NCMC method
 
-    Only one environment ('vacuum') is currently implemented; however all 
+    Only one environment ('vacuum') is currently implemented; however all
     samplers are saved in dictionaries for consistency with other testsystems
     """
 
@@ -2640,15 +2640,14 @@ def run_fused_rings():
         analysis.plot_ncmc_work('ncmc-%d.pdf' % ncmc_steps)
 
 if __name__ == '__main__':
-    testsystem = PropaneTestSystem(scheme='ncmc-geometry-ncmc')
-    run_null_system(testsystem)
-#    run_alanine_system(sterics=True)
+    #testsystem = PropaneTestSystem(scheme='ncmc-geometry-ncmc')
+    #run_null_system(testsystem)
+    #run_alanine_system(sterics=True)
     #run_alanine_system(sterics=False)
     #run_fused_rings()
-    run_valence_system()
+    #run_valence_system()
     #run_t4_inhibitors()
-    #run_imidazole()
-    #run_constph_imidazole()
+    run_imidazole()
     #run_constph_abl()
     #run_abl_affinity_write_pdb_ncmc_switching()
     #run_kinase_inhibitors()

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2067,8 +2067,6 @@ class NullTestSystem(PersesTestSystem):
                 initial_topology = modeller.getTopology()
                 initial_positions = modeller.getPositions()
                 initial_system = system_generators[key].build_system(initial_topology)
-                with open('is_there_water.pdb', 'w') as fo:
-                    app.PDBFile.writeFile(initial_topology, initial_positions, fo)
 
             initial_topology._state_key = proposal_engine._fake_states[0]
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2029,7 +2029,7 @@ class NullTestSystem(PersesTestSystem):
         if 'nsteps' not in options.keys():
             options['nsteps'] = 0
 
-        environments = ['vacuum']
+        environments = ['vacuum', 'explicit']
 
 #        self.geometry_engine.write_proposal_pdb = True
 
@@ -2047,15 +2047,27 @@ class NullTestSystem(PersesTestSystem):
         from perses.samplers.samplers import SamplerState, MCMCSampler, ExpandedEnsembleSampler
 
         for key in environments:
+            gaff_xml_filename = get_data_filename('data/gaff.xml')
             if key == "vacuum":
                 forcefield_kwargs = {'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : None}
-                gaff_xml_filename = get_data_filename('data/gaff.xml')
-            system_generator = SystemGenerator([gaff_xml_filename], forcefield_kwargs=forcefield_kwargs)
+                ff_list = [gaff_xml_filename]
+            if key == "exlicit":
+                ff_list = [gaff_xml_filename, 'tip3p.xml']
+                forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints }
+            system_generator = SystemGenerator(ff_list, forcefield_kwargs=forcefield_kwargs)
             system_generators[key] = system_generator
 
             proposal_engine = self.NullProposal(system_generator, residue_name=self.mol_name)
             initial_molecule = createOEMolFromIUPAC(iupac_name=self.mol_name)
             initial_system, initial_positions, initial_topology = oemol_to_omm_ff(initial_molecule, self.mol_name)
+
+            if key == "exlicit":
+                modeller = app.Modeller(initial_topology, initial_positions)
+                modeller.addSolvent(forcefield, model='tip3p', padding=9.0*unit.angstrom)
+                initial_topology = modeller.getTopology()
+                initial_positions = modeller.getPositions()
+                initial_system = system_generators[key].build_system(initial_topology)
+
             initial_topology._state_key = proposal_engine._fake_states[0]
 
             temperature = 300*unit.kelvin


### PR DESCRIPTION
This fixes a major bug in the proposal of new small molecule `Topology` objects in which newly-constructed `Topology` objects contained `chain` objects that incorrectly pointed to the old `Topology` object because deep copy was used instead of purely constructive `Topology` generation via the public API.

I'm not actually sure how this could have worked before. I just ran into ParmEd stack traces when I tried to run the imidazole test in explicit solvent. Perhaps it only worked in vacuum, where there was only one residue?