### PR TITLE
[WIP] Exact pme with relative factory

### DIFF
--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1296,7 +1296,12 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics.
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, 0.0])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0])
+
+                if not self._exact_pme:
+                    self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0])
+                else:
+                    self._hybrid_system_forces['hybrid_old_nonbonded_force'].addParticle(charge, 1.0, 0.0) #handle with regular nonbonded force
+                    self._hybrid_system_forces['hybrid_new_nonbonded_force'].addParticle(0.0, 1.0, 0.0) 
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction
                 #it will be handled by an exception
@@ -1309,7 +1314,12 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, 0.0, sigma, epsilon])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge])
+
+                if not self._exact_pme:
+                    self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge])
+                else:
+                    self._hybrid_system_forces['hybrid_old_nonbonded_force'].addParticle(0.0, 1.0, 0.0)
+                    self._hybrid_system_forces['hybrid_new_nonbonded_force'].addParticle(charge, 1.0, 0.0)
 
                 #Add the particle to the regular nonbonded force as required, but zero out interaction
                 #it will be handled by an exception
@@ -1325,7 +1335,12 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the custom forces, interpolating between the two parameters
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma_old, epsilon_old, sigma_new, epsilon_new])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge_old, charge_new])
+
+                if not self._exact_pme:
+                    self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge_old, charge_new])
+                else:
+                    self._hybrid_system_forces['hybrid_old_nonbonded_force'].addParticle(charge_old, 1.0, 0.0)
+                    self._hybrid_system_forces['hybrid_new_nonbonded_force'].addParticle(charge_new, 1.0, 0.0)
 
                 #still add the particle to the regular nonbonded force, but with zeroed out parameters.
                 self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, 1.0, 0.0)

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -45,7 +45,7 @@ class HybridTopologyFactory(object):
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
     _known_softcore_methods = ['default', 'amber', 'classic']
 
-    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='default', softcore_alpha=None, softcore_beta=None):
+    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='default', softcore_alpha=None, softcore_beta=None, exact_pme=False):
         """
         Initialize the Hybrid topology factory.
 
@@ -73,6 +73,9 @@ class HybridTopologyFactory(object):
             "alpha" parameter of softcore sterics. If None is provided, value will be set to 0.5
         softcore_beta: unit, default None
             "beta" parameter of softcore electrostatics. If None is provided, value will be set to 12*unit.angstrom**2
+        exact_pme: bool, default False
+            Whether to use the standard nonbonded force for electrostatics. This has the advantage of resulting in exact PME,
+            but may be considerably slower. Default is false.
         """
         self._topology_proposal = topology_proposal
         self._old_system = copy.deepcopy(topology_proposal.old_system)
@@ -82,6 +85,7 @@ class HybridTopologyFactory(object):
         self._hybrid_system_forces = dict()
         self._old_positions = current_positions
         self._new_positions = new_positions
+        self._exact_pme = exact_pme
 
         self._use_dispersion_correction = use_dispersion_correction
         

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -673,26 +673,25 @@ class HybridTopologyFactory(object):
             standard_nonbonded_force.setReactionFieldDielectric(epsilon_solvent)
             standard_nonbonded_force.setCutoffDistance(r_cutoff)
         elif self._nonbonded_method in [openmm.NonbondedForce.PME, openmm.NonbondedForce.Ewald]:
+            [alpha_ewald, nx, ny, nz] = self._old_system_forces['NonbondedForce'].getPMEParameters()
+            delta = self._old_system_forces['NonbondedForce'].getEwaldErrorTolerance()
+            r_cutoff = self._old_system_forces['NonbondedForce'].getCutoffDistance()
+            sterics_energy_expression, electrostatics_energy_expression = self._nonbonded_custom_ewald(alpha_ewald, delta, r_cutoff)
             if self._exact_pme:
                 hybrid_old_nonbonded_force = openmm.NonbondedForce()
                 hybrid_new_nonbonded_force = openmm.NonbondedForce() #these will handle electrostatics only for exact PME
-            else:
-                [alpha_ewald, nx, ny, nz] = self._old_system_forces['NonbondedForce'].getPMEParameters()
-                delta = self._old_system_forces['NonbondedForce'].getEwaldErrorTolerance()
-                r_cutoff = self._old_system_forces['NonbondedForce'].getCutoffDistance()
-                sterics_energy_expression, electrostatics_energy_expression = self._nonbonded_custom_ewald(alpha_ewald, delta, r_cutoff)
-                if not self._exact_pme:
-                    standard_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
-                    standard_nonbonded_force.setEwaldErrorTolerance(delta)
-                    standard_nonbonded_force.setCutoffDistance(r_cutoff)
-                else:
-                    hybrid_old_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
-                    hybrid_old_nonbonded_force.setEwaldErrorTolerance(delta)
-                    hybrid_old_nonbonded_force.setCutoffDistance(r_cutoff)
+                hybrid_old_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
+                hybrid_old_nonbonded_force.setEwaldErrorTolerance(delta)
+                hybrid_old_nonbonded_force.setCutoffDistance(r_cutoff)
 
-                    hybrid_new_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
-                    hybrid_new_nonbonded_force.setEwaldErrorTolerance(delta)
-                    hybrid_new_nonbonded_force.setCutoffDistance(r_cutoff)
+                hybrid_new_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
+                hybrid_new_nonbonded_force.setEwaldErrorTolerance(delta)
+                hybrid_new_nonbonded_force.setCutoffDistance(r_cutoff)
+
+            else:
+                standard_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
+                standard_nonbonded_force.setEwaldErrorTolerance(delta)
+                standard_nonbonded_force.setCutoffDistance(r_cutoff)
 
         else:
             raise Exception("Nonbonded method %s not supported yet." % str(self._nonbonded_method))


### PR DESCRIPTION
This implements what was being discussed in #468 . There is an additional option, `exact_pme`, which results in the electrostatics being split into two `NonbondedForces`, one with the parameters for systemA, and the other with parameters for systemB. With the exception (no pun intended) of sterics for intra-unique interactions, these forces zero out the sterics, as this is still handled by a `CustomNonbondedForce`. The two `NonbondedForce`s are then added to a `CustomCVForce` with the same `lambda_electrostatics` parameter as before. This is marked WIP because I need to enable tests for this new arrangement and see if I messed anything up.