### PR TITLE
Fix name of variable error in NCMCIntegrator

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -918,7 +918,7 @@ class NCMCAlchemicalIntegrator(openmm.CustomIntegrator):
         self.addConstrainPositions()
         self.addComputePerDof("v", "v + 0.5*dt*f/m + (x-x1)/dt")
         self.addConstrainVelocities()
-        self.addComputeSum("ke", "0.5*m*v*v")
+        self.addComputeSum("kinetic", "0.5*m*v*v")
         self.addComputeGlobal("Enew", "kinetic + energy")
         # Compute acceptance probability
         self.addComputeGlobal("accept", "step(exp(-(Enew-Eold)/kT) - uniform)")


### PR DESCRIPTION
This changes the unused `ke` to `kinetic`. Let me know if something is amiss. Should resolve #323 