### PR TITLE
[WIP] Numerous bugfixes

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -51,10 +51,6 @@ class HybridTopologyFactory(object):
         self.system1 = copy.deepcopy(system1)
         self.system2 = copy.deepcopy(system2)
 
-        # Remove barostat
-        self._remove_barostat(self.system1)
-        self._remove_barostat(self.system2)
-
         if softening < 0.0 or softening > 1.0:
             softening = 0.1
         self.softening = softening
@@ -96,14 +92,6 @@ class HybridTopologyFactory(object):
         self.unique_atoms2 = [atom for atom in range(topology2._numAtoms) if atom not in self.atom_mapping_1to2.values()]
 
         self.verbose = False
-
-    def _remove_barostat(self, system):
-        force_indices_to_remove = list()
-        for (force_index, force) in enumerate(system.getForces()):
-            if force.__class__.__name__ in ['MonteCarloBarostat', 'AnisotropicMonteCarloBarostat']:
-                force_indices_to_remove.append(force_index)
-        for force_index in force_indices_to_remove[::-1]:
-            system.removeForce(force_index)
 
     def _handle_constraints(self, system, system2, sys2_indices_in_system):
         if self.verbose: print("Adding constraints from system2...")

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1355,11 +1355,41 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         resname = self._residue_name
         mol_residues = [res for res in topology.residues() if res.name==resname]
         if len(mol_residues)!=1:
-            raise ValueError("There can only be one residue with a specific name in the topology.")
+            raise ValueError("There must be exactly one residue with a specific name in the topology. Found %d residues with name '%s'" % (len(mol_residues), resname))
         mol_residue = mol_residues[0]
         atoms = list(mol_residue.atoms())
         mol_start_idx = atoms[0].index
         return mol_start_idx, len(list(atoms))
+
+    def _append_topology(self, destination_topology, source_topology, exclude_residue_name=None):
+        """
+        Add the source OpenMM Topology to the destination Topology.
+
+        Parameters
+        ----------
+        destination_topology : simtk.openmm.app.Topology
+            The Topology to which the contents of `source_topology` are to be added.
+        source_topology : simtk.openmm.app.Topology
+            The Topology to be added.
+        exclude_residue_name : str, optional, default=None
+            If specified, any residues matching this name are excluded.
+
+        """
+        newAtoms = {}
+        for chain in source_topology.chains():
+            newChain = destination_topology.addChain(chain.id)
+            for residue in chain.residues():
+                if (residue.name == exclude_residue_name):
+                    continue
+                newResidue = destination_topology.addResidue(residue.name, newChain, residue.id)
+                for atom in residue.atoms():
+                    newAtom = destination_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
+                    newAtoms[atom] = newAtom
+        for bond in source_topology.bonds():
+            if (bond[0].residue.name==exclude_residue_name) or (bond[1].residue.name==exclude_residue_name):
+                continue
+            # TODO: Preserve bond order info using extended OpenMM API
+            destination_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
 
     def _build_new_topology(self, current_receptor_topology, oemol_proposed):
         """
@@ -1378,18 +1408,11 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         mol_start_index : int
             The first index of the small molecule
         """
+        oemol_proposed.SetTitle(self._residue_name)
         mol_topology = forcefield_generators.generateTopologyFromOEMol(oemol_proposed)
-        new_topology = copy.deepcopy(current_receptor_topology)
-        newAtoms = {}
-        for chain in mol_topology.chains():
-            newChain = new_topology.addChain(chain.id)
-            for residue in chain.residues():
-                newResidue = new_topology.addResidue(self._residue_name, newChain, residue.id)
-                for atom in residue.atoms():
-                    newAtom = new_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
-                    newAtoms[atom] = newAtom
-        for bond in mol_topology.bonds():
-            new_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
+        new_topology = app.Topology()
+        self._append_topology(new_topology, current_receptor_topology)
+        self._append_topology(new_topology, mol_topology)
         # Copy periodic box vectors.
         if current_receptor_topology._periodicBoxVectors != None:
             new_topology._periodicBoxVectors = copy.deepcopy(current_receptor_topology._periodicBoxVectors)
@@ -1413,19 +1436,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             Topology without small molecule
         """
         receptor_topology = app.Topology()
-        newAtoms = {}
-        for chain in topology.chains():
-            newChain = receptor_topology.addChain(chain.id)
-            for residue in chain.residues():
-                if residue.name != self._residue_name:
-                    newResidue = receptor_topology.addResidue(residue.name, newChain, residue.id)
-                    for atom in residue.atoms():
-                        newAtom = receptor_topology.addAtom(atom.name, atom.element, newResidue, atom.id)
-                        newAtoms[atom] = newAtom
-        for bond in topology.bonds():
-            if bond[0].residue.name==self._residue_name or bond[1].residue.name==self._residue_name:
-                continue
-            receptor_topology.addBond(newAtoms[bond[0]], newAtoms[bond[1]])
+        self._append_topology(receptor_topology, topology, exclude_residue_name=self._residue_name)
+        # Copy periodic box vectors.
         if topology._periodicBoxVectors != None:
             receptor_topology._periodicBoxVectors = copy.deepcopy(topology._periodicBoxVectors)
         return receptor_topology
@@ -1956,4 +1968,3 @@ class PropaneProposalEngine(NullProposalEngine):
             if atom.residue != ccbond[0].residue:
                 atom_map[atom.index] = atom.index
         return atom_map
-

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1059,14 +1059,26 @@ class SystemGenerator(object):
         Metadata associated with the SystemGenerator.
     use_antechamber : bool, optional, default=True
         If True, will add the GAFF residue template generator.
+    barostat : MonteCarloBarostat, optional, default=None
+        If provided, a matching barostat will be added to the generated system.
+
     """
 
-    def __init__(self, forcefields_to_use, forcefield_kwargs=None, metadata=None, use_antechamber=True):
+    def __init__(self, forcefields_to_use, forcefield_kwargs=None, metadata=None, use_antechamber=True, barostat=None):
         self._forcefield_xmls = forcefields_to_use
         self._forcefield_kwargs = forcefield_kwargs if forcefield_kwargs is not None else {}
         self._forcefield = app.ForceField(*self._forcefield_xmls)
         if use_antechamber:
             self._forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
+        self._barostat = None
+        if barostat is not None:
+            pressure = barostat.getDefaultPressure()
+            if hasattr(barostat, 'getDefaultTemperature'):
+                temperature = barostat.getDefaultTemperature()
+            else:
+                temperature = barostat.getTemperature()
+            frequency = barostat.getFrequency()
+            self._barostat = (pressure, temperature, frequency)
 
     def getForceField(self):
         """
@@ -1109,6 +1121,14 @@ class SystemGenerator(object):
             msg += "\n"
             msg += "PDB file written as 'BuildSystem-failure.pdb'"
             raise Exception(msg)
+
+        # Add barostat if requested.
+        if self._barostat is not None:
+            MAXINT = np.iinfo(np.int32).max
+            barostat = openmm.MonteCarloBarostat(*self._barostat)
+            seed = np.random.randint(MAXINT)
+            barostat.setRandomNumberSeed(seed)
+            system.addForce(barostat)
 
         # DEBUG: See if any torsions have duplicate atoms.
         #from perses.tests.utils import check_system
@@ -1442,27 +1462,6 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             receptor_topology._periodicBoxVectors = copy.deepcopy(topology._periodicBoxVectors)
         return receptor_topology
 
-
-    def _smiles_to_oemol(self, smiles_string):
-        """
-        Convert the SMILES string into an OEMol
-
-        Returns
-        -------
-        oemols : np.array of type object
-            array of oemols
-        """
-        mol = oechem.OEMol()
-        oechem.OESmilesToMol(mol, smiles_string)
-        mol.SetTitle("MOL")
-        oechem.OEAddExplicitHydrogens(mol)
-        oechem.OETriposAtomNames(mol)
-        oechem.OETriposBondTypeNames(mol)
-        omega = oeomega.OEOmega()
-        omega.SetMaxConfs(1)
-        omega(mol)
-        return mol
-
     @staticmethod
     def _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember | oechem.OEExprOpts_HvyDegree, bond_expr=oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember):
         """
@@ -1533,7 +1532,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         forward_probability = molecule_probabilities[proposed_smiles_idx]
         proposed_smiles = self._smiles_list[proposed_smiles_idx]
         logp = np.log(reverse_probability) - np.log(forward_probability)
-        proposed_mol = self._smiles_to_oemol(proposed_smiles)
+        from perses.tests.utils import smiles_to_oemol
+        proposed_mol = smiles_to_oemol(proposed_smiles)
         return proposed_smiles, proposed_mol, logp
 
     def _calculate_probability_matrix(self, molecule_smiles_list):

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1068,6 +1068,8 @@ class SystemGenerator(object):
         self._forcefield_xmls = forcefields_to_use
         self._forcefield_kwargs = forcefield_kwargs if forcefield_kwargs is not None else {}
         self._forcefield = app.ForceField(*self._forcefield_xmls)
+        if 'removeCMMotion' not in self._forcefield_kwargs:
+            self._forcefield_kwargs['removeCMMotion'] = False
         if use_antechamber:
             self._forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
         self._barostat = None

--- a/perses/samplers/thermodynamics.py
+++ b/perses/samplers/thermodynamics.py
@@ -139,8 +139,15 @@ class ThermodynamicState(object):
                     break
             if barostat:
                 # Set temperature.
-                # TODO: Set pressure too, once that option is available.
-                barostat.setTemperature(temperature)
+                if hasattr(barostat, 'setDefaultTemperature'):
+                    barostat.setDefaultTemperature(temperature)
+                elif hasattr(barostat, 'setTemperature'):
+                    barostat.setTemperature(temperature)
+                else:
+                    raise Exception("barostat does not have 'setTemperature' or 'setDefaultTemperature' interfaces!")
+                # Set pressure
+                barostat.setDefaultPressure(pressure)
+
             else:
                 # Create barostat.
                 barostat = mm.MonteCarloBarostat(pressure, temperature)

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2707,6 +2707,7 @@ def run_fused_rings():
         analysis.plot_ncmc_work('ncmc-%d.pdf' % ncmc_steps)
 
 if __name__ == '__main__':
+    run_imidazole()
     #testsystem = PropaneTestSystem(scheme='ncmc-geometry-ncmc')
     #run_null_system(testsystem)
     #run_alanine_system(sterics=True)
@@ -2717,7 +2718,6 @@ if __name__ == '__main__':
     #run_fused_rings()
     #run_valence_system()
     #run_t4_inhibitors()
-    run_imidazole()
     #run_imidazole()
     #run_constph_abl()
     #run_abl_affinity_write_pdb_ncmc_switching()

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2670,7 +2670,7 @@ def run_imidazole():
 
     # Run ligand in solvent constant-pH sampler calibration
     testsystem.sams_samplers['explicit-imidazole'].verbose=True
-    testsystem.sams_samplers['explicit-imidazole'].run(niterations=10)
+    testsystem.sams_samplers['explicit-imidazole'].run(niterations=50)
     
     # Analyze data.
     from perses.analysis import Analysis

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -145,15 +145,9 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
     def __init__(self, constraints=app.HBonds, **kwargs):
         super(AlanineDipeptideTestSystem, self).__init__(**kwargs)
         environments = ['explicit', 'implicit', 'vacuum']
-
-        # Define thermodynamic state of interest.
-        from perses.samplers.thermodynamics import ThermodynamicState
-        thermodynamic_states = dict()
         temperature = 300*unit.kelvin
         pressure = 1.0*unit.atmospheres
-        thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
-        thermodynamic_states['implicit'] = ThermodynamicState(system=systems['implicit'], temperature=temperature)
-        thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
+
 
         # Use sterics in proposals
         self.geometry_engine.use_sterics = True
@@ -211,6 +205,13 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
         systems = dict()
         for environment in environments:
             systems[environment] = system_generators[environment].build_system(topologies[environment])
+
+        # Define thermodynamic state of interest.
+        from perses.samplers.thermodynamics import ThermodynamicState
+        thermodynamic_states = dict()
+        thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
+        thermodynamic_states['implicit'] = ThermodynamicState(system=systems['implicit'], temperature=temperature)
+        thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
 
         # Create SAMS samplers
         from perses.samplers.samplers import SamplerState, MCMCSampler, ExpandedEnsembleSampler, SAMSSampler
@@ -442,16 +443,8 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
         super(T4LysozymeMutationTestSystem, self).__init__(**kwargs)
 #        environments = ['explicit-complex', 'explicit-receptor', 'implicit-complex', 'implicit-receptor', 'vacuum-complex', 'vacuum-receptor']
         environments = ['explicit-complex', 'explicit-receptor', 'vacuum-complex', 'vacuum-receptor']
-
-        # Define thermodynamic state of interest.
-        from perses.samplers.thermodynamics import ThermodynamicState
-        thermodynamic_states = dict()
         temperature = 300*unit.kelvin
         pressure = 1.0*unit.atmospheres
-        for component in ['receptor', 'complex']:
-            thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
-            #thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
-            thermodynamic_states['vacuum' + '-' + component]   = ThermodynamicState(system=systems['vacuum' + '-' + component], temperature=temperature)
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
@@ -574,6 +567,14 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
             print(environment)
             systems[environment] = system_generators[environment].build_system(topologies[environment])
 
+        # Define thermodynamic state of interest.
+        from perses.samplers.thermodynamics import ThermodynamicState
+        thermodynamic_states = dict()
+        for component in ['receptor', 'complex']:
+            thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
+            #thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
+            thermodynamic_states['vacuum' + '-' + component]   = ThermodynamicState(system=systems['vacuum' + '-' + component], temperature=temperature)
+
         # Create SAMS samplers
         from perses.samplers.samplers import SamplerState, MCMCSampler, ExpandedEnsembleSampler, SAMSSampler
         mcmc_samplers = dict()
@@ -657,16 +658,8 @@ class MybTestSystem(PersesTestSystem):
     def __init__(self, **kwargs):
         super(MybTestSystem, self).__init__(**kwargs)
         environments = ['explicit-complex', 'explicit-peptide', 'implicit-complex', 'implicit-peptide', 'vacuum-complex', 'vacuum-peptide']
-
-        # Define thermodynamic state of interest.
-        from perses.samplers.thermodynamics import ThermodynamicState
-        thermodynamic_states = dict()
         temperature = 300*unit.kelvin
         pressure = 1.0*unit.atmospheres
-        for component in ['peptide', 'complex']:
-            thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
-            thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
-            thermodynamic_states['vacuum' + '-' + component]   = ThermodynamicState(system=systems['vacuum' + '-' + component], temperature=temperature)
 
         # Use sterics in proposals
         self.geometry_engine.use_sterics = True
@@ -744,6 +737,14 @@ class MybTestSystem(PersesTestSystem):
         systems = dict()
         for environment in environments:
             systems[environment] = system_generators[environment].build_system(topologies[environment])
+
+        # Define thermodynamic state of interest.
+        from perses.samplers.thermodynamics import ThermodynamicState
+        thermodynamic_states = dict()
+        for component in ['peptide', 'complex']:
+            thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
+            thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
+            thermodynamic_states['vacuum' + '-' + component]   = ThermodynamicState(system=systems['vacuum' + '-' + component], temperature=temperature)
 
         # Create SAMS samplers
         from perses.samplers.samplers import SamplerState, MCMCSampler, ExpandedEnsembleSampler, SAMSSampler
@@ -1685,14 +1686,8 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         molecules = sanitizeSMILES(self.molecules)
         molecules = canonicalize_SMILES(molecules)
         environments = ['explicit', 'vacuum']
-
-        # Define thermodynamic state of interest.
-        from perses.samplers.thermodynamics import ThermodynamicState
-        thermodynamic_states = dict()
         temperature = 300*unit.kelvin
         pressure = 1.0*unit.atmospheres
-        thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
-        thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
@@ -1739,6 +1734,12 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         systems = dict()
         for environment in environments:
             systems[environment] = system_generators[environment].build_system(topologies[environment])
+
+        # Define thermodynamic state of interest.
+        from perses.samplers.thermodynamics import ThermodynamicState
+        thermodynamic_states = dict()
+        thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
+        thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
 
         # Create SAMS samplers
         from perses.samplers.samplers import SamplerState, MCMCSampler, ExpandedEnsembleSampler, SAMSSampler
@@ -1888,6 +1889,8 @@ class ValenceSmallMoleculeLibraryTestSystem(PersesTestSystem):
         initial_molecules = ['CCCCC','CC(C)CC', 'CCC(C)C', 'CCCCC', 'C(CC)CCC']
         molecules = self._canonicalize_smiles(initial_molecules)
         environments = ['vacuum']
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmospheres
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
@@ -1929,8 +1932,6 @@ class ValenceSmallMoleculeLibraryTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
 
         # Create SAMS samplers
@@ -2657,7 +2658,7 @@ def run_imidazole():
         testsystem.exen_samplers[environment].ncmc_engine.softcore_alpha = 0.5
         testsystem.exen_samplers[environment].ncmc_engine.softcore_beta = 0.5
         testsystem.exen_samplers[environment].ncmc_engine.functions = functions_linear
-        
+
         testsystem.exen_samplers[environment].accept_everything = True # accept everything that doesn't lead to NaN for testing
         #testsystem.exen_samplers[environment].ncmc_engine.write_ncmc_interval = 1
         testsystem.mcmc_samplers[environment].nsteps = 1000
@@ -2671,7 +2672,7 @@ def run_imidazole():
     # Run ligand in solvent constant-pH sampler calibration
     testsystem.sams_samplers['explicit-imidazole'].verbose=True
     testsystem.sams_samplers['explicit-imidazole'].run(niterations=50)
-    
+
     # Analyze data.
     from perses.analysis import Analysis
     analysis = Analysis(storage_filename=storage_filename)

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -2174,7 +2174,7 @@ class ButaneTestSystem(NullTestSystem):
             Must be in ['geometry-ncmc-geometry','ncmc-geometry-ncmc','geometry-ncmc']
             Default will use a hybrid NCMC method
 
-    Only one environment ('vacuum') is currently implemented; however all 
+    Only one environment ('vacuum') is currently implemented; however all
     samplers are saved in dictionaries for consistency with other testsystems
     """
 
@@ -2640,15 +2640,14 @@ def run_fused_rings():
         analysis.plot_ncmc_work('ncmc-%d.pdf' % ncmc_steps)
 
 if __name__ == '__main__':
-    testsystem = PropaneTestSystem(scheme='ncmc-geometry-ncmc')
-    run_null_system(testsystem)
-#    run_alanine_system(sterics=True)
+    #testsystem = PropaneTestSystem(scheme='ncmc-geometry-ncmc')
+    #run_null_system(testsystem)
+    #run_alanine_system(sterics=True)
     #run_alanine_system(sterics=False)
     #run_fused_rings()
-    run_valence_system()
+    #run_valence_system()
     #run_t4_inhibitors()
-    #run_imidazole()
-    #run_constph_imidazole()
+    run_imidazole()
     #run_constph_abl()
     #run_abl_affinity_write_pdb_ncmc_switching()
     #run_kinase_inhibitors()

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -375,6 +375,28 @@ def enumerate_undefined_stereocenters(molecule, verbose=False):
 
     return molecules
 
+def smiles_to_oemol(smiles_string, title="MOL"):
+    """
+    Convert the SMILES string into an OEMol
+    
+    Returns
+    -------
+    oemols : np.array of type object
+    array of oemols
+
+    """
+    from openeye import oechem, oeomega
+    mol = oechem.OEMol()
+    oechem.OESmilesToMol(mol, smiles_string)
+    mol.SetTitle(title)
+    oechem.OEAddExplicitHydrogens(mol)
+    oechem.OETriposAtomNames(mol)
+    oechem.OETriposBondTypeNames(mol)
+    omega = oeomega.OEOmega()
+    omega.SetMaxConfs(1)
+    omega(mol)
+    return mol
+
 def sanitizeSMILES(smiles_list, mode='drop', verbose=False):
     """
     Sanitize set of SMILES strings by ensuring all are canonical isomeric SMILES.
@@ -453,6 +475,37 @@ def sanitizeSMILES(smiles_list, mode='drop', verbose=False):
 
     sanitized_smiles_list = list(sanitized_smiles_set)
     return sanitized_smiles_list
+
+def canonicalize_SMILES(smiles_list):
+    """Ensure all SMILES strings end up in canonical form.
+
+    Stereochemistry must already have been expanded.
+    SMILES strings are converted to a OpenEye Topology and back again.
+
+    Parameters
+    ----------
+    smiles_list : list of str
+        List of SMILES strings
+
+    Returns
+    -------
+    canonical_smiles_list : list of str
+        List of SMILES strings, after canonicalization.
+
+    """
+    
+    # Round-trip each molecule to a Topology to end up in canonical form
+    from openmoltools.forcefield_generators import generateOEMolFromTopologyResidue, generateTopologyFromOEMol
+    from openeye import oechem
+    canonical_smiles_list = list()
+    for smiles in smiles_list:
+        molecule = smiles_to_oemol(smiles)
+        topology = generateTopologyFromOEMol(molecule)
+        residues = [ residue for residue in topology.residues() ]
+        new_molecule = generateOEMolFromTopologyResidue(residues[0])
+        new_smiles = oechem.OECreateIsoSmiString(new_molecule)
+        canonical_smiles_list.append(new_smiles)
+    return canonical_smiles_list
 
 def test_sanitizeSMILES():
     """


### PR DESCRIPTION
This merges in some changes from my `protonation` branch:
* SMILES strings are now canonicalized by converting them to OpenMM `Topology` objects and back to SMILES again. Without this, the protonation state of imidzole would end up with a different SMILES strings that wasn't in the original set. This is fixed for all testsystems.
* The proposal engines would silently remove any barostats because `SystemGenerator`had no facility to add these to newly generated systems. I've added a way to specify that `SystemGenerator` should add a barostat, and added this to all testsystems.
* `removeCMMotion` is now disabled by the system generator if not explicitly specified
* `HybridTopologyFactory` would raise a puzzling exception when the number of forces differed between `system1` and `system2` (because of the missing barostat). I've added a check during the constructor that prints useful debug information if this happens.
* Barostats are disabled during NCMC switching.
* `perses.analysis.plot_ncmc_work` now handles multiple environments. We can generalize this to still work even if environments are not present, but I haven't done this yet.

I haven't run extensive tests on these changes yet---I've been focusing on the imidazole protonation state test.

Despite these changes, I haven't been able to get the `geometry-ncmc-geometry` scheme to work with the imidazole protonation state test---the coordinates become `nan`. Still debugging why.
