### PR TITLE
Fix travis builds

### DIFF
--- a/devtools/travis-ci/install.sh
+++ b/devtools/travis-ci/install.sh
@@ -14,7 +14,7 @@ bash $MINICONDA -b -p miniconda
 
 # Configure miniconda
 export PATH=$HOME/miniconda/bin:$PATH
-conda install --yes conda-build jinja2 anaconda-client pip
+conda install --yes conda-build==2.1.5 jinja2 anaconda-client pip
 conda config --add channels omnia
 
 popd


### PR DESCRIPTION
This pins `conda-build` to 2.1.5 until https://github.com/conda/conda-build/issues/1825 is resolved.