### PR TITLE
Storage fixes

### DIFF
--- a/perses/storage/storage.py
+++ b/perses/storage/storage.py
@@ -211,7 +211,9 @@ class NetCDFStorage(object):
             The retrieved object
 
         """
+
         nc_path = "/{envname}/{modname}/{varname}".format(envname=envname, modname=modname, varname=varname)
+        
         if iteration is not None:
             pickled = self._ncfile[nc_path][iteration]
         else:

--- a/perses/storage/storage.py
+++ b/perses/storage/storage.py
@@ -191,11 +191,15 @@ class NetCDFStorage(object):
         else:
             ncgrp.variables[varname] = pickled
 
-    def get_object(self, varname, iteration=None):
+    def get_object(self, envname, modname, varname, iteration=None):
         """Get the serialized Python object.
 
         Parameters
         ----------
+        envname : str
+            The name of the environment for the variable
+        modname : str
+            The name of the module for the variable
         varname : str
             The variable name to be stored
         iteration : int, optional, default=None
@@ -207,10 +211,11 @@ class NetCDFStorage(object):
             The retrieved object
 
         """
+        nc_path = "/{envname}/{modname}/{varname}".format(envname=envname, modname=modname, varname=varname)
         if iteration is not None:
-            pickled = self._ncfile['/envname/modname/varname'][iteration]
+            pickled = self._ncfile[nc_path][iteration]
         else:
-            pickled = self._ncfile['/envname/modname/varname'][0]
+            pickled = self._ncfile[nc_path][0]
 
         obj = pickle.loads(codecs.decode(pickled.encode(), "base64"))
         return obj

--- a/perses/storage/storage.py
+++ b/perses/storage/storage.py
@@ -213,7 +213,7 @@ class NetCDFStorage(object):
         """
 
         nc_path = "/{envname}/{modname}/{varname}".format(envname=envname, modname=modname, varname=varname)
-        
+
         if iteration is not None:
             pickled = self._ncfile[nc_path][iteration]
         else:

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -124,14 +124,14 @@ def check_alchemical_null_elimination(topology_proposal, positions, ncmc_nsteps=
     #print("df = %12.6f +- %12.5f kT" % (df, ddf))
     if (abs(df) > NSIGMA_MAX * ddf):
         msg = 'Delta F (%d steps switching) = %f +- %f kT; should be within %f sigma of 0\n' % (ncmc_nsteps, df, ddf, NSIGMA_MAX)
-        msg += 'delete logP:\n'
-        msg += str(logP_delete_n) + '\n'
-        msg += 'insert logP:\n'
-        msg += str(logP_insert_n) + '\n'
-        msg += 'switch logP:\n'
-        msg += str(logP_switch_n) + '\n'
-        msg += 'logP:\n'
-        msg += str(logP_n) + '\n'
+        #msg += 'delete logP:\n'
+        #msg += str(logP_delete_n) + '\n'
+        #msg += 'insert logP:\n'
+        #msg += str(logP_insert_n) + '\n'
+        #msg += 'switch logP:\n'
+        #msg += str(logP_switch_n) + '\n'
+        #msg += 'logP:\n'
+        #msg += str(logP_n) + '\n'
         raise Exception(msg)
 
 def check_hybrid_null_elimination(topology_proposal, positions, ncmc_nsteps=50, NSIGMA_MAX=6.0, geometry=False):

--- a/perses/tests/test_storage.py
+++ b/perses/tests/test_storage.py
@@ -110,17 +110,24 @@ def test_write_object():
     """
     tmpfile = tempfile.NamedTemporaryFile()
     storage = NetCDFStorage(tmpfile.name, mode='w')
-    view = NetCDFStorageView(storage, 'envname', 'modname')
+
+    #use names we might encounter in simulation
+    envname = 'vacuum'
+    modname = 'ExpandedEnsembleSampler'
+    varname = 'energy'
+
+
+    view = NetCDFStorageView(storage, envname, modname)
 
     obj = { 0 : 0 }
     view.write_object('singleton', obj)
 
     for iteration in range(10):
         obj = { 'iteration' : iteration }
-        view.write_object('varname', obj, iteration=iteration)
+        view.write_object(varname, obj, iteration=iteration)
 
     for iteration in range(10):
-        obj = storage.get_object('/envname/modname/varname', iteration=iteration)
+        obj = storage.get_object(envname, modname, varname, iteration=iteration)
         assert ('iteration' in obj)
         assert (obj['iteration'] == iteration)
 
@@ -174,3 +181,6 @@ def test_storage_with_samplers():
             f.description = "Testing designer for %s with environment %s" % (testsystem_name, environment)
             #yield f
             f()
+
+if __name__=="__main__":
+    test_write_object()


### PR DESCRIPTION
This is a small PR with a few storage fixes:

* `get_object` had the variable name hardcoded, which prevented it from being used. This is fixed, but I had to add two extra parameters to `get_object`: `envname` and `modname`. 

* The test happened to use the exact same name as the hardcoded variable, so it was passing. I changed it to use some names we might encounter in simulation (though maybe even just a random string would suffice)

I debated for a bit about how to do this exactly in the spirit of the API, but I decided on the quick patch now so that we could keep going. I'm happy to take a look at this again later.