### PR TITLE
Various bugfixes

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1463,27 +1463,6 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             receptor_topology._periodicBoxVectors = copy.deepcopy(topology._periodicBoxVectors)
         return receptor_topology
 
-
-    def _smiles_to_oemol(self, smiles_string):
-        """
-        Convert the SMILES string into an OEMol
-
-        Returns
-        -------
-        oemols : np.array of type object
-            array of oemols
-        """
-        mol = oechem.OEMol()
-        oechem.OESmilesToMol(mol, smiles_string)
-        mol.SetTitle("MOL")
-        oechem.OEAddExplicitHydrogens(mol)
-        oechem.OETriposAtomNames(mol)
-        oechem.OETriposBondTypeNames(mol)
-        omega = oeomega.OEOmega()
-        omega.SetMaxConfs(1)
-        omega(mol)
-        return mol
-
     @staticmethod
     def _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember | oechem.OEExprOpts_HvyDegree, bond_expr=oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember):
         """
@@ -1554,7 +1533,8 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         forward_probability = molecule_probabilities[proposed_smiles_idx]
         proposed_smiles = self._smiles_list[proposed_smiles_idx]
         logp = np.log(reverse_probability) - np.log(forward_probability)
-        proposed_mol = self._smiles_to_oemol(proposed_smiles)
+        from perses.tests.utils import smiles_to_oemol
+        proposed_mol = smiles_to_oemol(proposed_smiles)
         return proposed_smiles, proposed_mol, logp
 
     def _calculate_probability_matrix(self, molecule_smiles_list):

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1069,6 +1069,8 @@ class SystemGenerator(object):
         self._forcefield = app.ForceField(*self._forcefield_xmls)
         if use_antechamber:
             self._forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
+        if 'removeCMMotion' not in self._forcefield_kwargs:
+            self._forcefield_kwargs['removeCMMotion'] = False
         self._barostat = None
         if barostat is not None:
             pressure = barostat.getDefaultPressure()

--- a/perses/samplers/thermodynamics.py
+++ b/perses/samplers/thermodynamics.py
@@ -67,7 +67,7 @@ class ThermodynamicState(object):
     >>> state = ThermodynamicState(system=system, temperature=298.0*units.kelvin)
 
     Get the inverse temperature
-    
+
     >>> beta = state.beta
 
     Specify an NPT state at 298 K and 1 atm pressure.
@@ -139,8 +139,14 @@ class ThermodynamicState(object):
                     break
             if barostat:
                 # Set temperature.
-                # TODO: Set pressure too, once that option is available.
-                barostat.setTemperature(temperature)
+                if hasattr(barostat, 'setDefaultTemperature'):
+                    barostat.setDefaultTemperature(temperature)
+                elif hasattr(barostat, 'setTemperature'):
+                    barostat.setTemperature(temperature)
+                else:
+                    raise Exception("barostat does not have 'setTemperature' or 'setDefaultTemperature' interfaces!")
+                # Set pressure
+                barostat.setDefaultPressure(pressure)
             else:
                 # Create barostat.
                 barostat = mm.MonteCarloBarostat(pressure, temperature)

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -455,9 +455,17 @@ def test_run_geometry_engine(index=0):
     geometry_engine.pdb_filename_prefix = 't13geometry-proposal'
     test_pdb_file = open("%s_to_%s_%d.pdb" % (molecule_name_1, molecule_name_2, index), 'w')
 
+    def remove_nonbonded_force(system):
+        """Remove NonbondedForce from specified system."""
+        force_indices_to_remove = list()
+        for [force_index, force] in enumerate(system.getForces()):
+            if force.__class__.__name__ == 'NonbondedForce':
+                force_indices_to_remove.append(force_index)
+        for force_index in force_indices_to_remove[::-1]:
+            system.removeForce(force_index)
+
     valence_system = copy.deepcopy(sys2)
-    valence_system.removeForce(3)
-    valence_system.removeForce(3)
+    remove_nonbonded_force(valence_system)
     integrator = openmm.VerletIntegrator(1*unit.femtoseconds)
     integrator_1 = openmm.VerletIntegrator(1*unit.femtoseconds)
     ctx_1 = openmm.Context(sys1, integrator_1)

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -33,7 +33,7 @@ from functools import partial
 from pkg_resources import resource_filename
 from openeye import oechem, oeshape, oeomega
 from openmmtools import testsystems
-from perses.tests.utils import sanitizeSMILES
+from perses.tests.utils import sanitizeSMILES, canonicalize_SMILES
 from perses.storage import NetCDFStorage, NetCDFStorageView
 from perses.rjmc.geometry import FFAllAngleGeometryEngine
 import tempfile
@@ -1044,6 +1044,7 @@ class AblAffinityTestSystem(PersesTestSystem):
 
         # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
         molecules = sanitizeSMILES(self.molecules)
+        molecules = canonicalize_SMILES(molecules)
 
         # Create a system generator for desired forcefields
         from perses.rjmc.topology_proposal import SystemGenerator
@@ -1677,6 +1678,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         super(SmallMoleculeLibraryTestSystem, self).__init__(**kwargs)
         # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
         molecules = sanitizeSMILES(self.molecules)
+        molecules = canonicalize_SMILES(molecules)
         environments = ['explicit', 'vacuum']
         temperature = 300*unit.kelvin
         pressure = 1.0*unit.atmospheres

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -145,6 +145,8 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
     def __init__(self, constraints=app.HBonds, **kwargs):
         super(AlanineDipeptideTestSystem, self).__init__(**kwargs)
         environments = ['explicit', 'implicit', 'vacuum']
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmospheres
 
         # Use sterics in proposals
         self.geometry_engine.use_sterics = True
@@ -155,10 +157,11 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator(['amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints },
-            use_antechamber=False)
+            use_antechamber=False, barostat=barostat)
         system_generators['implicit'] = SystemGenerator(['amber99sbildn.xml', 'amber99_obc.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : app.OBC2, 'constraints' : constraints },
             use_antechamber=False)
@@ -205,8 +208,6 @@ class AlanineDipeptideTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
         thermodynamic_states['implicit'] = ThermodynamicState(system=systems['implicit'], temperature=temperature)
         thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
@@ -442,15 +443,18 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
         super(T4LysozymeMutationTestSystem, self).__init__(**kwargs)
 #        environments = ['explicit-complex', 'explicit-receptor', 'implicit-complex', 'implicit-receptor', 'vacuum-complex', 'vacuum-receptor']
         environments = ['explicit-complex', 'explicit-receptor', 'vacuum-complex', 'vacuum-receptor']
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmospheres
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
         from pkg_resources import resource_filename
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename,'amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
-            use_antechamber=True)
+            use_antechamber=True, barostat=barostat)
         system_generators['explicit-complex'] = system_generators['explicit']
         system_generators['explicit-receptor'] = system_generators['explicit']
         system_generators['implicit'] = SystemGenerator([gaff_xml_filename,'amber99sbildn.xml', 'amber99_obc.xml'],
@@ -566,8 +570,6 @@ class T4LysozymeMutationTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         for component in ['receptor', 'complex']:
             thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
             #thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
@@ -656,6 +658,8 @@ class MybTestSystem(PersesTestSystem):
     def __init__(self, **kwargs):
         super(MybTestSystem, self).__init__(**kwargs)
         environments = ['explicit-complex', 'explicit-peptide', 'implicit-complex', 'implicit-peptide', 'vacuum-complex', 'vacuum-peptide']
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmospheres
 
         # Use sterics in proposals
         self.geometry_engine.use_sterics = True
@@ -666,6 +670,7 @@ class MybTestSystem(PersesTestSystem):
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator(['amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
@@ -736,8 +741,6 @@ class MybTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         for component in ['peptide', 'complex']:
             thermodynamic_states['explicit' + '-' + component] = ThermodynamicState(system=systems['explicit' + '-' + component], temperature=temperature, pressure=pressure)
             thermodynamic_states['implicit' + '-' + component] = ThermodynamicState(system=systems['implicit' + '-' + component], temperature=temperature)
@@ -846,10 +849,11 @@ class AblImatinibResistanceTestSystem(PersesTestSystem):
         from perses.rjmc.topology_proposal import SystemGenerator
         from pkg_resources import resource_filename
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
-            use_antechamber=True)
+            use_antechamber=True, barostat=barostat)
         system_generators['implicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'amber99_obc.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : app.OBC2, 'constraints' : None },
             use_antechamber=True)
@@ -1045,10 +1049,11 @@ class AblAffinityTestSystem(PersesTestSystem):
         from perses.rjmc.topology_proposal import SystemGenerator
         from pkg_resources import resource_filename
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
-            use_antechamber=True)
+            use_antechamber=True, barostat=barostat)
         system_generators['implicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'amber99_obc.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : app.OBC2, 'constraints' : None },
             use_antechamber=True)
@@ -1105,8 +1110,6 @@ class AblAffinityTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         for component in components:
             for solvent in solvents:
                 environment = solvent + '-' + component
@@ -1258,10 +1261,11 @@ class AblImatinibProtonationStateTestSystem(PersesTestSystem):
         print('Creating system generators...')
         from perses.rjmc.topology_proposal import SystemGenerator
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
-            use_antechamber=True)
+            use_antechamber=True, barostat=barostat)
         system_generators['implicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'amber99_obc.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : app.OBC2, 'constraints' : None },
             use_antechamber=True)
@@ -1322,8 +1326,6 @@ class AblImatinibProtonationStateTestSystem(PersesTestSystem):
         print('Defining thermodynamic states...')
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         for component in components:
             for solvent in solvents:
                 environment = solvent + '-' + component
@@ -1470,10 +1472,11 @@ class ImidazoleProtonationStateTestSystem(PersesTestSystem):
         print('Creating system generators...')
         from perses.rjmc.topology_proposal import SystemGenerator
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators = dict()
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'tip3p.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : None },
-            use_antechamber=True)
+            use_antechamber=True, barostat=barostat)
         system_generators['implicit'] = SystemGenerator([gaff_xml_filename, 'amber99sbildn.xml', 'amber99_obc.xml'],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : app.OBC2, 'constraints' : None },
             use_antechamber=True)
@@ -1543,8 +1546,6 @@ class ImidazoleProtonationStateTestSystem(PersesTestSystem):
         print('Defining thermodynamic states...')
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         for component in components:
             for solvent in solvents:
                 environment = solvent + '-' + component
@@ -1677,14 +1678,17 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # Expand molecules without explicit stereochemistry and make canonical isomeric SMILES.
         molecules = sanitizeSMILES(self.molecules)
         environments = ['explicit', 'vacuum']
+        temperature = 300*unit.kelvin
+        pressure = 1.0*unit.atmospheres
 
         # Create a system generator for our desired forcefields.
         from perses.rjmc.topology_proposal import SystemGenerator
         system_generators = dict()
         from pkg_resources import resource_filename
         gaff_xml_filename = resource_filename('perses', 'data/gaff.xml')
+        barostat = openmm.MonteCarloBarostat(pressure, temperature)
         system_generators['explicit'] = SystemGenerator([gaff_xml_filename, 'tip3p.xml'],
-            forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints })
+            forcefield_kwargs={ 'nonbondedMethod' : app.CutoffPeriodic, 'nonbondedCutoff' : 9.0 * unit.angstrom, 'implicitSolvent' : None, 'constraints' : constraints }, barostat=barostat)
         system_generators['vacuum'] = SystemGenerator([gaff_xml_filename],
             forcefield_kwargs={ 'nonbondedMethod' : app.NoCutoff, 'implicitSolvent' : None, 'constraints' : constraints })
 
@@ -1726,8 +1730,6 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # Define thermodynamic state of interest.
         from perses.samplers.thermodynamics import ThermodynamicState
         thermodynamic_states = dict()
-        temperature = 300*unit.kelvin
-        pressure = 1.0*unit.atmospheres
         thermodynamic_states['explicit'] = ThermodynamicState(system=systems['explicit'], temperature=temperature, pressure=pressure)
         thermodynamic_states['vacuum']   = ThermodynamicState(system=systems['vacuum'], temperature=temperature)
 
@@ -2176,7 +2178,7 @@ class ButaneTestSystem(NullTestSystem):
             Must be in ['geometry-ncmc-geometry','ncmc-geometry-ncmc','geometry-ncmc']
             Default will use a hybrid NCMC method
 
-    Only one environment ('vacuum') is currently implemented; however all 
+    Only one environment ('vacuum') is currently implemented; however all
     samplers are saved in dictionaries for consistency with other testsystems
     """
 


### PR DESCRIPTION
Bugfixes culled (by hand) from #284:
* SMILES strings are now canonicalized by converting them to OpenMM `Topology` objects and back to SMILES again. Without this, the protonation state of imidzole would end up with a different SMILES strings that wasn't in the original set. This is fixed for all testsystems.
* The proposal engines would silently remove any barostats because `SystemGenerator`had no facility to add these to newly generated systems. I've added a way to specify that `SystemGenerator` should add a barostat, and added this to all testsystems.
* `removeCMMotion` is now disabled by the system generator if not explicitly specified
* `HybridTopologyFactory` would raise a puzzling exception when the number of forces differed between `system1` and `system2` (because of the missing barostat). I've added a check during the constructor that prints useful debug information if this happens.
* Barostats are disabled during NCMC switching.