### PR TITLE
Allow travis builds on all branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ addons:
       #- g++-multilib
       #- gcc-multilib
 branches:
-  only:
-    - master
+  except:
+    - /^(?i:notest)-.*$/
 
 install:
   #add random sleep from 1-10s to try to prevent overloading the anaconda servers


### PR DESCRIPTION
@jchodera noticed a flaw with the git-flow model in that travis builds were not triggered, leading to introduction of new errors. This PR would enable travis for all branches except those with `notest` in them. (I don't know at the moment why we'd want that, but it might be useful at some point). We'd then be able to check the status of all branches on the nice travis dashboard, while keeping the clean development model of git-flow.