### PR TITLE
Improve alchemical path for atoms being created/destroyed

### DIFF
--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1,3 +1,4 @@
+import sys
 import simtk.openmm as openmm
 import simtk.openmm.app as app
 import simtk.unit as unit
@@ -42,6 +43,8 @@ class HybridTopologyFactory(object):
     """
 
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
+
+    _SYSTEM_EPSILON = sys.float_info.epsilon
 
     def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None):
         """
@@ -1190,7 +1193,7 @@ class HybridTopologyFactory(object):
                 [charge, sigma, epsilon] = old_system_nonbonded_force.getParticleParameters(old_index)
 
                 #add the particle to the hybrid custom sterics and electrostatics.
-                self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, 1.0, 0.0])
+                self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, self._SYSTEM_EPSILON, 0.0])
                 self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0])
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction
@@ -1203,7 +1206,7 @@ class HybridTopologyFactory(object):
                 [charge, sigma, epsilon] = new_system_nonbonded_force.getParticleParameters(new_index)
 
                 #add the particle to the hybrid custom sterics and electrostatics
-                self._hybrid_system_forces['core_sterics_force'].addParticle([1.0, 0.0, sigma, epsilon])
+                self._hybrid_system_forces['core_sterics_force'].addParticle([self._SYSTEM_EPSILON, 0.0, sigma, epsilon])
                 self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge])
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1193,7 +1193,7 @@ class HybridTopologyFactory(object):
                 [charge, sigma, epsilon] = old_system_nonbonded_force.getParticleParameters(old_index)
 
                 #add the particle to the hybrid custom sterics and electrostatics.
-                self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, self._SYSTEM_EPSILON, 0.0])
+                self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, 0.0])
                 self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0])
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction
@@ -1206,7 +1206,7 @@ class HybridTopologyFactory(object):
                 [charge, sigma, epsilon] = new_system_nonbonded_force.getParticleParameters(new_index)
 
                 #add the particle to the hybrid custom sterics and electrostatics
-                self._hybrid_system_forces['core_sterics_force'].addParticle([self._SYSTEM_EPSILON, 0.0, sigma, epsilon])
+                self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, 0.0, sigma, epsilon])
                 self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge])
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction

--- a/perses/dispersed/relative_setup.py
+++ b/perses/dispersed/relative_setup.py
@@ -142,7 +142,7 @@ class NonequilibriumFEPSetup(object):
                 barostat = openmm.MonteCarloBarostat(self._pressure, self._temperature, self._barostat_period)
             else:
                 barostat = None
-            self._system_generator = SystemGenerator(forcefield_files, barostat=barostat, forcefield_kwargs={'nonbondedMethod' : self._nonbonded_method})
+            self._system_generator = SystemGenerator(forcefield_files, barostat=barostat, forcefield_kwargs={'nonbondedMethod' : self._nonbonded_method, 'constraints': app.HBonds})
         else:
             self._system_generator = SystemGenerator(forcefield_files)
 


### PR DESCRIPTION
Instead of switching sigma to 1.0 when it is being turned off, this switches sigma to machine epsilon. It can't be switched to zero, otherwise OpenMM will complain that the number of exceptions is changing. When it is switched to 1.0, it has no effect at the endpoint as long as epsilon is zero; however, it creates a very strange protocol for intermediate states that could be inefficient.

I need to evaluate this to see if that is what happens.