### PR TITLE
Use constants from openmmtools

### DIFF
--- a/perses/annihilation/ncmc_switching.py
+++ b/perses/annihilation/ncmc_switching.py
@@ -6,6 +6,7 @@ import traceback
 from simtk import openmm, unit
 from perses.storage import NetCDFStorageView
 from perses.tests.utils import quantity_is_finite
+from openmmtools.constants import kB
 
 default_functions = {
     'lambda_sterics' : '2*lambda * step(0.5 - lambda) + (1.0 - step(0.5 - lambda))',
@@ -124,7 +125,6 @@ class NCMCEngine(object):
 
     @property
     def beta(self):
-        kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
         kT = kB * self.temperature
         beta = 1.0 / kT
         return beta
@@ -778,7 +778,6 @@ class NCMCAlchemicalIntegrator(openmm.CustomIntegrator):
         self.direction = direction
 
         # Compute kT in natural openmm units.
-        kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
         kT = kB * temperature
         self.kT = kT
 

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -5,8 +5,8 @@ import mdtraj as md
 import numpy as np
 import copy
 import enum
+from openmmtools.constants import ONE_4PI_EPS0
 
-ONE_4PI_EPS0 = 138.935456
 InteractionGroup = enum.Enum("InteractionGroup", ['unique_old', 'unique_new', 'core', 'environment'])
 
 class HybridTopologyFactory(object):

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -4,8 +4,7 @@ import simtk.openmm.app as app
 import numpy as np
 import copy
 from perses.rjmc.topology_proposal import deepcopy_topology
-
-ONE_4PI_EPS0 = 138.935456 # OpenMM constant for Coulomb interactions (openmm/platforms/reference/include/SimTKOpenMMRealType.h) in OpenMM units
+from openmmtools.constants import ONE_4PI_EPS0
 
 def unique(atom_list):
     if atom_list[0] > atom_list[-1]:

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -16,8 +16,8 @@ from openmoltools import forcefield_generators
 import copy
 import mdtraj as md
 from io import StringIO
+from openmmtools.constants import kB
 
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT
@@ -464,6 +464,3 @@ if __name__=="__main__":
     ne_fep.run_nonequilibrium_task()
     ne_fep.run_equilibrium()
     ne_fep.collect_ne_work()
-
-
-

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -23,6 +23,7 @@ import numpy as np
 from openmmtools import testsystems
 import copy
 import time
+from openmmtools.constants import kB
 
 from perses.storage import NetCDFStorageView
 from perses.samplers import thermodynamics
@@ -34,12 +35,6 @@ from perses.tests.utils import quantity_is_finite
 
 import logging
 logger = logging.getLogger(__name__)
-
-################################################################################
-# CONSTANTS
-################################################################################
-
-from perses.samplers.thermodynamics import kB
 
 ################################################################################
 # THERMODYNAMIC STATE

--- a/perses/samplers/thermodynamics.py
+++ b/perses/samplers/thermodynamics.py
@@ -33,6 +33,7 @@ import numpy as np
 import simtk.openmm as mm
 import simtk.unit as units
 from openmmtools import testsystems
+from openmmtools.constants import kB
 
 import logging
 logger = logging.getLogger(__name__)
@@ -42,12 +43,6 @@ logger = logging.getLogger(__name__)
 #=============================================================================================
 
 __version__ = "$Revision: $"
-
-#=============================================================================================
-# MODULE CONSTANTS
-#=============================================================================================
-
-kB = units.BOLTZMANN_CONSTANT_kB * units.AVOGADRO_CONSTANT_NA # Boltzmann constant
 
 #=============================================================================================
 # Thermodynamic state description

--- a/perses/tests/benchmark.py
+++ b/perses/tests/benchmark.py
@@ -16,7 +16,7 @@ else:
 import matplotlib as mpl
 mpl.use('Agg')
 import seaborn as sns
-
+from openmmtools.constants import kB
 import matplotlib.pyplot as plt
 
 ################################################################################
@@ -30,7 +30,6 @@ ENV = 'vacuum'
 # CONSTANTS
 ################################################################################
 
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT

--- a/perses/tests/test_elimination.py
+++ b/perses/tests/test_elimination.py
@@ -24,12 +24,12 @@ if sys.version_info >= (3, 0):
 else:
     from cStringIO import StringIO
     from commands import getstatusoutput
+from openmmtools.constants import kB
 
 ################################################################################
 # CONSTANTS
 ################################################################################
 
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     from commands import getoutput  # If python 2
 from nose.plugins.attrib import attr
-
+from openmmtools.constants import kB
 from perses.rjmc import coordinate_numba
 
 #correct p-value threshold for some multiple hypothesis testing
@@ -35,7 +35,6 @@ ntests = 3.0
 ncommits = 10000.0
 
 pval_threshold = pval_base / (ntests * ncommits)
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT

--- a/perses/tests/test_ncmc_integrator.py
+++ b/perses/tests/test_ncmc_integrator.py
@@ -13,12 +13,7 @@ from simtk import openmm, unit
 import math
 import numpy as np
 from functools import partial
-
-################################################################################
-# CONSTANTS
-################################################################################
-
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
+from openmmtools.constants import kB
 
 ################################################################################
 # TESTS

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -12,9 +12,9 @@ except:
     from urllib2 import urlopen
     from cStringIO import StringIO
 from nose.plugins.attrib import attr
+from openmmtools.constants import kB
 
 temperature = 300*unit.kelvin
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 # Compute kT and inverse temperature.
 kT = kB * temperature
 beta = 1.0 / kT

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -38,12 +38,7 @@ from perses.storage import NetCDFStorage, NetCDFStorageView
 from perses.rjmc.geometry import FFAllAngleGeometryEngine
 import tempfile
 import copy
-
-################################################################################
-# CONSTANTS
-################################################################################
-
-from perses.samplers.thermodynamics import kB
+from openmmtools.constants import kB
 
 ################################################################################
 # TEST SYSTEMS

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -23,12 +23,12 @@ if sys.version_info >= (3, 0):
 else:
     from cStringIO import StringIO
     from commands import getstatusoutput
+from openmmtools.constants import kB
 
 ################################################################################
 # CONSTANTS
 ################################################################################
 
-kB = unit.BOLTZMANN_CONSTANT_kB * unit.AVOGADRO_CONSTANT_NA
 temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT


### PR DESCRIPTION
Fixes #359: Use `kB` and `ONE_4PI_EPS0` from `openmmtools.constants`.