### PR TITLE
Remove use of no-longer-existing self._forcefield

### DIFF
--- a/perses/dispersed/relative_setup.py
+++ b/perses/dispersed/relative_setup.py
@@ -218,7 +218,7 @@ class NonequilibriumFEPSetup(object):
         print("preparing to add solvent")
         if self._solvate:
             print("preparing to add solvent")
-            modeller.addSolvent(self._forcefield, model=model, padding=self._padding)
+            modeller.addSolvent(self._system_generator._forcefield, model=model, padding=self._padding)
             solvated_topology = modeller.getTopology()
             solvated_positions = modeller.getPositions()
             print("solvent added, parameterizing")


### PR DESCRIPTION
There was a mistake that remained from the previous PR. I eliminated the superfluous forcefield object, but was apparently using it elsewhere. It wasn't caught by the test because the solvated setup is too long to run on travis.