### PR TITLE
Switch to using MCMove framework in feptasks.py

### DIFF
--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1510,7 +1510,7 @@ class HybridTopologyFactory(object):
         added_atoms = dict()
 
         #get the core atoms in the new index system (as opposed to the hybrid index system). We will need this later
-        core_atoms_new_indices = {self._hybrid_to_new_map[core_atom] for core_atom in self._atom_classes['core']}
+        core_atoms_new_indices = {self._hybrid_to_new_map[core_atom] for core_atom in self._atom_classes['core_atoms']}
 
         #now, add each unique new atom to the topology (this is the same order as the system)
         for particle_idx in self._topology_proposal.unique_new_atoms:

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -118,7 +118,7 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
             The relevant thermodynamic state for this context and integrator
         """
         integrator = context.getIntegrator()
-        self._current_total_work += integrator.get_total_work(dimensionless=True)
+        self._current_total_work = integrator.get_total_work(dimensionless=True)
 
     @property
     def current_total_work(self):

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -228,7 +228,7 @@ def run_protocol(thermodynamic_state, sampler_state, ne_mc_move, topology, n_ite
         trajectory_positions[iteration, :, :] = sampler_state.positions
 
         #get the box angles and lengths
-        a, b, c, alpha, beta, gamma = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(sampler_state.box_vectors)
+        a, b, c, alpha, beta, gamma = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(*sampler_state.box_vectors)
         trajectory_box_lengths[iteration, :] = [a, b, c]
         trajectory_box_angles[iteration, :] = [alpha, beta, gamma]
 
@@ -283,7 +283,7 @@ def run_equilibrium(thermodynamic_state, sampler_state, mc_move, topology, n_ite
         trajectory_positions[iteration, :] = sampler_state.positions
 
         #get the box lengths and angles
-        a, b, c, alpha, beta, gamma = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(sampler_state.box_vectors)
+        a, b, c, alpha, beta, gamma = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(*sampler_state.box_vectors)
         trajectory_box_lengths[iteration, :] = [a, b, c]
         trajectory_box_angles[iteration, :] = [alpha, beta, gamma]
 

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -95,7 +95,7 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
         """
         return self._integrator
 
-    def reset(self, thermodynamic_state):
+    def reset(self):
         """
         Reset the work statistics on the associated ContextCache integrator.
 
@@ -104,21 +104,7 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
         thermodynamic_state : openmmtools.states.ThermodynamicState
             the thermodynamic state for which this integrator is cached.
         """
-
-        # Check if we have to use the global cache.
-        if self.context_cache is None:
-            context_cache = cache.global_context_cache
-        else:
-            context_cache = self.context_cache
-
-        #Get the integrator from the context cache
-        context, integrator = context_cache.get_context(thermodynamic_state, self._integrator)
-
-        #Reset the statistics on the integrator
-        integrator.reset()
-
-        #reset the class's own statistics:
-        self._current_total_work = 0.0
+        self._integrator.reset()
 
     def _after_integration(self, context, thermodynamic_state):
         """
@@ -217,7 +203,7 @@ def run_protocol(thermodynamic_state, sampler_state, ne_mc_move, topology, n_ite
     cumulative_work = np.zeros(n_iterations)
     #rdb.set_trace()
     #reset the MCMove to ensure that we are starting with zero work.
-    ne_mc_move.reset(thermodynamic_state)
+    ne_mc_move.reset()
 
     #now loop through the iterations and run the protocol:
     for iteration in range(n_iterations):

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -147,8 +147,8 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
         self._integrator = pickle.loads(serialization['integrator'])
         integrators.RestorableIntegrator.restore_interface(self._integrator)
         self._integrator._measure_shadow_work = serialization['measure_shadow_work']
-        self._integrator._measure_heat = serialization['measure_shadow_work']
-        self._integrator._metropolized_integrator = serialization['measure_shadow_work']
+        self._integrator._measure_heat = serialization['measure_heat']
+        self._integrator._metropolized_integrator = serialization['metropolized_integrator']
 
 
 def update_broker_location(broker_location, backend_location=None):
@@ -199,7 +199,7 @@ def run_protocol(thermodynamic_state, sampler_state, ne_mc_move, topology, n_ite
 
     #create a numpy array for the work values
     cumulative_work = np.zeros(n_iterations)
-    #rdb.set_trace()
+    rdb.set_trace()
     #reset the MCMove to ensure that we are starting with zero work.
     ne_mc_move.reset(thermodynamic_state)
 

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -136,6 +136,9 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
         dictionary = super(NonequilibriumSwitchingMove, self).__getstate__()
         dictionary['integrator'] = pickle.dumps(self._integrator)
         dictionary['current_total_work'] = self.current_total_work
+        dictionary['measure_shadow_work'] = self._integrator._measure_shadow_work
+        dictionary['measure_heat'] = self._integrator._measure_heat
+        dictionary['metropolized_integrator'] = self._integrator._metropolized_integrator
         return dictionary
 
     def __setstate__(self, serialization):
@@ -143,6 +146,10 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
         self._current_total_work = serialization['current_total_work']
         self._integrator = pickle.loads(serialization['integrator'])
         integrators.RestorableIntegrator.restore_interface(self._integrator)
+        self._integrator._measure_shadow_work = serialization['measure_shadow_work']
+        self._integrator._measure_heat = serialization['measure_shadow_work']
+        self._integrator._metropolized_integrator = serialization['measure_shadow_work']
+
 
 def update_broker_location(broker_location, backend_location=None):
     """

--- a/perses/distributed/feptasks.py
+++ b/perses/distributed/feptasks.py
@@ -2,6 +2,19 @@ import celery
 from celery.contrib import rdb
 import simtk.openmm as openmm
 import openmmtools.cache as cache
+
+#Add the variables specific to the Alchemical langevin integrator
+cache.global_context_cache.COMPATIBLE_INTEGRATOR_ATTRIBUTES.update({
+    "protocol_work" : 0.0,
+    "Eold" : 0.0,
+    "Enew" : 0.0,
+    "lambda" : 0.0,
+    "nsteps" : 0.0,
+    "step" : 0.0,
+    "n_lambda_steps" : 0.0,
+    "lambda_step" : 0.0
+})
+
 import openmmtools.mcmc as mcmc
 import openmmtools.utils as utils
 import openmmtools.integrators as integrators
@@ -199,7 +212,7 @@ def run_protocol(thermodynamic_state, sampler_state, ne_mc_move, topology, n_ite
 
     #create a numpy array for the work values
     cumulative_work = np.zeros(n_iterations)
-    rdb.set_trace()
+    #rdb.set_trace()
     #reset the MCMove to ensure that we are starting with zero work.
     ne_mc_move.reset(thermodynamic_state)
 

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -486,8 +486,8 @@ class NonequilibriumSwitchingFEP(object):
         self.minimize()
 
         #initialize the trajectories for the lambda 0 and 1 equilibrium simulations
-        self._lambda_zero_traj = md.Trajectory(self._lambda_zero_sampler_state.positions, self._factory.hybrid_topology)
-        self._lambda_one_traj = md.Trajectory(self._lambda_one_sampler_state.positions, self._factory.hybrid_topology)
+        self._lambda_zero_traj = md.Trajectory(np.array(self._lambda_zero_sampler_state.positions), self._factory.hybrid_topology)
+        self._lambda_one_traj = md.Trajectory(np.array(self._lambda_one_sampler_state.positions), self._factory.hybrid_topology)
 
     def _set_all_parameters_of_state(self, alchemical_state, value):
         """
@@ -527,8 +527,8 @@ class NonequilibriumSwitchingFEP(object):
         minimized_lambda_one_result = feptasks.minimize.delay(self._lambda_one_thermodynamic_state, self._lambda_one_sampler_state, self._equilibrium_mc_move, max_iterations=max_steps)
 
         #now synchronously retrieve the results and save the sampler states.
-        self._lambda_zero_sampler_state = minimized_lambda_zero_result.join()
-        self._lambda_one_sampler_state = minimized_lambda_one_result.join()
+        self._lambda_zero_sampler_state = minimized_lambda_zero_result.get()
+        self._lambda_one_sampler_state = minimized_lambda_one_result.get()
 
     def run(self, n_iterations=5, concurrency=1):
         """
@@ -678,7 +678,7 @@ class NonequilibriumSwitchingFEP(object):
         file_prefix : str
             A prefix for the filenames
         """
-        
+
 
     @property
     def lambda_zero_equilibrium_trajectory(self):
@@ -710,13 +710,20 @@ class NonequilibriumSwitchingFEP(object):
         return [df, ddf]
 
 if __name__=="__main__":
-    import os
-    gaff_filename = get_data_filename("data/gaff.xml")
-    forcefield_files = [gaff_filename, 'tip3p.xml', 'amber99sbildn.xml']
-    path_to_schrodinger_inputs = "/Users/grinawap/Downloads"
-    protein_file = os.path.join(path_to_schrodinger_inputs, "/Users/grinawap/Downloads/CDK2_fixed_nohet.pdb")
-    molecule_file = os.path.join(path_to_schrodinger_inputs, "/Users/grinawap/Downloads/Inputs_for_FEP/CDK2_ligands.mol2")
-    fesetup = NonequilibriumFEPSetup(protein_file, molecule_file, 0, 2, forcefield_files)
-
+    #import os
+    #outfile = open("fesetup.pkl", 'wb')
+    #gaff_filename = get_data_filename("data/gaff.xml")
+    #forcefield_files = [gaff_filename, 'tip3p.xml', 'amber99sbildn.xml']
+    #path_to_schrodinger_inputs = "/Users/grinawap/Downloads"
+    #protein_file = os.path.join(path_to_schrodinger_inputs, "/Users/grinawap/Downloads/CDK2_fixed_nohet.pdb")
+    #molecule_file = os.path.join(path_to_schrodinger_inputs, "/Users/grinawap/Downloads/Inputs_for_FEP/CDK2_ligands.mol2")
+    #fesetup = NonequilibriumFEPSetup(protein_file, molecule_file, 0, 2, forcefield_files)
+    import pickle
+    infile = open("fesetup.pkl", 'rb')
+    fesetup = pickle.load(infile)
+    infile.close()
+    #pickle.dump(fesetup, outfile)
+    #outfile.close()
     ne_fep = NonequilibriumSwitchingFEP(fesetup.solvent_topology_proposal, fesetup.solvent_old_positions, fesetup.solvent_new_positions)
     print("ne-fep initialized")
+    ne_fep.run(n_iterations=1)

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -358,8 +358,8 @@ class NonequilibriumSwitchingFEP(object):
         lambda_one_alchemical_state = copy.deepcopy(lambda_zero_alchemical_state)
 
         #ensure their states are set appropriately
-        lambda_zero_alchemical_state = self._set_all_parameters_of_state(lambda_zero_alchemical_state, 0.0)
-        lambda_one_alchemical_state = self._set_all_parameters_of_state(lambda_one_alchemical_state, 1.0)
+        lambda_zero_alchemical_state.set_alchemical_parameters(0.0)
+        lambda_one_alchemical_state.set_alchemical_parameters(0.0)
 
         #create the base thermodynamic state with the hybrid system
         self._thermodynamic_state = ThermodynamicState(self._hybrid_system, temperature=temperature)
@@ -393,30 +393,6 @@ class NonequilibriumSwitchingFEP(object):
 
         self._lambda_zero_traj = md.Trajectory(np.array(self._lambda_zero_sampler_state.positions), self._factory.hybrid_topology, unitcell_lengths=[a_0, b_0, c_0], unitcell_angles=[alpha_0, beta_0, gamma_0])
         self._lambda_one_traj = md.Trajectory(np.array(self._lambda_one_sampler_state.positions), self._factory.hybrid_topology, unitcell_lengths=[a_1, b_1, c_1], unitcell_angles=[alpha_1, beta_1, gamma_1])
-
-    def _set_all_parameters_of_state(self, alchemical_state, value):
-        """
-        Set all the parameters of an AlchemicalState object to a specified value.
-
-        Parameters
-        ----------
-        alchemical_state : openmmtools.alchemy.AlchemicalState
-            The alchemical state whose parameters should be set
-        value : float
-            the value to use when setting these parameters
-
-        Returns
-        -------
-        alchemical_state : openmmtools.alchemy.AlchemicalState
-            the alchemical state with parameters set to the new value
-        """
-        alchemical_state.lambda_angles = value
-        alchemical_state.lambda_bonds = value
-        alchemical_state.lambda_torsions = value
-        alchemical_state.lambda_sterics = value
-        alchemical_state.lambda_electrostatics = value
-
-        return alchemical_state
 
     def minimize(self, max_steps=50):
         """

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -653,5 +653,6 @@ if __name__=="__main__":
     #outfile.close()
     ne_fep = NonequilibriumSwitchingFEP(fesetup.solvent_topology_proposal, fesetup.solvent_old_positions, fesetup.solvent_new_positions)
     print("ne-fep initialized")
-    ne_fep.run(n_iterations=1)
+    ne_fep.run(n_iterations=2)
     ne_fep.retrieve_nonequilibrium_results()
+    print("retrieved")

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -633,6 +633,77 @@ class NonequilibriumSwitchingFEP(object):
                 self._reverse_nonequilibrium_cumulative_works.append(cum_work)
                 self._reverse_nonequilibrium_trajectories.append(traj)
 
+    def write_nonequilibrium_trajectories(self, directory, file_prefix):
+        """
+        Write out an MDTraj h5 file for each nonequilibrium trajectory. The files will be placed in
+        [directory]/file_prefix-[forward, reverse]-index.h5. This method will ensure that all pending
+        results are collected.
+
+        Parameters
+        ----------
+        directory : str
+            The directory in which to place the files
+        file_prefix : str
+            A prefix for the filenames
+        """
+        self.retrieve_nonequilibrium_results()
+
+        #loop through the forward trajectories
+        for index, forward_trajectory in enumerate(self._forward_nonequilibrium_trajectories):
+
+            #construct the name for this file
+            full_filename = os.path.join(directory, file_prefix + "forward" + str(index) + ".h5")
+
+            #save the trajectory
+            forward_trajectory.save_hdf5(full_filename)
+
+        #repeat for the reverse trajectories:
+        for index, reverse_trajectory in enumerate(self._reverse_nonequilibrium_trajectories):
+
+            #construct the name for this file
+            full_filename = os.path.join(directory, file_prefix + "reverse" + str(index) + ".h5")
+
+            #save the trajectory
+            reverse_trajectory.save_hdf5(full_filename)
+
+    def write_equilibrium_trajectories(self, directory, file_prefix):
+        """
+        Write out an MDTraj h5 file for each nonequilibrium trajectory. The files will be placed in
+        [directory]/file_prefix-[lambda0, lambda1].h5.
+
+        Parameters
+        ----------
+        directory : str
+            The directory in which to place the files
+        file_prefix : str
+            A prefix for the filenames
+        """
+        
+
+    @property
+    def lambda_zero_equilibrium_trajectory(self):
+        return self._lambda_zero_traj
+
+    @property
+    def lambda_one_equilibrium_trajectory(self):
+        return self._lambda_one_traj
+
+    @property
+    def forward_nonequilibrium_trajectories(self):
+        return self._forward_nonequilibrium_trajectories
+
+    @property
+    def reverse_nonequilibrium_trajectories(self):
+        return self._reverse_nonequilibrium_trajectories
+
+    @property
+    def forward_cumulative_works(self):
+        return self._forward_nonequilibrium_cumulative_works
+
+    @property
+    def reverse_cumulative_works(self):
+        return self._reverse_nonequilibrium_cumulative_works
+
     @property
     def current_free_energy_estimate(self):
         [df, ddf] = pymbar.BAR(self._forward_total_work, self._reverse_total_work)

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -711,7 +711,6 @@ class NonequilibriumSwitchingFEP(object):
 
 if __name__=="__main__":
     #import os
-    #outfile = open("fesetup.pkl", 'wb')
     #gaff_filename = get_data_filename("data/gaff.xml")
     #forcefield_files = [gaff_filename, 'tip3p.xml', 'amber99sbildn.xml']
     #path_to_schrodinger_inputs = "/Users/grinawap/Downloads"

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -1,6 +1,8 @@
 from perses.distributed import feptasks
 from openmmtools.integrators import AlchemicalNonequilibriumLangevinIntegrator, LangevinIntegrator
 from openmmtools.states import ThermodynamicState
+import openmmtools.mcmc as mcmc
+import openmmtools.cache as cache
 import pymbar
 import simtk.openmm as openmm
 import simtk.openmm.app as app
@@ -17,6 +19,110 @@ import copy
 import mdtraj as md
 from io import StringIO
 from openmmtools.constants import kB
+
+class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
+    """
+    This class represents an MCMove that runs a nonequilibrium switching protocol using the AlchemicalNonequilibriumLangevinIntegrator.
+    It is simply a wrapper around the aforementioned integrator, which must be provided in the constructor.
+
+    Parameters
+    ----------
+    n_steps : int
+        The number of integration steps to take each time the move is applied.
+    integrator : openmmtools.integrators.AlchemicalNonequilibriumLangevinIntegrator
+        The integrator that will be used for the nonequilibrium switching.
+    context_cache : openmmtools.cache.ContextCache, optional
+        The ContextCache to use for Context creation. If None, the global cache
+        openmmtools.cache.global_context_cache is used (default is None).
+    reassign_velocities : bool, optional
+        If True, the velocities will be reassigned from the Maxwell-Boltzmann
+        distribution at the beginning of the move (default is False).
+    restart_attempts : int, optional
+        When greater than 0, if after the integration there are NaNs in energies,
+        the move will restart. When the integrator has a random component, this
+        may help recovering. An IntegratorMoveError is raised after the given
+        number of attempts if there are still NaNs.
+
+    Attributes
+    ----------
+    n_steps : int
+    context_cache : openmmtools.cache.ContextCache
+    reassign_velocities : bool
+    restart_attempts : int or None
+    current_total_work : float
+    """
+
+    def __init__(self, integrator, n_steps, **kwargs):
+        super(NonequilibriumSwitchingMove, self).__init__(n_steps, **kwargs)
+        self._integrator = integrator
+        self._current_total_work = 0.0
+
+    def _get_integrator(self, thermodynamic_state):
+        """
+        Get the integrator associated with this move. In this case, it is simply the integrator passed in to the constructor.
+
+        Parameters
+        ----------
+        thermodynamic_state : openmmtools.states.ThermodynamicState
+            thermodynamic state; unused here.
+
+        Returns
+        -------
+        integrator : openmmtools.integrators.AlchemicalNonequilibriumLangevinIntegrator
+            The integrator that is associated with this MCMove
+        """
+        return self._integrator
+
+    def reset(self, thermodynamic_state):
+        """
+        Reset the work statistics on the associated ContextCache integrator.
+
+        Parameters
+        ----------
+        thermodynamic_state : openmmtools.states.ThermodynamicState
+            the thermodynamic state for which this integrator is cached.
+        """
+
+        # Check if we have to use the global cache.
+        if self.context_cache is None:
+            context_cache = cache.global_context_cache
+        else:
+            context_cache = self.context_cache
+
+        #Get the integrator from the context cache
+        context, integrator = context_cache.get_context(thermodynamic_state, self._integrator)
+
+        #Reset the statistics on the integrator
+        integrator.reset()
+
+        #reset the class's own statistics:
+        self._current_total_work = 0.0
+
+    def _after_integration(self, context, thermodynamic_state):
+        """
+        Accumulate the work after n_steps is performed.
+
+        Parameters
+        ----------
+        context : openmm.Context
+            The OpenMM context which is performing the integration
+        thermodynamic_state : openmmtools.states.ThermodynamicState
+            The relevant thermodynamic state for this context and integrator
+        """
+        integrator = context.getIntegrator()
+        self._current_total_work += integrator.get_total_work(dimensionless=True)
+
+    @property
+    def current_total_work(self):
+        """
+        Get the current total work in kT
+
+        Returns
+        -------
+        current_total_work : float
+            the current total work performed by this move since the last reset()
+        """
+        return self._current_total_work
 
 class NonequilibriumFEPSetup(object):
     """

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -18,6 +18,7 @@ import celery
 from openmoltools import forcefield_generators
 import copy
 import mdtraj as md
+import mdtraj.utils as mdtrajutils
 from io import StringIO
 from openmmtools.constants import kB
 import logging
@@ -386,8 +387,12 @@ class NonequilibriumSwitchingFEP(object):
         self.minimize()
 
         #initialize the trajectories for the lambda 0 and 1 equilibrium simulations
-        self._lambda_zero_traj = md.Trajectory(np.array(self._lambda_zero_sampler_state.positions), self._factory.hybrid_topology)
-        self._lambda_one_traj = md.Trajectory(np.array(self._lambda_one_sampler_state.positions), self._factory.hybrid_topology)
+
+        a_0, b_0, c_0, alpha_0, beta_0, gamma_0 = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(*self._lambda_zero_sampler_state.box_vectors)
+        a_1, b_1, c_1, alpha_1, beta_1, gamma_1 = mdtrajutils.unitcell.box_vectors_to_lengths_and_angles(*self._lambda_one_sampler_state.box_vectors)
+
+        self._lambda_zero_traj = md.Trajectory(np.array(self._lambda_zero_sampler_state.positions), self._factory.hybrid_topology, unitcell_lengths=[a_0, b_0, c_0], unitcell_angles=[alpha_0, beta_0, gamma_0])
+        self._lambda_one_traj = md.Trajectory(np.array(self._lambda_one_sampler_state.positions), self._factory.hybrid_topology, unitcell_lengths=[a_1, b_1, c_1], unitcell_angles=[alpha_1, beta_1, gamma_1])
 
     def _set_all_parameters_of_state(self, alchemical_state, value):
         """

--- a/perses/distributed/relative_setup.py
+++ b/perses/distributed/relative_setup.py
@@ -21,6 +21,7 @@ import mdtraj as md
 from io import StringIO
 from openmmtools.constants import kB
 import logging
+import os
 
 class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
     """
@@ -572,8 +573,8 @@ class NonequilibriumSwitchingFEP(object):
         self._lambda_one_sampler_state, traj_one_result = lambda_one_result.get()
 
         #join the trajectories to the reference trajectories
-        self._lambda_zero_traj = self._lambda_zero_traj.join(traj_zero_result)
-        self._lambda_one_traj = self._lambda_one_traj.join(traj_one_result)
+        self._lambda_zero_traj = self._lambda_zero_traj.join(traj_zero_result, check_topology=False)
+        self._lambda_one_traj = self._lambda_one_traj.join(traj_one_result, check_topology=False)
 
     def _run_nonequilibrium(self, concurrency=1, n_iterations=1):
         """


### PR DESCRIPTION
In this PR, I'm switching the `feptasks.py` tasklets to use the MCMove framework. This will also involve some substantial changes to `relative_setup.py` in order to accommodate the new (and cleaner, I think) API.