### PR TITLE
Check to make sure atom mapping preserves rings

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - parmed # for testing/debugging
     - pdbfixer
     - lxml
+    - networkx >=2.0
 
   run:
     - python
@@ -55,6 +56,7 @@ requirements:
     - parmed # for testing/debugging
     - pdbfixer
     - lxml
+    - networkx >=2.0
 
 test:
   requires:

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -1541,7 +1541,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         return receptor_topology
 
     @staticmethod
-    def _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=None, bond_expr=None, verbose=False, allow_ring_breaking=False):
+    def _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=None, bond_expr=None, verbose=False, allow_ring_breaking=True):
         """
         Given two molecules, returns the mapping of atoms between them using the match with the greatest number of atoms
 
@@ -1835,6 +1835,26 @@ class TwoMoleculeSetProposalEngine(SmallMoleculeSetProposalEngine):
 
     def _propose_molecule(self, system, topology, molecule_smiles, exclude_self=False):
         return self._new_mol_smiles, self._new_mol, 0.0
+
+    @staticmethod
+    def _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=None, bond_expr=None, verbose=False)
+        """
+        Given two molecules, returns the mapping of atoms between them using the match with the greatest number of atoms.
+        Matches that would form or break rings are removed.
+
+        Arguments
+        ---------
+        current_molecule : openeye.oechem.oemol object
+             The current molecule in the sampler
+        proposed_molecule : openeye.oechem.oemol object
+             The proposed new molecule
+
+        Returns
+        -------
+        matches : list of match
+            list of the matches between the molecules
+        """
+        return _get_mol_atom_map(current_molecule, proposed_molecule, atom_expr=None, bond_expr=None, verbose=False, allow_ring_breaking=False)
 
 class NullProposalEngine(SmallMoleculeSetProposalEngine):
     """

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -565,7 +565,7 @@ def test_run_peptide_library_engine():
 
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
-def test_molecular_atom_mapping(initial_smiles="naphthalene", final_smiles="benzene"):
+def test_molecular_atom_mapping():
     """
     Test the creation of atom maps between pairs of molecules from the JACS benchmark set.
 

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -572,13 +572,28 @@ def test_ring_breaking_detection():
     """
     from perses.rjmc.topology_proposal import SmallMoleculeSetProposalEngine
     from perses.tests.utils import createOEMolFromIUPAC
+    from perses.tests.utils import render_atom_mapping
     molecule1 = createOEMolFromIUPAC("naphthalene")
     molecule2 = createOEMolFromIUPAC("benzene")
+
+    # Allow ring breaking
+    new_to_old_atom_map = SmallMoleculeSetProposalEngine._get_mol_atom_map(molecule1, molecule2, allow_ring_breaking=True)
+    if not len(new_to_old_atom_map) > 0:
+        filename = 'mapping-error.png'
+        render_atom_mapping(filename, molecule1, molecule2, new_to_old_atom_map)
+        msg = 'Napthalene -> benzene transformation with allow_ring_breaking=True is not returning a valid mapping\n'
+        msg += 'Wrote atom mapping to %s for inspection; please check this.' % filename
+        msg += str(new_to_old_atom_map)
+        raise Exception(msg)
+
     new_to_old_atom_map = SmallMoleculeSetProposalEngine._get_mol_atom_map(molecule1, molecule2, allow_ring_breaking=False)
-    filename = 'mapping-error.png'
-    from perses.tests.utils import render_atom_mapping    
-    render_atom_mapping(filename, molecule1, molecule2, new_to_old_atom_map)
-    print(new_to_old_atom_map)
+    if not len(new_to_old_atom_map)==0:
+        filename = 'mapping-error.png'
+        render_atom_mapping(filename, molecule1, molecule2, new_to_old_atom_map)
+        msg = 'Napthalene -> benzene transformation with allow_ring_breaking=False is erroneously allowing ring breaking\n'
+        msg += 'Wrote atom mapping to %s for inspection; please check this.' % filename
+        msg += str(new_to_old_atom_map)
+        raise Exception(msg)
 
 def test_molecular_atom_mapping():
     """
@@ -618,7 +633,7 @@ def test_molecular_atom_mapping():
                     msg += 'molecule 1 : %s\n' % oechem.OECreateIsoSmiString(molecule1)
                     msg += 'molecule 2 : %s\n' % oechem.OECreateIsoSmiString(molecule2)
                     msg += 'Wrote atom mapping to %s for inspection; please check this.' % filename
-                    msg += str(atom_map)
+                    msg += str(new_to_old_atom_map)
                     raise Exception(msg)
 
 if __name__ == "__main__":

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -565,6 +565,21 @@ def test_run_peptide_library_engine():
 
     pl_top_proposal = pl_top_library.propose(system, modeller.topology)
 
+def test_ring_breaking_detection():
+    """
+    Test the detection of ring-breaking transformations.
+
+    """
+    from perses.rjmc.topology_proposal import SmallMoleculeSetProposalEngine
+    from perses.tests.utils import createOEMolFromIUPAC
+    molecule1 = createOEMolFromIUPAC("naphthalene")
+    molecule2 = createOEMolFromIUPAC("benzene")
+    new_to_old_atom_map = SmallMoleculeSetProposalEngine._get_mol_atom_map(molecule1, molecule2, allow_ring_breaking=False)
+    filename = 'mapping-error.png'
+    from perses.tests.utils import render_atom_mapping    
+    render_atom_mapping(filename, molecule1, molecule2, new_to_old_atom_map)
+    print(new_to_old_atom_map)
+
 def test_molecular_atom_mapping():
     """
     Test the creation of atom maps between pairs of molecules from the JACS benchmark set.

--- a/setup.py
+++ b/setup.py
@@ -94,5 +94,6 @@ setup(name='perses',
         'numba',
         'parmed',
         'pdbfixer',
+        'networkx',
         ],
       )


### PR DESCRIPTION
Addresses #438 

This took an hour longer than expected to implement because my first idea turned out to be too simplistic to catch the naphthalene -> benzene issue, and the second idea used the [OpenEye tools](https://docs.eyesopen.com/toolkits/python/oechemtk/ring.html#section-ring-cyclic-membership) which aren't able to enumerate all cycles. Instead, I was forced to resort to using [NetworkX to enumerate a cycle basis](https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.cycles.cycle_basis.html?highlight=cycle_basis#networkx.algorithms.cycles.cycle_basis) that should catch all cases we care about.

I've added a corresponding naphthalene -> benzene test to make sure we allow this transformation when `allow_ring_breaking=True` and disallow this transformation when `allow_ring_breaking=False` in `SmallMoleculeSetProposalEngine._get_mol_atom_map()`. The default is now to *disallow* ring breaking.

Disallowing ring-breaking simply removes those matches that permit rings to be altered from the set of allowable matches, so a disallowed mapping may return an empty `dict()`. @pgrinaway might have to raise an exception if you run into an empty map in transformations.
