### PR TITLE
[BUGFIX] Fix lazy computation of equilibrium map

### DIFF
--- a/perses/dispersed/relative_setup.py
+++ b/perses/dispersed/relative_setup.py
@@ -502,7 +502,7 @@ class NonequilibriumSwitchingFEP(object):
                 noneq_trajectory_filenames = [None, None]
 
             #run a round of equilibrium
-            self._equilibrium_results = self._map(feptasks.run_equilibrium, self._equilibrium_results, self._hybrid_thermodynamic_states.values(), eq_mc_move_list, hybrid_topology_list, niterations_per_call_list, atom_indices_to_save_list, equilibrium_trajectory_filenames)
+            self._equilibrium_results = list(self._map(feptasks.run_equilibrium, self._equilibrium_results, self._hybrid_thermodynamic_states.values(), eq_mc_move_list, hybrid_topology_list, niterations_per_call_list, atom_indices_to_save_list, equilibrium_trajectory_filenames))
 
             #get the perturbations to nonalchemical states:
             endpoint_perturbation_results_list.append(self._map(feptasks.compute_nonalchemical_perturbation, self._equilibrium_results, hybrid_factory_list, self._nonalchemical_thermodynamic_states.values(), endpoints))


### PR DESCRIPTION
I really like the added ability to run the `NonequilibriumSwitchingFEP` class locally but found a bug when I was running the code. After debugging I determined that the lazy map call to `feptasks.run_equilibrium` where `self._equilibrium_results` is passed as an argument and returned was disrupting the next lazy map call to `feptasks.run_protocol` which again uses `self._equilibrium_results` as one of its arguments. When the maps are evaluated in the `self._gather step`, the first equilibrium map successfully returns its `endpoint_perturbations`, however the `nonequilibrium_results` was returning an empty list, likely due to it not recognizing that it depends on the `equilibrium_results` and must wait for them. By wrapping a `list` around the first equilibrium map call, this forces the computation of the new `self._equilibrium_results` before the next nonequilibrium map is called, thus fixing the problem for the local implementation. I am now testing to see how this affects dask.