### PR TITLE
Fixing shadow_work and dask gather bug.

### DIFF
--- a/perses/dispersed/feptasks.py
+++ b/perses/dispersed/feptasks.py
@@ -5,17 +5,16 @@ import os
 
 #Add the variables specific to the Alchemical langevin integrator
 cache.global_context_cache.COMPATIBLE_INTEGRATOR_ATTRIBUTES.update({
-    "protocol_work" : 0.0,
-    "Eold" : 0.0,
-    "Enew" : 0.0,
-    "lambda" : 0.0,
-    "nsteps" : 0.0,
-    "step" : 0.0,
-    "n_lambda_steps" : 0.0,
-    "lambda_step" : 0.0
-})
+     "protocol_work" : 0.0,
+     "Eold" : 0.0,
+     "Enew" : 0.0,
+     "lambda" : 0.0,
+     "nsteps" : 0.0,
+     "step" : 0.0,
+     "n_lambda_steps" : 0.0,
+     "lambda_step" : 0.0
+ })
 
-cache.global_context_cache.platform = openmm.Platform.getPlatformByName("OpenCL")
 
 import openmmtools.mcmc as mcmc
 import openmmtools.integrators as integrators
@@ -108,7 +107,7 @@ class NonequilibriumSwitchingMove(mcmc.BaseIntegratorMove):
             The relevant thermodynamic state for this context and integrator
         """
         integrator = context.getIntegrator()
-        self._current_total_work = integrator.get_total_work(dimensionless=True)
+        self._current_total_work = integrator.get_protocol_work(dimensionless=True)
 
     @property
     def current_total_work(self):

--- a/perses/dispersed/relative_setup.py
+++ b/perses/dispersed/relative_setup.py
@@ -387,12 +387,10 @@ class NonequilibriumSwitchingFEP(object):
             The address of the dask scheduler. If None, local will be used.
         """
         if scheduler_address is None:
-            cluster = distributed.LocalCluster()
-            self._client = distributed.Client(cluster)
-            self._map = self._client.map
-            self._gather = self._client.gather
+            self._map = map
+            self._gather = lambda mapped_list: list(mapped_list)
         else:
-            if scheduler_address=='localhost':
+            if scheduler_address == 'localhost':
                 self._client = distributed.Client()
             else:
                 self._client = distributed.Client(scheduler_address)
@@ -556,9 +554,9 @@ class NonequilibriumSwitchingFEP(object):
 
         #after all tasks have been requested, retrieve the results:
         for i in range(n_iterations):
-            nonequilibrium_results = self._gather(nonequilibrium_results_list[i])
+            self._equilibrium_results = self._gather(self._equilibrium_results)
             endpoint_perturbations = self._gather(endpoint_perturbation_results_list[i])
-            #nonequilibrium_results = self._gather(nonequilibrium_results_list[i])
+            nonequilibrium_results = self._gather(nonequilibrium_results_list[i])
 
             for lambda_state in [0,1]:
                 self._reduced_potential_differences[lambda_state].append(endpoint_perturbations[lambda_state])


### PR DESCRIPTION
This PR fixes a large bug we identified last week where multiple calls to [run](https://github.com/choderalab/perses/blob/master/perses/dispersed/relative_setup.py#L512) in `relative_setup.py` leading to integrator errors in [run_protocol](https://github.com/choderalab/perses/blob/master/perses/dispersed/feptasks.py#L144) where `ne_mc_move.apply(thermodynamic_state, sampler_state)` would return near zero work values. Upon debugging this step we found that neither `lambda` nor `step` in the integrator was increasing every time apply was called (over 100 iterations), AFTER the initial [run](https://github.com/choderalab/perses/blob/master/perses/dispersed/relative_setup.py#L512) command. I have validated that this PR fixes this issue on my local linux and lilac setup. This issue was originally raised in #445 but I think this fix is more clear and applicable to both `local` and `distributed` setups.