### PR TITLE
NCMC refactor -- cherry picking from hybrid-tests

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -707,9 +707,6 @@ class NCMCHybridEngine(NCMCEngine):
         logP_alchemical_correction = initial_logP_correction + final_logP_correction
         return logP_alchemical_correction
 
-    def _compute_switch_logP(self, unmodified_old_system, unmodified_new_system, initial_positions, final_positions):
-        return self.compute_logP(unmodified_new_system, final_positions) - self.compute_logP(unmodified_old_system, initial_positions)
-
     def make_alchemical_system(self, topology_proposal, old_positions,
                                new_positions):
         """

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -622,52 +622,9 @@ class NCMCHybridEngine(NCMCEngine):
                                                platform=platform, write_ncmc_interval=write_ncmc_interval,
                                                integrator_type=integrator_type)
 
-    def compute_logP(self, system, positions, parameter=None):
-        """
-        Compute potential energy of the specified system object at the specified positions.
-
-        Constraints are applied before the energy is computed.
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-            The System object for which the potential energy is to be computed.
-        positions : simtk.unit.Quantity with dimension [natoms, 3] with units of distance.
-            Positions of the atoms for which energy is to be computed.
-
-        Returns
-        -------
-        potential : simtk.unit.Quantity with units of energy
-            The computed potential energy
-            
-        """
-        # Create dummy integrator.
-        integrator = openmm.VerletIntegrator(self.timestep)
-        # Set the constraint tolerance if specified.
-        if self.constraint_tolerance is not None:
-            integrator.setConstraintTolerance(self.constraint_tolerance)
-        # Create a context on the specified platform.
-        if self.platform is not None:
-            context = openmm.Context(system, integrator, self.platform)
-        else:
-            context = openmm.Context(system, integrator)
-        context.setPositions(positions)
-        context.applyConstraints(integrator.getConstraintTolerance())
-        if parameter is not None:
-            available_parameters = self._getAvailableParameters(system)
-            for parameter_name in available_parameters:
-                context.setParameter(parameter_name, parameter)
-        # Compute potential energy.
-        potential = context.getState(getEnergy=True).getPotentialEnergy()
-        # Clean up context and integrator.
-        del context, integrator
-        # Return potential energy.
-        return -self.beta * potential
-
-    def _computeAlchemicalCorrection(self, unmodified_old_system,
-                                     unmodified_new_system, alchemical_system,
-                                     initial_positions, alchemical_positions,
-                                     final_hybrid_positions, final_positions,
+    def _computeAlchemicalCorrection(self, integrator, context,
+                                     unmodified_old_system, unmodified_new_system,
+                                     initial_positions, final_positions,
                                      direction='insert'):
         """
         Compute log probability for correction from transforming real system
@@ -700,10 +657,10 @@ class NCMCHybridEngine(NCMCEngine):
         logP_alchemical_correction : float
             The log acceptance probability of the switch
         """
+        from perses.tests.utils import compute_potential
+        initial_logP_correction = (self.beta * integrator.getGlobalVariableByName("Einitial") * unit.kilojoules_per_mole) - self.beta * compute_potential(unmodified_old_system, initial_positions, platform=self.platform)
+        final_logP_correction = self.beta * self.compute_potential(unmodified_new_system, final_positions, platform=self.platform) - (self.beta * context.getState(getEnergy=True).getPotentialEnergy())
 
-        # Compute correction from transforming real system to/from alchemical system
-        initial_logP_correction = self.compute_logP(alchemical_system, alchemical_positions, parameter=0) - self.compute_logP(unmodified_old_system, initial_positions)
-        final_logP_correction = self.compute_logP(unmodified_new_system, final_positions) - self.compute_logP(alchemical_system, final_hybrid_positions, parameter=1)
         logP_alchemical_correction = initial_logP_correction + final_logP_correction
         return logP_alchemical_correction
 

--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -557,7 +557,7 @@ class NCMCEngine(object):
         logP_ncmc = self._clean_up_integration(logP_NCMC, logP_alchemical_correction, alchemical_system, context, integrator)
 
         # Return
-        return [final_positions, logP, switch_logp]
+        return [final_positions, logP_ncmc, switch_logp]
 
 class NCMCHybridEngine(NCMCEngine):
     """

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -1,0 +1,228 @@
+from simtk import openmm, unit
+from simtk.openmm import app
+import os, os.path
+import sys, math
+from unittest import skipIf
+import numpy as np
+from functools import partial
+from pkg_resources import resource_filename
+from openeye import oechem
+if sys.version_info >= (3, 0):
+    from io import StringIO
+    from subprocess import getstatusoutput
+else:
+    from cStringIO import StringIO
+    from commands import getstatusoutput
+import matplotlib as mpl
+mpl.use('Agg')
+import seaborn as sns
+
+import matplotlib.pyplot as plt
+
+################################################################################
+# NUMBER OF ATTEMPTS
+################################################################################
+niterations = 50
+################################################################################
+# CONSTANTS
+################################################################################
+
+kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
+temperature = 300.0 * unit.kelvin
+kT = kB * temperature
+beta = 1.0/kT
+
+def simulate(system, positions, nsteps=500, timestep=1.0*unit.femtoseconds, temperature=temperature, collision_rate=5.0/unit.picoseconds, platform=None):
+    integrator = openmm.LangevinIntegrator(temperature, collision_rate, timestep)
+    if platform == None:
+        context = openmm.Context(system, integrator)
+    else:
+        context = openmm.Context(system, integrator, platform)
+    context.setPositions(positions)
+    context.setVelocitiesToTemperature(temperature)
+    integrator.step(nsteps)
+    positions = context.getState(getPositions=True).getPositions(asNumpy=True)
+    velocities = context.getState(getVelocities=True).getVelocities(asNumpy=True)
+    return [positions, velocities]
+
+def check_hybrid_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
+    """
+    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
+
+    Parameters
+    ----------
+    NullProposal : class
+        subclass of testsystems.NullTestSystem
+    ncmc_nsteps : int, optional, default=50
+        Number of NCMC switching steps, or 0 for instantaneous switching.
+    NSIGMA_MAX : float, optional, default=6.0
+        Number of standard errors away from analytical solution tolerated before Exception is thrown
+    geometry : bool, optional, default=None
+        If True, will also use geometry engine in the middle of the null transformation.
+    """
+    functions = {
+        'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
+        'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
+        'lambda_bonds' : '1.0',  
+        'lambda_angles' : '0.5*lambda+0.5', 
+        'lambda_torsions' : '0.5*lambda+0.5'
+    }
+
+    testsystem = NullProposal(storage_filename=None, scheme='geometry-ncmc-geometry',options={'functions': functions, 'nsteps': ncmc_nsteps})
+    for key in testsystem.environments: # only one key: vacuum
+        # run a single iteration to generate item in number_of_state_visits dict
+        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
+
+        topology = testsystem.topologies[key]
+        system = testsystem.system_generators[key].build_system(topology)
+        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
+        positions = testsystem.positions[key]
+
+    nequil = 5 # number of equilibration iterations
+    logP_n = np.zeros([niterations], np.float64)
+    for iteration in range(nequil):
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+    for iteration in range(niterations):
+        # Equilibrate
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN during equilibration")
+
+        # Hybrid NCMC from old to new
+        [positions, new_old_positions, logP] = ncmc_engine.integrate(topology_proposal, positions, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on Hybrid NCMC switch")
+
+        # Compute total probability
+        logP_n[iteration] = logP
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    work_n = - logP_n
+    from pymbar import EXP
+    [df, ddf] = EXP(work_n)
+    return df, ddf
+
+def check_alchemical_null_elimination(NullProposal, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):
+    """
+    Test alchemical elimination engine on null transformations, where some atoms are deleted and then reinserted in a cycle.
+
+    Parameters
+    ----------
+    topology_proposal : TopologyProposal
+        The topology proposal to test.
+        This must be a null transformation, where topology_proposal.old_system == topology_proposal.new_system
+    ncmc_nsteps : int, optional, default=50
+        Number of NCMC switching steps, or 0 for instantaneous switching.
+    NSIGMA_MAX : float, optional, default=6.0
+        Number of standard errors away from analytical solution tolerated before Exception is thrown
+    geometry : bool, optional, default=None
+        If True, will also use geometry engine in the middle of the null transformation.
+    """
+    functions = {
+        'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
+        'lambda_electrostatics' : '2*(lambda - 0.5) * step(lambda - 0.5)',
+        'lambda_bonds' : '1.0', # don't soften bonds
+        'lambda_angles' : '1.0', # don't soften angles
+        'lambda_torsions' : 'lambda'
+    }
+    testsystem = NullProposal(storage_filename=None, scheme='ncmc-geometry-ncmc',options={'functions': functions, 'nsteps': ncmc_nsteps})
+
+    for key in testsystem.environments: # only one key: vacuum
+        # run a single iteration to generate item in number_of_state_visits dict
+        ncmc_engine = testsystem.exen_samplers[key].ncmc_engine
+
+        topology = testsystem.topologies[key]
+        system = testsystem.system_generators[key].build_system(topology)
+        topology_proposal = testsystem.proposal_engines[key].propose(system, topology)
+        positions = testsystem.positions[key]
+
+    nequil = 5 # number of equilibration iterations
+    logP_insert_n = np.zeros([niterations], np.float64)
+    logP_delete_n = np.zeros([niterations], np.float64)
+    logP_switch_n = np.zeros([niterations], np.float64)
+    for iteration in range(nequil):
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+    for iteration in range(niterations):
+        # Equilibrate
+        [positions, velocities] = simulate(topology_proposal.old_system, positions)
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN during equilibration")
+
+        # Delete atoms
+        [positions, logP_delete, potential_delete] = ncmc_engine.integrate(topology_proposal, positions, direction='delete')
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on NCMC deletion")
+
+        # Insert atoms
+        [positions, logP_insert, potential_insert] = ncmc_engine.integrate(topology_proposal, positions, direction='insert')
+
+        # Check that positions are not NaN
+        if(np.any(np.isnan(positions / unit.angstroms))):
+            raise Exception("Positions became NaN on NCMC insertion")
+
+        # Compute probability of switching geometries.
+        logP_switch = - (potential_insert - potential_delete)
+
+        # Compute total probability
+        logP_delete_n[iteration] = logP_delete
+        logP_insert_n[iteration] = logP_insert
+        logP_switch_n[iteration] = logP_switch
+
+    # Check free energy difference is withing NSIGMA_MAX standard errors of zero.
+    logP_n = logP_delete_n + logP_insert_n + logP_switch_n
+    work_n = - logP_n
+    from pymbar import EXP
+    [df, ddf] = EXP(work_n)
+    return df, ddf
+
+def plot_ncmc_logP(mol_name, ncmc_type, mean, sigma):
+    x = mean.keys()
+    y = [mean[steps] for steps in x]
+    dy = [sigma[steps] for steps in x]
+    plt.fill_between(x, [mean - dev for mean, dev in zip(y, dy)], [mean + dev for mean, dev in zip(y, dy)])
+    plt.plot(x, y, 'k')
+
+    plt.title("Log acceptance probability of {0} NCMC for {1}".format(ncmc_type, mol_name))
+    plt.ylabel('logP NCMC')
+    plt.xlabel('ncmc steps')
+    plt.savefig('{0}_{1}NCMC_logP'.format(mol_name, ncmc_type))
+    print('Saved plot to {0}_{1}NCMC_logP.png'.format(mol_name, ncmc_type))
+    plt.clf()
+
+def benchmark_ncmc_null_protocols():
+    """
+    Check alchemical elimination for alanine dipeptide in vacuum with 0, 1, 2, and 50 switching steps.
+    """
+    from perses.tests.testsystems import NaphthaleneTestSystem, ButaneTestSystem, PropaneTestSystem
+    molecule_names = {
+        'naphthalene' : NaphthaleneTestSystem,
+        'butane' : ButaneTestSystem,
+        'propane' : PropaneTestSystem,
+    }
+    for molecule_name, NullProposal in molecule_names.items():
+        print('Now testing {0} null transformations'.format(molecule_name))
+        mean = dict()
+        sigma = dict()
+        for ncmc_nsteps in [0, 1, 10, 100]:#, 1000, 10000]:
+            print('Running {0} hybrid NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
+            mean[ncmc_nsteps], sigma[ncmc_nsteps] = check_hybrid_null_elimination(NullProposal, ncmc_nsteps=ncmc_nsteps)
+        plot_ncmc_logP(molecule_name, 'hybrid', mean, sigma)
+
+        mean = dict()
+        sigma = dict()
+        for ncmc_nsteps in [0, 1, 10, 100, 1000, 10000]:
+            print('Running {0} delete-insert NCMC steps for {1} iterations'.format(ncmc_nsteps, niterations))
+            mean[ncmc_nsteps], sigma[ncmc_nsteps] = check_alchemical_null_elimination(NullProposal, ncmc_nsteps=ncmc_nsteps)
+        plot_ncmc_logP(molecule_name, 'two-stage', mean, sigma)
+
+if __name__ == "__main__":
+    benchmark_ncmc_null_protocols()
+


### PR DESCRIPTION
Extracting changes in the `hybrid-tests` branch that are independent to testing hybrid builder; here: refactoring `ncmc_switching.py` to inherit between `NCMCEngine` and `NCMCHybridEngine`