### PR TITLE
Reset NCMC statistics before nonequilibrium switching

### DIFF
--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -87,11 +87,10 @@ def run_protocol(self, starting_positions, nsteps, thermodynamic_state, integrat
     """
     integrator = restore_properties(integrator)
     switching_ctx, integrator_neq = self._cache.get_context(thermodynamic_state, integrator)
-    integrator_neq = restore_properties(integrator_neq)
     switching_ctx.setPositions(starting_positions)
+    integrator_neq.reset()
     integrator_neq.step(nsteps)
     work = integrator_neq.get_protocol_work(dimensionless=True)
-    integrator_neq.reset()
     return work
 
 @app.task(bind=True, base=NonequilibriumSwitchTask, serializer="pickle")

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -78,12 +78,12 @@ def restore_properties(integrator, measure_shadow_work=False, measure_heat=False
 @app.task(bind=True, base=NonequilibriumSwitchTask, serializer="pickle")
 def run_protocol(self, starting_positions, nsteps, thermodynamic_state, integrator):
     """
-    Perform a switching protocol and return the nonequilibrium switching weight
+    Perform a nonequilibrium switching protocol and return the nonequilibrium protocol work
 
     Returns
     -------
-    weight : float64
-        The nonequilibrium switching weight
+    work : float
+        The dimensionless nonequilibrium work
     """
     integrator = restore_properties(integrator)
     switching_ctx, integrator_neq = self._cache.get_context(thermodynamic_state, integrator)

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -48,33 +48,6 @@ class NonequilibriumSwitchTask(celery.Task):
         platform = openmm.Platform.getPlatformByName("OpenCL")
         self._cache = cache.ContextCache(platform=platform)
 
-def restore_properties(integrator, measure_shadow_work=False, measure_heat=False, metropolized_integrator=False):
-    """
-    This is a temporary utility function to restore the properties of the AlchemicalNonequilibriumLangevin...
-    integrator so that we can avoid exceptions.
-
-    Parameters
-    ----------
-    integrator : AlchemicalNone...
-        integrator to which the attributes should be added
-    measure_shadow_work : bool, default False
-        whether to tell it to measure shadow work
-    measure_heat : bool, default False
-        whether to tell it to measure heat
-    metropolized_integrator : bool, default False
-        whether the integrator is metropolized
-
-    Returns
-    -------
-    integrator : AlchemicalNone...
-        integrator with attributes added
-    """
-    integrator._measure_shadow_work = measure_shadow_work
-    integrator._measure_heat = measure_heat
-    integrator._metropolized_integrator = metropolized_integrator
-    return integrator
-
-
 @app.task(bind=True, base=NonequilibriumSwitchTask, serializer="pickle")
 def run_protocol(self, starting_positions, nsteps, thermodynamic_state, integrator):
     """
@@ -85,7 +58,6 @@ def run_protocol(self, starting_positions, nsteps, thermodynamic_state, integrat
     work : float
         The dimensionless nonequilibrium work
     """
-    integrator = restore_properties(integrator)
     switching_ctx, integrator_neq = self._cache.get_context(thermodynamic_state, integrator)
     switching_ctx.setPositions(starting_positions)
     integrator_neq.reset()
@@ -102,7 +74,6 @@ def run_equilibrium(self, starting_positions, nsteps, lambda_state, functions, t
     -------
     positions : [n, 3] np.ndarray quantity
     """
-    integrator = restore_properties(integrator)
     equilibrium_ctx, integrator = self._cache.get_context(thermodynamic_state, integrator)
     equilibrium_ctx.setPositions(starting_positions)
     for parm in functions.keys():
@@ -114,8 +85,6 @@ def run_equilibrium(self, starting_positions, nsteps, lambda_state, functions, t
 
 @app.task(bind=True, base=NonequilibriumSwitchTask, serializer="pickle")
 def minimize(self, starting_positions, nsteps_max, lambda_state, functions, thermodynamic_state, integrator):
-    integrator = restore_properties(integrator)
-
     equilibrium_ctx, integrator = self._cache.get_context(thermodynamic_state, integrator)
 
     equilibrium_ctx.setPositions(starting_positions)

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -51,12 +51,12 @@ class NonequilibriumSwitchTask(celery.Task):
 @app.task(bind=True, base=NonequilibriumSwitchTask, serializer="pickle")
 def run_protocol(self, starting_positions, nsteps, thermodynamic_state, integrator):
     """
-    Perform a nonequilibrium switching protocol and return the nonequilibrium protocol work
+    Perform a nonequilibrium switching protocol and return the nonequilibrium protocol work.
 
     Returns
     -------
     work : float
-        The dimensionless nonequilibrium work
+        The dimensionless nonequilibrium protocol work.
     """
     switching_ctx, integrator_neq = self._cache.get_context(thermodynamic_state, integrator)
     switching_ctx.setPositions(starting_positions)

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -464,6 +464,3 @@ if __name__=="__main__":
     ne_fep.run_nonequilibrium_task()
     ne_fep.run_equilibrium()
     ne_fep.collect_ne_work()
-
-
-


### PR DESCRIPTION
Fixes #368.

Since #1870, the development version of OpenMM has `Context.getIntegrator()` return the correct Python subclass, so the `restore_properties()` workaround should no longer be needed (and would also interfere with the ability to call `integrator.reset()`).

We may also have to update `openmmtools.ContextCache()` to streamline the `RestorableIntegrator` scheme, but this will only work with OpenMM 7.2 and later, so we should hold off on that if we can.

Docstrings have also been clarified.