### PR TITLE
Fix bug + add feature

### DIFF
--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -76,6 +76,9 @@ class HybridTopologyFactory(object):
 
         if functions:
             self._functions = functions
+            self._has_functions = True
+        else:
+            self._has_functions = False
 
         #prepare dicts of forces, which will be useful later
         self._old_system_forces = {type(force).__name__ : force for force in self._old_system.getForces()}
@@ -451,7 +454,7 @@ class HybridTopologyFactory(object):
         core_energy_expression = '(K/2)*(r-length)^2;'
         core_energy_expression += 'K = (1-lambda_bonds)*K1 + lambda_bonds*K2;' # linearly interpolate spring constant
         core_energy_expression += 'length = (1-lambda_bonds)*length1 + lambda_bonds*length2;' # linearly interpolate bond length
-        if self._functions:
+        if self._has_functions is not None:
             try:
                 core_energy_expression += 'lambda_bonds = ' + self._functions['lambda_bonds']
             except KeyError as e:
@@ -465,7 +468,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerBondParameter('length2') # new bond length
         custom_core_force.addPerBondParameter('K2') #new spring constant
 
-        if self._functions:
+        if self._has_functions is not None:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -487,7 +490,7 @@ class HybridTopologyFactory(object):
         energy_expression  = '(K/2)*(theta-theta0)^2;'
         energy_expression += 'K = (1.0-lambda_angles)*K_1 + lambda_angles*K_2;' # linearly interpolate spring constant
         energy_expression += 'theta0 = (1.0-lambda_angles)*theta0_1 + lambda_angles*theta0_2;' # linearly interpolate equilibrium angle
-        if self._functions:
+        if self._has_functions is not None:
             try:
                 energy_expression += 'lambda_angles = ' + self._functions['lambda_angles']
             except KeyError as e:
@@ -501,7 +504,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerAngleParameter('theta0_2') # molecule2 equilibrium angle
         custom_core_force.addPerAngleParameter('K_2') # molecule2 spring constant
 
-        if self._functions:
+        if self._has_functions is not None:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -526,7 +529,7 @@ class HybridTopologyFactory(object):
         energy_expression += 'U1 = K1*(1+cos(periodicity1*theta-phase1));'
         energy_expression += 'U2 = K2*(1+cos(periodicity2*theta-phase2));'
 
-        if self._functions:
+        if self._has_functions is not None:
             try:
                 energy_expression += 'lambda_torsions = ' + self._functions['lambda_torsions']
             except KeyError as e:
@@ -543,7 +546,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerTorsionParameter('phase2') # molecule2 phase
         custom_core_force.addPerTorsionParameter('K2') # molecule2 spring constant
 
-        if self._functions:
+        if self._has_functions is not None:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -603,7 +606,7 @@ class HybridTopologyFactory(object):
 
         # Create CustomNonbondedForce to handle interactions between alchemically-modified atoms and rest of system.
         total_electrostatics_energy = "U_electrostatics;" + electrostatics_energy_expression + electrostatics_mixing_rules
-        if self._functions:
+        if self._has_functions is not None:
             try:
                 total_electrostatics_energy += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
             except KeyError as e:
@@ -615,7 +618,7 @@ class HybridTopologyFactory(object):
         electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeA") # partial charge initial
         electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeB") # partial charge final
 
-        if self._functions:
+        if self._has_functions is not None:
             electrostatics_custom_nonbonded_force.addGlobalParameter("lambda", 0.0)
             electrostatics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
         else:
@@ -628,7 +631,7 @@ class HybridTopologyFactory(object):
         self._hybrid_system_forces['core_electrostatics_force'] = electrostatics_custom_nonbonded_force
 
         total_sterics_energy = "U_sterics;" + sterics_energy_expression + sterics_mixing_rules
-        if self._functions:
+        if self._has_functions is not None:
             try:
                 total_sterics_energy += 'lambda_sterics  = ' + self._functions['lambda_sterics']
             except KeyError as e:
@@ -642,7 +645,7 @@ class HybridTopologyFactory(object):
         sterics_custom_nonbonded_force.addPerParticleParameter("sigmaB") # Lennard-Jones sigma final
         sterics_custom_nonbonded_force.addPerParticleParameter("epsilonB") # Lennard-Jones epsilon final
 
-        if self._functions:
+        if self._has_functions is not None:
             sterics_custom_nonbonded_force.addGlobalParameter('lambda', 0.0)
             sterics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
         else:
@@ -825,7 +828,7 @@ class HybridTopologyFactory(object):
         """
         #Create the force and add its relevant parameters.
         #we don't need to check that the keys exist, since by the time this is called, these are already checked.
-        if self._functions:
+        if self._has_functions is not None:
             sterics_energy_expression += 'lambda_sterics = ' + self._functions['lambda_sterics']
             electrostatics_energy_expression += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
         custom_bond_force = openmm.CustomBondForce("U_sterics + U_electrostatics;" + sterics_energy_expression + electrostatics_energy_expression)
@@ -840,7 +843,7 @@ class HybridTopologyFactory(object):
         custom_bond_force.addPerBondParameter("sigmaB")
         custom_bond_force.addPerBondParameter("epsilonB")
 
-        if self._functions:
+        if self._has_functions is not None:
             custom_bond_force.addGlobalParameter('lambda', 0.0)
             custom_bond_force.addEnergyParameterDerivative('lambda')
         else:

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -454,7 +454,7 @@ class HybridTopologyFactory(object):
         core_energy_expression = '(K/2)*(r-length)^2;'
         core_energy_expression += 'K = (1-lambda_bonds)*K1 + lambda_bonds*K2;' # linearly interpolate spring constant
         core_energy_expression += 'length = (1-lambda_bonds)*length1 + lambda_bonds*length2;' # linearly interpolate bond length
-        if self._has_functions is not None:
+        if self._has_functions:
             try:
                 core_energy_expression += 'lambda_bonds = ' + self._functions['lambda_bonds']
             except KeyError as e:
@@ -468,7 +468,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerBondParameter('length2') # new bond length
         custom_core_force.addPerBondParameter('K2') #new spring constant
 
-        if self._has_functions is not None:
+        if self._has_functions:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -490,7 +490,7 @@ class HybridTopologyFactory(object):
         energy_expression  = '(K/2)*(theta-theta0)^2;'
         energy_expression += 'K = (1.0-lambda_angles)*K_1 + lambda_angles*K_2;' # linearly interpolate spring constant
         energy_expression += 'theta0 = (1.0-lambda_angles)*theta0_1 + lambda_angles*theta0_2;' # linearly interpolate equilibrium angle
-        if self._has_functions is not None:
+        if self._has_functions:
             try:
                 energy_expression += 'lambda_angles = ' + self._functions['lambda_angles']
             except KeyError as e:
@@ -504,7 +504,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerAngleParameter('theta0_2') # molecule2 equilibrium angle
         custom_core_force.addPerAngleParameter('K_2') # molecule2 spring constant
 
-        if self._has_functions is not None:
+        if self._has_functions:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -529,7 +529,7 @@ class HybridTopologyFactory(object):
         energy_expression += 'U1 = K1*(1+cos(periodicity1*theta-phase1));'
         energy_expression += 'U2 = K2*(1+cos(periodicity2*theta-phase2));'
 
-        if self._has_functions is not None:
+        if self._has_functions:
             try:
                 energy_expression += 'lambda_torsions = ' + self._functions['lambda_torsions']
             except KeyError as e:
@@ -546,7 +546,7 @@ class HybridTopologyFactory(object):
         custom_core_force.addPerTorsionParameter('phase2') # molecule2 phase
         custom_core_force.addPerTorsionParameter('K2') # molecule2 spring constant
 
-        if self._has_functions is not None:
+        if self._has_functions:
             custom_core_force.addGlobalParameter('lambda', 0.0)
             custom_core_force.addEnergyParameterDerivative('lambda')
         else:
@@ -606,7 +606,7 @@ class HybridTopologyFactory(object):
 
         # Create CustomNonbondedForce to handle interactions between alchemically-modified atoms and rest of system.
         total_electrostatics_energy = "U_electrostatics;" + electrostatics_energy_expression + electrostatics_mixing_rules
-        if self._has_functions is not None:
+        if self._has_functions:
             try:
                 total_electrostatics_energy += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
             except KeyError as e:
@@ -618,7 +618,7 @@ class HybridTopologyFactory(object):
         electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeA") # partial charge initial
         electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeB") # partial charge final
 
-        if self._has_functions is not None:
+        if self._has_functions:
             electrostatics_custom_nonbonded_force.addGlobalParameter("lambda", 0.0)
             electrostatics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
         else:
@@ -631,7 +631,7 @@ class HybridTopologyFactory(object):
         self._hybrid_system_forces['core_electrostatics_force'] = electrostatics_custom_nonbonded_force
 
         total_sterics_energy = "U_sterics;" + sterics_energy_expression + sterics_mixing_rules
-        if self._has_functions is not None:
+        if self._has_functions:
             try:
                 total_sterics_energy += 'lambda_sterics  = ' + self._functions['lambda_sterics']
             except KeyError as e:
@@ -645,7 +645,7 @@ class HybridTopologyFactory(object):
         sterics_custom_nonbonded_force.addPerParticleParameter("sigmaB") # Lennard-Jones sigma final
         sterics_custom_nonbonded_force.addPerParticleParameter("epsilonB") # Lennard-Jones epsilon final
 
-        if self._has_functions is not None:
+        if self._has_functions:
             sterics_custom_nonbonded_force.addGlobalParameter('lambda', 0.0)
             sterics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
         else:
@@ -828,7 +828,7 @@ class HybridTopologyFactory(object):
         """
         #Create the force and add its relevant parameters.
         #we don't need to check that the keys exist, since by the time this is called, these are already checked.
-        if self._has_functions is not None:
+        if self._has_functions:
             sterics_energy_expression += 'lambda_sterics = ' + self._functions['lambda_sterics']
             electrostatics_energy_expression += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
         custom_bond_force = openmm.CustomBondForce("U_sterics + U_electrostatics;" + sterics_energy_expression + electrostatics_energy_expression)
@@ -843,7 +843,7 @@ class HybridTopologyFactory(object):
         custom_bond_force.addPerBondParameter("sigmaB")
         custom_bond_force.addPerBondParameter("epsilonB")
 
-        if self._has_functions is not None:
+        if self._has_functions:
             custom_bond_force.addGlobalParameter('lambda', 0.0)
             custom_bond_force.addEnergyParameterDerivative('lambda')
         else:

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -58,7 +58,8 @@ class HybridTopologyFactory(object):
         functions : dict, default None
             Alchemical functions that determine how each force is scaled with lambda. The keys must be strings with
             names beginning with lambda_ and ending with each of bonds, angles, torsions, sterics, electrostatics.
-            If none, then the integrator will need to set each of these and parameter derivatives will be unavailable.
+            If functions is none, then the integrator will need to set each of these and parameter derivatives will be unavailable.
+            If functions is not None, all lambdas must be specified.
         """
         self._topology_proposal = topology_proposal
         self._old_system = copy.deepcopy(topology_proposal.old_system)

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -831,7 +831,7 @@ class HybridTopologyFactory(object):
         #now loop through the new system to get the interactions that are unique to it.
         for bond_index in range(new_system_bond_force.getNumBonds()):
             #get each set of bond parameters
-            [index1_new, index2_new, r0_new, k_new] = old_system_bond_force.getBondParameters(bond_index)
+            [index1_new, index2_new, r0_new, k_new] = new_system_bond_force.getBondParameters(bond_index)
 
             #convert indices to hybrid, since that is how we represent atom classes:
             index1_hybrid = self._new_to_hybrid_map[index1_new]
@@ -951,7 +951,7 @@ class HybridTopologyFactory(object):
             angle_parameters = new_system_angle_force.getAngleParameters(angle_index)
 
             #get the indices in the hybrid system
-            hybrid_index_list = [self._old_to_hybrid_map[new_index] for new_index in angle_parameters[:3]]
+            hybrid_index_list = [self._new_to_hybrid_map[new_index] for new_index in angle_parameters[:3]]
             hybrid_index_set = set(hybrid_index_list)
 
             #if the intersection of this hybrid set with the unique new atoms is nonempty, it must be added:

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -41,7 +41,7 @@ class HybridTopologyFactory(object):
 
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
 
-    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False):
+    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None):
         """
         Initialize the Hybrid topology factory.
 
@@ -55,6 +55,10 @@ class HybridTopologyFactory(object):
             The positions of the "new system"
         use_dispersion_correction : bool, default False
             Whether to use the long range correction in the custom sterics force. This is very expensive for NCMC.
+        functions : dict, default None
+            Alchemical functions that determine how each force is scaled with lambda. The keys must be strings with
+            names beginning with lambda_ and ending with each of bonds, angles, torsions, sterics, electrostatics.
+            If none, then the integrator will need to set each of these and parameter derivatives will be unavailable.
         """
         self._topology_proposal = topology_proposal
         self._old_system = copy.deepcopy(topology_proposal.old_system)
@@ -69,6 +73,9 @@ class HybridTopologyFactory(object):
 
         self.softcore_alpha=0.5
         self.softcore_beta=12*unit.angstrom**2
+
+        if functions:
+            self._functions = functions
 
         #prepare dicts of forces, which will be useful later
         self._old_system_forces = {type(force).__name__ : force for force in self._old_system.getForces()}
@@ -444,14 +451,25 @@ class HybridTopologyFactory(object):
         core_energy_expression = '(K/2)*(r-length)^2;'
         core_energy_expression += 'K = (1-lambda_bonds)*K1 + lambda_bonds*K2;' # linearly interpolate spring constant
         core_energy_expression += 'length = (1-lambda_bonds)*length1 + lambda_bonds*length2;' # linearly interpolate bond length
+        if self._functions:
+            try:
+                core_energy_expression += 'lambda_bonds = ' + self._functions['lambda_bonds']
+            except KeyError as e:
+                print("Functions were provided, but no term was provided for the bonds")
+                raise e
 
         #create the force and add the relevant parameters
         custom_core_force = openmm.CustomBondForce(core_energy_expression)
-        custom_core_force.addGlobalParameter('lambda_bonds', 0.0)
         custom_core_force.addPerBondParameter('length1') # old bond length
         custom_core_force.addPerBondParameter('K1') # old spring constant
         custom_core_force.addPerBondParameter('length2') # new bond length
         custom_core_force.addPerBondParameter('K2') #new spring constant
+
+        if self._functions:
+            custom_core_force.addGlobalParameter('lambda', 0.0)
+            custom_core_force.addEnergyParameterDerivative('lambda')
+        else:
+            custom_core_force.addGlobalParameter('lambda_bonds', 0.0)
 
         self._hybrid_system.addForce(custom_core_force)
         self._hybrid_system_forces['core_bond_force'] = custom_core_force
@@ -469,14 +487,26 @@ class HybridTopologyFactory(object):
         energy_expression  = '(K/2)*(theta-theta0)^2;'
         energy_expression += 'K = (1.0-lambda_angles)*K_1 + lambda_angles*K_2;' # linearly interpolate spring constant
         energy_expression += 'theta0 = (1.0-lambda_angles)*theta0_1 + lambda_angles*theta0_2;' # linearly interpolate equilibrium angle
+        if self._functions:
+            try:
+                energy_expression += 'lambda_angles = ' + self._functions['lambda_angles']
+            except KeyError as e:
+                print("Functions were provided, but no term was provided for the angles")
+                raise e
 
         #create the force and add relevant parameters
         custom_core_force = openmm.CustomAngleForce(energy_expression)
-        custom_core_force.addGlobalParameter('lambda_angles', 0.0)
         custom_core_force.addPerAngleParameter('theta0_1') # molecule1 equilibrium angle
         custom_core_force.addPerAngleParameter('K_1') # molecule1 spring constant
         custom_core_force.addPerAngleParameter('theta0_2') # molecule2 equilibrium angle
         custom_core_force.addPerAngleParameter('K_2') # molecule2 spring constant
+
+        if self._functions:
+            custom_core_force.addGlobalParameter('lambda', 0.0)
+            custom_core_force.addEnergyParameterDerivative('lambda')
+        else:
+            custom_core_force.addGlobalParameter('lambda_angles', 0.0)
+
 
         #add the force to the system and the force dict.
         self._hybrid_system.addForce(custom_core_force)
@@ -496,15 +526,28 @@ class HybridTopologyFactory(object):
         energy_expression += 'U1 = K1*(1+cos(periodicity1*theta-phase1));'
         energy_expression += 'U2 = K2*(1+cos(periodicity2*theta-phase2));'
 
+        if self._functions:
+            try:
+                energy_expression += 'lambda_torsions = ' + self._functions['lambda_torsions']
+            except KeyError as e:
+                print("Functions were provided, but no term was provided for torsions")
+                raise e
+
+
         #create the force and add the relevant parameters
         custom_core_force = openmm.CustomTorsionForce(energy_expression)
-        custom_core_force.addGlobalParameter('lambda_torsions', 0.0)
         custom_core_force.addPerTorsionParameter('periodicity1') # molecule1 periodicity
         custom_core_force.addPerTorsionParameter('phase1') # molecule1 phase
         custom_core_force.addPerTorsionParameter('K1') # molecule1 spring constant
         custom_core_force.addPerTorsionParameter('periodicity2') # molecule2 periodicity
         custom_core_force.addPerTorsionParameter('phase2') # molecule2 phase
         custom_core_force.addPerTorsionParameter('K2') # molecule2 spring constant
+
+        if self._functions:
+            custom_core_force.addGlobalParameter('lambda', 0.0)
+            custom_core_force.addEnergyParameterDerivative('lambda')
+        else:
+            custom_core_force.addGlobalParameter('lambda_torsions', 0.0)
 
         #add the force to the system
         self._hybrid_system.addForce(custom_core_force)


### PR DESCRIPTION
This PR does two things:

* Fixes a bug where the wrong range is used for looping through the bond force and angle force.

* Allows (but does not expect by default) specification of the alchemical functions in the hybrid. The advantage of this is that we can get openmm to calculate dU/dlambda easily. This would presumably also allow for alchemical functions to be defined using the OpenMM spline classes as well, which are accessible from the force side but not the integrator side.