### PR TITLE
[WIP] Modifications to use new 'offset' OpenMM feature for nonbonded electrostatics

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
-    - openmm >=7.2.0
+    - openmm >=7.3.0
     - parmed
     - openmoltools
     - alchemy >=1.2.3
@@ -43,7 +43,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
-    - openmm >=7.2.0
+    - openmm >=7.3.0
     - parmed
     - openmoltools
     - alchemy >=1.2.3

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
-    - openmm >=7.3.0
+    - openmm ==7.3.0
     - parmed
     - openmoltools
     - alchemy >=1.2.3
@@ -43,7 +43,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
-    - openmm >=7.3.0
+    - openmm ==7.3.0
     - parmed
     - openmoltools
     - alchemy >=1.2.3

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -18,6 +18,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
+    - cuda92
     - openmm ==7.3.0
     - parmed
     - openmoltools
@@ -43,6 +44,7 @@ requirements:
     - numexpr
     - autograd
     - pymbar
+    - cuda92
     - openmm ==7.3.0
     - parmed
     - openmoltools

--- a/examples/cdk2-example/cdk2_setup.yaml
+++ b/examples/cdk2-example/cdk2_setup.yaml
@@ -13,8 +13,8 @@ new_ligand_index: 15
 #be provided with a full path
 forcefield_files:
     - gaff.xml
-    - amber99sbildn.xml
-    - tip3p.xml
+    - amber14/protein.ff14SB.xml
+    - amber14/tip3p.xml
 
 #the temperature and pressure of the simulation, as well as how much solvent paddding to add
 #units:
@@ -31,7 +31,9 @@ save_setup_pickle_as: fesetup_hbonds.pkl
 
 #the type of free energy calculation.
 #currently, this could be either nonequilibrium or sams
-fe_type: nonequilibrium
+fe_type: sams
+
+n_states: 100
 
 #the forward switching functions. The reverse ones will be computed from this. Only valid for nonequilibrium switching
 forward_functions:
@@ -42,17 +44,17 @@ forward_functions:
     lambda_torsions: lambda
 
 #the number of equilibration iterations:
-n_equilibration_iterations: 100
+n_equilibration_iterations: 10
 
 #The number of equilibrium steps to take between nonequilibrium switching events (only valid for nonequiibrium switching)
-n_equilibrium_steps_per_iteration: 100
+n_equilibrium_steps_per_iteration: 1000
 
 #The length of the ncmc protocol (only valid for nonequilibrium switching)
 n_steps_ncmc_protocol: 50
 
 #The number of NCMC steps per move application. This controls the output frequency
 #1 step/move application means writing out the work at every step. (only valid for nonequilibrium switching)
-n_steps_per_move_application: 10
+n_steps_per_move_application: 2500
 
 #where to put the trajectories
 trajectory_directory: cdk2_neq_hbonds
@@ -66,6 +68,7 @@ atom_selection: not water
 #which phases do we want to run (solvent, complex, or both solvent and complex in the list are acceptable):
 phases:
     - solvent
+    - complex
 
 #timestep in fs
 timestep: 1.0
@@ -83,5 +86,5 @@ measure_shadow_work: True
 scheduler_address: null
 
 #how many iterations to run (n_cycles*n_iterations_per_cycle) (only valid for nonequilibrium switching)
-n_cycles: 5
+n_cycles: 10000
 n_iterations_per_cycle: 1

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -45,7 +45,7 @@ class HybridTopologyFactory(object):
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
     _known_softcore_methods = ['default', 'amber', 'classic']
 
-    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='amber', softcore_alpha=None, softcore_beta=None, annihilate_intraunique_charges=True):
+    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='amber', softcore_alpha=None, softcore_beta=None):
         """
         Initialize the Hybrid topology factory.
 
@@ -73,8 +73,6 @@ class HybridTopologyFactory(object):
             "alpha" parameter of softcore sterics. If None is provided, value will be set to 0.5
         softcore_beta: unit, default None
             "beta" parameter of softcore electrostatics. If None is provided, value will be set to 12*unit.angstrom**2
-        annihilate_intraunique_charges: bool, optional, default False
-            If True, unique old/new atoms will be discharged as part of the switching process
 
         """
         self._topology_proposal = topology_proposal
@@ -87,7 +85,6 @@ class HybridTopologyFactory(object):
         self._new_positions = new_positions
 
         self._use_dispersion_correction = use_dispersion_correction
-        self._annihilate_intraunique_charges = annihilate_intraunique_charges
 
         if softcore_alpha is None:
             self.softcore_alpha = 0.5
@@ -1328,16 +1325,14 @@ class HybridTopologyFactory(object):
             #now we check if the pair is in the exception dictionary
             if old_index_atom_pair in self._old_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._old_system_exceptions[old_index_atom_pair]
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
             #check if the pair is in the reverse order and use that if so
             elif old_index_atom_pair[::-1] in self._old_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._old_system_exceptions[old_index_atom_pair[::-1]]
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
@@ -1346,8 +1341,7 @@ class HybridTopologyFactory(object):
                 [charge0, sigma0, epsilon0] = self._old_system_forces['NonbondedForce'].getParticleParameters(old_index_atom_pair[0])
                 [charge1, sigma1, epsilon1] = self._old_system_forces['NonbondedForce'].getParticleParameters(old_index_atom_pair[1])
                 chargeProd = charge0*charge1
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 epsilon = unit.sqrt(epsilon0*epsilon1)
                 sigma = 0.5*(sigma0+sigma1)
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
@@ -1361,16 +1355,14 @@ class HybridTopologyFactory(object):
             #now we check if the pair is in the exception dictionary
             if new_index_atom_pair in self._new_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._new_system_exceptions[new_index_atom_pair]
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
             #check if the pair is present in the reverse order and use that if so
             elif new_index_atom_pair[::-1] in self._new_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._new_system_exceptions[new_index_atom_pair[::-1]]
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
@@ -1379,8 +1371,7 @@ class HybridTopologyFactory(object):
                 [charge0, sigma0, epsilon0] = self._new_system_forces['NonbondedForce'].getParticleParameters(new_index_atom_pair[0])
                 [charge1, sigma1, epsilon1] = self._new_system_forces['NonbondedForce'].getParticleParameters(new_index_atom_pair[1])
                 chargeProd = charge0*charge1
-                if self._annihilate_intraunique_charges:
-                    chargeProd *= 0.0
+                chargeProd *= 0.0
                 epsilon = unit.sqrt(epsilon0*epsilon1)
                 sigma = 0.5*(sigma0+sigma1)
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -45,7 +45,7 @@ class HybridTopologyFactory(object):
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
     _known_softcore_methods = ['default', 'amber', 'classic']
 
-    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='default', softcore_alpha=None, softcore_beta=None, annihilate_intraunique_charges=False):
+    def __init__(self, topology_proposal, current_positions, new_positions, use_dispersion_correction=False, functions=None, softcore_method='default', softcore_alpha=None, softcore_beta=None, annihilate_intraunique_charges=True):
         """
         Initialize the Hybrid topology factory.
 

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -928,7 +928,8 @@ class HybridTopologyFactory(object):
         if self._has_functions:
             sterics_energy_expression += 'lambda_sterics = ' + self._functions['lambda_sterics']
             electrostatics_energy_expression += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
-        custom_bond_force = openmm.CustomBondForce("U_sterics + U_electrostatics;" + sterics_energy_expression + electrostatics_energy_expression)
+        #custom_bond_force = openmm.CustomBondForce("U_sterics + U_electrostatics;" + sterics_energy_expression + electrostatics_energy_expression)
+        custom_bond_force = openmm.CustomBondForce("U_sterics;" + sterics_energy_expression + electrostatics_energy_expression) # DEBUG
         custom_bond_force.addGlobalParameter("softcore_alpha", self.softcore_alpha)
         custom_bond_force.addGlobalParameter("softcore_beta", self.softcore_beta)
         custom_bond_force.addPerBondParameter("chargeprodA")

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1457,7 +1457,7 @@ class HybridTopologyFactory(object):
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
 
             #otherwise, check if one of the atoms in the set is in the unique_old_group:
-            elif len(index_set.intersection(self._atom_classes['unique_old_atoms'])) > 0:
+            elif len(index_set.intersection(self._atom_classes['unique_old_atoms'])) == 1:
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
 

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -87,6 +87,7 @@ class HybridTopologyFactory(object):
         self._new_positions = new_positions
 
         self._use_dispersion_correction = use_dispersion_correction
+        self._annihilate_intraunique_charges = annihilate_intraunique_charges
 
         if softcore_alpha is None:
             self.softcore_alpha = 0.5
@@ -1367,12 +1368,16 @@ class HybridTopologyFactory(object):
             #now we check if the pair is in the exception dictionary
             if old_index_atom_pair in self._old_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._old_system_exceptions[old_index_atom_pair]
+                if self._annihilate_intraunique_charges:
+                    chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
             #check if the pair is in the reverse order and use that if so
             elif old_index_atom_pair[::-1] in self._old_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._old_system_exceptions[old_index_atom_pair[::-1]]
+                if self._annihilate_intraunique_charges:
+                    chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
@@ -1381,7 +1386,7 @@ class HybridTopologyFactory(object):
                 [charge0, sigma0, epsilon0] = self._old_system_forces['NonbondedForce'].getParticleParameters(old_index_atom_pair[0])
                 [charge1, sigma1, epsilon1] = self._old_system_forces['NonbondedForce'].getParticleParameters(old_index_atom_pair[1])
                 chargeProd = charge0*charge1
-                if self.annihilate_intraunique_charges:
+                if self._annihilate_intraunique_charges:
                     chargeProd *= 0.0
                 epsilon = unit.sqrt(epsilon0*epsilon1)
                 sigma = 0.5*(sigma0+sigma1)
@@ -1396,12 +1401,16 @@ class HybridTopologyFactory(object):
             #now we check if the pair is in the exception dictionary
             if new_index_atom_pair in self._new_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._new_system_exceptions[new_index_atom_pair]
+                if self._annihilate_intraunique_charges:
+                    chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
             #check if the pair is present in the reverse order and use that if so
             elif new_index_atom_pair[::-1] in self._new_system_exceptions:
                 [chargeProd, sigma, epsilon] = self._new_system_exceptions[new_index_atom_pair[::-1]]
+                if self._annihilate_intraunique_charges:
+                    chargeProd *= 0.0
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(atom_pair[0], atom_pair[1], chargeProd, sigma, epsilon)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(atom_pair[0], atom_pair[1]) # add exclusion to ensure exceptions are consistent
 
@@ -1410,7 +1419,7 @@ class HybridTopologyFactory(object):
                 [charge0, sigma0, epsilon0] = self._new_system_forces['NonbondedForce'].getParticleParameters(new_index_atom_pair[0])
                 [charge1, sigma1, epsilon1] = self._new_system_forces['NonbondedForce'].getParticleParameters(new_index_atom_pair[1])
                 chargeProd = charge0*charge1
-                if self.annihilate_intraunique_charges:
+                if self._annihilate_intraunique_charges:
                     chargeProd *= 0.0
                 epsilon = unit.sqrt(epsilon0*epsilon1)
                 sigma = 0.5*(sigma0+sigma1)

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -1456,7 +1456,11 @@ class HybridTopologyFactory(object):
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
 
-            #otherwise, check if one of the atoms in the set is in the unique_old_group:
+            #we have already handled unique old - unique old exceptions
+            elif len(index_set.intersection(self._atom_classes['unique_old_atoms'])) == 2:
+                continue
+
+            #otherwise, check if one of the atoms in the set is in the unique_old_group and the other is not:
             elif len(index_set.intersection(self._atom_classes['unique_old_atoms'])) == 1:
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -700,33 +700,6 @@ class HybridTopologyFactory(object):
 
         custom_nonbonded_method = self._translate_nonbonded_method_to_custom(self._nonbonded_method)
 
-        # TODO: Delete
-        # Create CustomNonbondedForce to handle interactions between alchemically-modified atoms and rest of system.
-        #total_electrostatics_energy = "U_electrostatics;" + electrostatics_energy_expression + electrostatics_mixing_rules
-        #if self._has_functions:
-        #    try:
-        #        total_electrostatics_energy += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
-        #    except KeyError as e:
-        #        print("Functions were provided, but there is no entry for electrostatics")
-        #        raise e
-
-        #electrostatics_custom_nonbonded_force = openmm.CustomNonbondedForce(total_electrostatics_energy)
-        #electrostatics_custom_nonbonded_force.addGlobalParameter("softcore_beta", self.softcore_beta)
-        #electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeA") # partial charge initial
-        #electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeB") # partial charge final
-
-        #if self._has_functions:
-        #    electrostatics_custom_nonbonded_force.addGlobalParameter("lambda", 0.0)
-        #    electrostatics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
-        #else:
-        #    electrostatics_custom_nonbonded_force.addGlobalParameter("lambda_electrostatics", 0.0)
-
-
-        #electrostatics_custom_nonbonded_force.setNonbondedMethod(custom_nonbonded_method)
-
-        #self._hybrid_system.addForce(electrostatics_custom_nonbonded_force)
-        #self._hybrid_system_forces['core_electrostatics_force'] = electrostatics_custom_nonbonded_force
-
         total_sterics_energy = "U_sterics;" + sterics_energy_expression + sterics_mixing_rules
         if self._has_functions:
             try:
@@ -768,18 +741,9 @@ class HybridTopologyFactory(object):
             standard_nonbonded_force.setSwitchingDistance(switching_distance)
             sterics_custom_nonbonded_force.setUseSwitchingFunction(True)
             sterics_custom_nonbonded_force.setSwitchingDistance(switching_distance)
-            #electrostatics_custom_nonbonded_force.setUseSwitchingFunction(True) # TODO: Delete
-            #electrostatics_custom_nonbonded_force.setSwitchingDistance(switching_distance) # TODO: Delete
         else:
             standard_nonbonded_force.setUseSwitchingFunction(False)
-            #electrostatics_custom_nonbonded_force.setUseSwitchingFunction(False) # TODO: Delete
             sterics_custom_nonbonded_force.setUseSwitchingFunction(False)
-
-        # TODO: Delete
-        #Add a CustomBondForce for exceptions:
-        #custom_nonbonded_bond_force = self._nonbonded_custom_bond_force(sterics_energy_expression, electrostatics_energy_expression)
-        #self._hybrid_system.addForce(custom_nonbonded_bond_force)
-        #self._hybrid_system_forces['core_nonbonded_bond_force'] = custom_nonbonded_bond_force
 
     def _nonbonded_custom_sterics_common(self):
         """
@@ -961,8 +925,6 @@ class HybridTopologyFactory(object):
             sterics_energy_expression += 'lambda_sterics = ' + self._functions['lambda_sterics']
             electrostatics_energy_expression += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
         custom_bond_force = openmm.CustomBondForce("U_sterics + U_electrostatics;" + sterics_energy_expression + electrostatics_energy_expression)
-        #custom_bond_force.addGlobalParameter("lambda_electrostatics", 0.0)
-        #custom_bond_force.addGlobalParameter("lambda_sterics", 0.0)
         custom_bond_force.addGlobalParameter("softcore_alpha", self.softcore_alpha)
         custom_bond_force.addGlobalParameter("softcore_beta", self.softcore_beta)
         custom_bond_force.addPerBondParameter("chargeprodA")
@@ -1261,7 +1223,6 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics.
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, 0.0])
-                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0]) # TODO: Remove once core_electrostatics_force is eliminated
 
                 # Add particle to the regular nonbonded force, but Lennard-Jones will be handled by CustomNonbondedForce
                 particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge, sigma, 0.0)
@@ -1275,7 +1236,6 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, 0.0, sigma, epsilon])
-                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge]) # TODO: Remove once core_electrostatics_force is eliminated
 
                 # Add particle to the regular nonbonded force, but Lennard-Jones will be handled by CustomNonbondedForce
                 particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, sigma, 0.0)
@@ -1291,7 +1251,6 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the custom forces, interpolating between the two parameters
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma_old, epsilon_old, sigma_new, epsilon_new])
-                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge_old, charge_new])
 
                 #still add the particle to the regular nonbonded force, but with zeroed out parameters.
                 particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge_old, 0.5*(sigma_old+sigma_new), 0.0)
@@ -1307,7 +1266,6 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics, but they dont change
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, epsilon])
-                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, charge]) # TODO: Remove once core_electrostatics_force is eliminated
 
                 #add the environment atoms to the regular nonbonded force as well:
                 self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge, sigma, epsilon)
@@ -1355,7 +1313,6 @@ class HybridTopologyFactory(object):
         Must be called after particles are added to the Nonbonded forces
         """
         #get the force objects for convenience:
-        #electrostatics_custom_force = self._hybrid_system_forces['core_electrostatics_force'] # TODO: Delete
         sterics_custom_force = self._hybrid_system_forces['core_sterics_force']
 
         #also prepare the atom classes
@@ -1365,22 +1322,16 @@ class HybridTopologyFactory(object):
         environment_atoms = self._atom_classes['environment_atoms']
 
 
-        #electrostatics_custom_force.addInteractionGroup(unique_old_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_old_atoms, core_atoms)
 
-        #electrostatics_custom_force.addInteractionGroup(unique_old_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_old_atoms, environment_atoms)
 
-        #electrostatics_custom_force.addInteractionGroup(unique_new_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_new_atoms, core_atoms)
 
-        #electrostatics_custom_force.addInteractionGroup(unique_new_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_new_atoms, environment_atoms)
 
-        #electrostatics_custom_force.addInteractionGroup(core_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(core_atoms, environment_atoms)
 
-        #electrostatics_custom_force.addInteractionGroup(core_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(core_atoms, core_atoms)
 
     def _handle_original_exceptions(self):
@@ -1413,14 +1364,6 @@ class HybridTopologyFactory(object):
 
             #otherwise, check if one of the atoms in the set is in the unique_old_group:
             elif len(index_set.intersection(self._atom_classes['unique_old_atoms'])) > 0:
-                #if it is, we should add it to the CustomBondForce for the nonbonded exceptions, and have it remain on
-                #by having the two endpoints with the same parameters.
-                #Currently, we keep sigma at the same value
-                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
-                #                                                                 [chargeProd_old, sigma_old,
-                #                                                                  epsilon_old, chargeProd_old,
-                #                                                                  sigma_old, epsilon_old])
-
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
 
@@ -1435,11 +1378,7 @@ class HybridTopologyFactory(object):
                 [index1_new, index2_new, chargeProd_new, sigma_new, epsilon_new] = self._find_exception(
                     new_system_nonbonded_force, index1_new, index2_new)
 
-                #Now add a term to the CustomBondForce to interpolate between the new and old systems:
-                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
-                #                                                                 [chargeProd_old, sigma_old,
-                #                                                                  epsilon_old, chargeProd_new,
-                #                                                                  sigma_new, epsilon_new])
+                #interpolate between old and new
                 exception_index = self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
                 self._hybrid_system_forces['standard_nonbonded_force'].addExceptionParameterOffset('lambda_electrostatics', exception_index, (chargeProd_new - chargeProd_old), 0, 0)
                 self._hybrid_system_forces['standard_nonbonded_force'].addExceptionParameterOffset('lambda_sterics', exception_index, 0, (sigma_new - sigma_old), (epsilon_new - epsilon_old))
@@ -1464,10 +1403,6 @@ class HybridTopologyFactory(object):
             #look for the final class- interactions between uniquenew-core and uniquenew-environment. They are treated
             #similarly: they are simply on and constant the entire time (as a valence term)
             elif len(index_set.intersection(self._atom_classes['unique_new_atoms'])) > 0:
-                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
-                #                                                                 [chargeProd_new, sigma_new,
-                #                                                                  epsilon_new, chargeProd_new,
-                #                                                                  sigma_new, epsilon_new])
                 self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_new, sigma_new, epsilon_new)
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
 

--- a/perses/annihilation/new_relative.py
+++ b/perses/annihilation/new_relative.py
@@ -84,17 +84,17 @@ class HybridTopologyFactory(object):
         self._new_positions = new_positions
 
         self._use_dispersion_correction = use_dispersion_correction
-        
+
         if softcore_alpha is None:
             self.softcore_alpha = 0.5
         else:
             self.softcore_alpha = softcore_alpha
-        
+
         if softcore_beta is None:
             self.softcore_beta = 12*unit.angstrom**2
         else:
             self.softcore_beta = softcore_beta
-        
+
         if softcore_method not in self._known_softcore_methods:
             raise ValueError("Softcore method {} is not a valid method. Acceptable options are default, amber, and classic".format(softcore_method))
 
@@ -700,31 +700,32 @@ class HybridTopologyFactory(object):
 
         custom_nonbonded_method = self._translate_nonbonded_method_to_custom(self._nonbonded_method)
 
+        # TODO: Delete
         # Create CustomNonbondedForce to handle interactions between alchemically-modified atoms and rest of system.
-        total_electrostatics_energy = "U_electrostatics;" + electrostatics_energy_expression + electrostatics_mixing_rules
-        if self._has_functions:
-            try:
-                total_electrostatics_energy += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
-            except KeyError as e:
-                print("Functions were provided, but there is no entry for electrostatics")
-                raise e
+        #total_electrostatics_energy = "U_electrostatics;" + electrostatics_energy_expression + electrostatics_mixing_rules
+        #if self._has_functions:
+        #    try:
+        #        total_electrostatics_energy += 'lambda_electrostatics = ' + self._functions['lambda_electrostatics']
+        #    except KeyError as e:
+        #        print("Functions were provided, but there is no entry for electrostatics")
+        #        raise e
 
-        electrostatics_custom_nonbonded_force = openmm.CustomNonbondedForce(total_electrostatics_energy)
-        electrostatics_custom_nonbonded_force.addGlobalParameter("softcore_beta", self.softcore_beta)
-        electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeA") # partial charge initial
-        electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeB") # partial charge final
+        #electrostatics_custom_nonbonded_force = openmm.CustomNonbondedForce(total_electrostatics_energy)
+        #electrostatics_custom_nonbonded_force.addGlobalParameter("softcore_beta", self.softcore_beta)
+        #electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeA") # partial charge initial
+        #electrostatics_custom_nonbonded_force.addPerParticleParameter("chargeB") # partial charge final
 
-        if self._has_functions:
-            electrostatics_custom_nonbonded_force.addGlobalParameter("lambda", 0.0)
-            electrostatics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
-        else:
-            electrostatics_custom_nonbonded_force.addGlobalParameter("lambda_electrostatics", 0.0)
+        #if self._has_functions:
+        #    electrostatics_custom_nonbonded_force.addGlobalParameter("lambda", 0.0)
+        #    electrostatics_custom_nonbonded_force.addEnergyParameterDerivative('lambda')
+        #else:
+        #    electrostatics_custom_nonbonded_force.addGlobalParameter("lambda_electrostatics", 0.0)
 
 
-        electrostatics_custom_nonbonded_force.setNonbondedMethod(custom_nonbonded_method)
+        #electrostatics_custom_nonbonded_force.setNonbondedMethod(custom_nonbonded_method)
 
-        self._hybrid_system.addForce(electrostatics_custom_nonbonded_force)
-        self._hybrid_system_forces['core_electrostatics_force'] = electrostatics_custom_nonbonded_force
+        #self._hybrid_system.addForce(electrostatics_custom_nonbonded_force)
+        #self._hybrid_system_forces['core_electrostatics_force'] = electrostatics_custom_nonbonded_force
 
         total_sterics_energy = "U_sterics;" + sterics_energy_expression + sterics_mixing_rules
         if self._has_functions:
@@ -767,17 +768,18 @@ class HybridTopologyFactory(object):
             standard_nonbonded_force.setSwitchingDistance(switching_distance)
             sterics_custom_nonbonded_force.setUseSwitchingFunction(True)
             sterics_custom_nonbonded_force.setSwitchingDistance(switching_distance)
-            electrostatics_custom_nonbonded_force.setUseSwitchingFunction(True)
-            electrostatics_custom_nonbonded_force.setSwitchingDistance(switching_distance)
+            #electrostatics_custom_nonbonded_force.setUseSwitchingFunction(True) # TODO: Delete
+            #electrostatics_custom_nonbonded_force.setSwitchingDistance(switching_distance) # TODO: Delete
         else:
             standard_nonbonded_force.setUseSwitchingFunction(False)
-            electrostatics_custom_nonbonded_force.setUseSwitchingFunction(False)
+            #electrostatics_custom_nonbonded_force.setUseSwitchingFunction(False) # TODO: Delete
             sterics_custom_nonbonded_force.setUseSwitchingFunction(False)
 
+        # TODO: Delete
         #Add a CustomBondForce for exceptions:
-        custom_nonbonded_bond_force = self._nonbonded_custom_bond_force(sterics_energy_expression, electrostatics_energy_expression)
-        self._hybrid_system.addForce(custom_nonbonded_bond_force)
-        self._hybrid_system_forces['core_nonbonded_bond_force'] = custom_nonbonded_bond_force
+        #custom_nonbonded_bond_force = self._nonbonded_custom_bond_force(sterics_energy_expression, electrostatics_energy_expression)
+        #self._hybrid_system.addForce(custom_nonbonded_bond_force)
+        #self._hybrid_system_forces['core_nonbonded_bond_force'] = custom_nonbonded_bond_force
 
     def _nonbonded_custom_sterics_common(self):
         """
@@ -1259,11 +1261,12 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics.
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, 0.0])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0])
+                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, 0.0]) # TODO: Remove once core_electrostatics_force is eliminated
 
-                #Add the particle to the regular nonbonded force as required, but zero out interaction
-                #it will be handled by an exception
-                self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, 1.0, 0.0)
+                # Add particle to the regular nonbonded force, but Lennard-Jones will be handled by CustomNonbondedForce
+                particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge, sigma, 0.0)
+                # Charge will be turned on at lambda_electrostatics = 0, off at lambda_electrostatics = 1
+                self._hybrid_system_forces['standard_nonbonded_force'].addParticleParameterOffset('lambda_electrostatics', particle_index, -charge, 0, 0)
 
             elif particle_index in self._atom_classes['unique_new_atoms']:
                 #get the parameters in the new system
@@ -1272,12 +1275,12 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, 0.0, sigma, epsilon])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge])
+                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([0.0, charge]) # TODO: Remove once core_electrostatics_force is eliminated
 
-                #Add the particle to the regular nonbonded force as required, but zero out interaction
-                #it will be handled by an exception
-                self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, 1.0, 0.0)
-
+                # Add particle to the regular nonbonded force, but Lennard-Jones will be handled by CustomNonbondedForce
+                particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, sigma, 0.0)
+                # Charge will be turned off at lambda_electrostatics = 0, on at lambda_electrostatics = 1
+                self._hybrid_system_forces['standard_nonbonded_force'].addParticleParameterOffset('lambda_electrostatics', particle_index, +charge, 0, 0)
 
             elif particle_index in self._atom_classes['core_atoms']:
                 #get the parameters in the new and old systems:
@@ -1288,10 +1291,13 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the custom forces, interpolating between the two parameters
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma_old, epsilon_old, sigma_new, epsilon_new])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge_old, charge_new])
+                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge_old, charge_new])
 
                 #still add the particle to the regular nonbonded force, but with zeroed out parameters.
-                self._hybrid_system_forces['standard_nonbonded_force'].addParticle(0.0, 1.0, 0.0)
+                particle_index = self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge_old, 0.5*(sigma_old+sigma_new), 0.0)
+                # Charge is charge_old at lambda_electrostatics = 0, charge_new at lambda_electrostatics = 1
+                # TODO: We could also interpolate the Lennard-Jones here instead of core_sterics force so that core_sterics_force could just be softcore
+                self._hybrid_system_forces['standard_nonbonded_force'].addParticleParameterOffset('lambda_electrostatics', particle_index, (charge_new - charge_old), 0, 0)
 
             #otherwise, the particle is in the environment
             else:
@@ -1301,13 +1307,13 @@ class HybridTopologyFactory(object):
 
                 #add the particle to the hybrid custom sterics and electrostatics, but they dont change
                 self._hybrid_system_forces['core_sterics_force'].addParticle([sigma, epsilon, sigma, epsilon])
-                self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, charge])
+                #self._hybrid_system_forces['core_electrostatics_force'].addParticle([charge, charge]) # TODO: Remove once core_electrostatics_force is eliminated
 
                 #add the environment atoms to the regular nonbonded force as well:
                 self._hybrid_system_forces['standard_nonbonded_force'].addParticle(charge, sigma, epsilon)
 
         self._handle_interaction_groups()
-        self._handle_hybrid_exceptions()
+        #self._handle_hybrid_exceptions() # TODO: Delete?
         self._handle_original_exceptions()
 
     def _generate_dict_from_exceptions(self, force):
@@ -1350,7 +1356,7 @@ class HybridTopologyFactory(object):
         Must be called after particles are added to the Nonbonded forces
         """
         #get the force objects for convenience:
-        electrostatics_custom_force = self._hybrid_system_forces['core_electrostatics_force']
+        #electrostatics_custom_force = self._hybrid_system_forces['core_electrostatics_force'] # TODO: Delete
         sterics_custom_force = self._hybrid_system_forces['core_sterics_force']
 
         #also prepare the atom classes
@@ -1360,22 +1366,22 @@ class HybridTopologyFactory(object):
         environment_atoms = self._atom_classes['environment_atoms']
 
 
-        electrostatics_custom_force.addInteractionGroup(unique_old_atoms, core_atoms)
+        #electrostatics_custom_force.addInteractionGroup(unique_old_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_old_atoms, core_atoms)
 
-        electrostatics_custom_force.addInteractionGroup(unique_old_atoms, environment_atoms)
+        #electrostatics_custom_force.addInteractionGroup(unique_old_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_old_atoms, environment_atoms)
 
-        electrostatics_custom_force.addInteractionGroup(unique_new_atoms, core_atoms)
+        #electrostatics_custom_force.addInteractionGroup(unique_new_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_new_atoms, core_atoms)
 
-        electrostatics_custom_force.addInteractionGroup(unique_new_atoms, environment_atoms)
+        #electrostatics_custom_force.addInteractionGroup(unique_new_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(unique_new_atoms, environment_atoms)
 
-        electrostatics_custom_force.addInteractionGroup(core_atoms, environment_atoms)
+        #electrostatics_custom_force.addInteractionGroup(core_atoms, environment_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(core_atoms, environment_atoms)
 
-        electrostatics_custom_force.addInteractionGroup(core_atoms, core_atoms)
+        #electrostatics_custom_force.addInteractionGroup(core_atoms, core_atoms) # TODO: Delete
         sterics_custom_force.addInteractionGroup(core_atoms, core_atoms)
 
     def _handle_hybrid_exceptions(self):
@@ -1484,14 +1490,16 @@ class HybridTopologyFactory(object):
                 #if it is, we should add it to the CustomBondForce for the nonbonded exceptions, and have it remain on
                 #by having the two endpoints with the same parameters.
                 #Currently, we keep sigma at the same value
-                self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid,
-                                                                                 [chargeProd_old, sigma_old,
-                                                                                  epsilon_old, chargeProd_old,
-                                                                                  sigma_old, epsilon_old])
+                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
+                #                                                                 [chargeProd_old, sigma_old,
+                #                                                                  epsilon_old, chargeProd_old,
+                #                                                                  sigma_old, epsilon_old])
+
+                self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
 
                 #We also need to exclude this interaction from the custom nonbonded forces, otherwise we'll be double counting
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
-                self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid)
+                #self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid) # TODO: Remove once core_electrostatics_force is eliminated
 
             #If the exception particles are neither solely old unique, solely environment, nor contain any unique old atoms, they are either core/environment or core/core
             #In this case, we need to get the parameters from the exception in the other (new) system, and interpolate between the two
@@ -1505,14 +1513,17 @@ class HybridTopologyFactory(object):
                     new_system_nonbonded_force, index1_new, index2_new)
 
                 #Now add a term to the CustomBondForce to interpolate between the new and old systems:
-                self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid,
-                                                                                 [chargeProd_old, sigma_old,
-                                                                                  epsilon_old, chargeProd_new,
-                                                                                  sigma_new, epsilon_new])
+                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
+                #                                                                 [chargeProd_old, sigma_old,
+                #                                                                  epsilon_old, chargeProd_new,
+                #                                                                  sigma_new, epsilon_new])
+                exception_index = self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_old, sigma_old, epsilon_old)
+                self._hybrid_system_forces['standard_nonbonded_force'].addExceptionParameterOffset('lambda_electrostatics', exception_index, (chargeProd_new - chargeProd_old), 0, 0)
+                self._hybrid_system_forces['standard_nonbonded_force'].addExceptionParameterOffset('lambda_sterics', exception_index, 0, (sigma_new - sigma_old), (epsilon_new - epsilon_old))
 
                 #We also need to exclude this interaction from the custom nonbonded forces, otherwise we'll be double counting
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
-                self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid)
+                #self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid) # TODO: Remove once core_electrostatics_force is eliminated
 
         #now, loop through the new system to collect remaining interactions. The only that remain here are
         #uniquenew-uniquenew, uniquenew-core, and uniquenew-environment.
@@ -1533,14 +1544,16 @@ class HybridTopologyFactory(object):
             #look for the final class- interactions between uniquenew-core and uniquenew-environment. They are treated
             #similarly: they are simply on and constant the entire time (as a valence term)
             elif len(index_set.intersection(self._atom_classes['unique_new_atoms'])) > 0:
-                self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid,
-                                                                                 [chargeProd_new, sigma_new,
-                                                                                  epsilon_new, chargeProd_new,
-                                                                                  sigma_new, epsilon_new])
+                #self._hybrid_system_forces['core_nonbonded_bond_force'].addBond(index1_hybrid, index2_hybrid, # TODO: Delete this when we remove core_nonbonded_bond_force
+                #                                                                 [chargeProd_new, sigma_new,
+                #                                                                  epsilon_new, chargeProd_new,
+                #                                                                  sigma_new, epsilon_new])
+                self._hybrid_system_forces['standard_nonbonded_force'].addException(index1_hybrid, index2_hybrid, chargeProd_new, sigma_new, epsilon_new)
+
 
                 #We also need to exclude this interaction from the custom nonbonded forces, otherwise we'll be double counting
                 self._hybrid_system_forces['core_sterics_force'].addExclusion(index1_hybrid, index2_hybrid)
-                self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid)
+                #self._hybrid_system_forces['core_electrostatics_force'].addExclusion(index1_hybrid, index2_hybrid) # TODO: Remove once core_electrostatics_force is eliminated
 
     def _find_exception(self, force, index1, index2):
         """

--- a/perses/dispersed/relative_setup.py
+++ b/perses/dispersed/relative_setup.py
@@ -1050,7 +1050,7 @@ def run_setup(setup_options):
             ne_fep[phase] = NonequilibriumSwitchingFEP(top_prop['%s_topology_proposal' % phase],
                                                        top_prop['%s_old_positions' % phase],
                                                        top_prop['%s_new_positions' % phase],
-                                                       forward_functions=forward_functions,
+                                                       forward_functions=forward_functions, 
                                                        n_equil_steps=n_equilibrium_steps_per_iteration,
                                                        ncmc_nsteps=n_steps_ncmc_protocol,
                                                        nsteps_per_iteration=n_steps_per_move_application,

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -373,6 +373,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         oemol : openeye.oechem.OEMol
             an oemol representation of the residue with topology indices
         """
+        # TODO: This seems to be broken. Can we fix it?
         from openmoltools.forcefield_generators import generateOEMolFromTopologyResidue
         external_bonds = list(res.external_bonds())
         for bond in external_bonds:

--- a/perses/tests/test_hybrid_builder.py
+++ b/perses/tests/test_hybrid_builder.py
@@ -162,15 +162,12 @@ def generate_vacuum_topology_proposal(current_mol_name="benzene", proposed_mol_n
 
     gaff_xml_filename = get_data_filename("data/gaff.xml")
     forcefield = app.ForceField(gaff_xml_filename, 'tip3p.xml')
-    #ffxml = forcefield_generators.generateForceFieldFromMolecules([current_mol, proposed_mol])
-    #forcefield.loadFile(StringIO(ffxml))
     forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
 
     solvated_system = forcefield.createSystem(top_old, removeCMMotion=False)
 
     gaff_filename = get_data_filename('data/gaff.xml')
     system_generator = SystemGenerator([gaff_filename, 'amber99sbildn.xml', 'tip3p.xml'], forcefield_kwargs={'removeCMMotion': False, 'nonbondedMethod': app.NoCutoff})
-    system_generator._forcefield.loadFile(StringIO(ffxml))
     geometry_engine = FFAllAngleGeometryEngine()
     proposal_engine = SmallMoleculeSetProposalEngine(
         [initial_smiles, final_smiles], system_generator, residue_name=current_mol_name)
@@ -217,8 +214,6 @@ def generate_solvated_hybrid_test_topology(current_mol_name="naphthalene", propo
 
     gaff_xml_filename = get_data_filename("data/gaff.xml")
     forcefield = app.ForceField(gaff_xml_filename, 'tip3p.xml')
-    #ffxml = forcefield_generators.generateForceFieldFromMolecules([current_mol, proposed_mol])
-    #forcefield.loadFile(StringIO(ffxml))
     forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
 
     modeller = app.Modeller(top_old, pos_old)
@@ -233,7 +228,6 @@ def generate_solvated_hybrid_test_topology(current_mol_name="naphthalene", propo
     gaff_filename = get_data_filename('data/gaff.xml')
 
     system_generator = SystemGenerator([gaff_filename, 'amber99sbildn.xml', 'tip3p.xml'], barostat=barostat, forcefield_kwargs={'removeCMMotion': False, 'nonbondedMethod': app.PME})
-    #system_generator._forcefield.loadFile(StringIO(ffxml))
     geometry_engine = FFAllAngleGeometryEngine()
     proposal_engine = SmallMoleculeSetProposalEngine(
         [initial_smiles, final_smiles], system_generator, residue_name=current_mol_name)

--- a/perses/tests/test_hybrid_builder.py
+++ b/perses/tests/test_hybrid_builder.py
@@ -325,7 +325,23 @@ def test_simple_overlap():
 @skipIf(istravis, "Skip expensive test on travis")
 def test_difficult_overlap():
     """Test that the variance of the endpoint->nonalchemical perturbation is sufficiently small for imatinib->nilotinib in solvent"""
-    topology_proposal, solvated_positions, new_positions = generate_solvated_hybrid_test_topology(current_mol_name='imatinib', proposed_mol_name='nilotinib')
+    name1 = 'imatinib'
+    name2 = 'nilotinib'
+
+    print(name1, name2)
+    topology_proposal, solvated_positions, new_positions = generate_solvated_hybrid_test_topology(current_mol_name=name1, proposed_mol_name=name2)
+    results = run_hybrid_endpoint_overlap(topology_proposal, solvated_positions, new_positions)
+
+    for idx, lambda_result in enumerate(results):
+        try:
+            check_result(lambda_result)
+        except Exception as e:
+            message = "solvated imatinib->nilotinib failed at lambda %d \n" % idx
+            message += str(e)
+            raise Exception(message)
+
+    print(name2, name1)
+    topology_proposal, solvated_positions, new_positions = generate_solvated_hybrid_test_topology(current_mol_name=name2, proposed_mol_name=name1)
     results = run_hybrid_endpoint_overlap(topology_proposal, solvated_positions, new_positions)
 
     for idx, lambda_result in enumerate(results):

--- a/perses/tests/test_hybrid_builder.py
+++ b/perses/tests/test_hybrid_builder.py
@@ -162,14 +162,14 @@ def generate_vacuum_topology_proposal(current_mol_name="benzene", proposed_mol_n
 
     gaff_xml_filename = get_data_filename("data/gaff.xml")
     forcefield = app.ForceField(gaff_xml_filename, 'tip3p.xml')
-    ffxml = forcefield_generators.generateForceFieldFromMolecules([current_mol, proposed_mol])
-    forcefield.loadFile(StringIO(ffxml))
-    #forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
+    #ffxml = forcefield_generators.generateForceFieldFromMolecules([current_mol, proposed_mol])
+    #forcefield.loadFile(StringIO(ffxml))
+    forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
 
     solvated_system = forcefield.createSystem(top_old, removeCMMotion=False)
 
     gaff_filename = get_data_filename('data/gaff.xml')
-    system_generator = SystemGenerator([gaff_filename, 'amber99sbildn.xml', 'tip3p.xml'])
+    system_generator = SystemGenerator([gaff_filename, 'amber99sbildn.xml', 'tip3p.xml'], forcefield_kwargs={'removeCMMotion': False, 'nonbondedMethod': app.NoCutoff})
     system_generator._forcefield.loadFile(StringIO(ffxml))
     geometry_engine = FFAllAngleGeometryEngine()
     proposal_engine = SmallMoleculeSetProposalEngine(
@@ -183,16 +183,16 @@ def generate_vacuum_topology_proposal(current_mol_name="benzene", proposed_mol_n
 
     return topology_proposal, pos_old, new_positions
 
-def generate_solvated_hybrid_test_topology(mol_name="naphthalene", ref_mol_name="benzene"):
+def generate_solvated_hybrid_test_topology(current_mol_name="naphthalene", proposed_mol_name="benzene"):
     """
     Generate a test solvated topology proposal, current positions, and new positions triplet
     from two IUPAC molecule names.
 
     Parameters
     ----------
-    mol_name : str, optional
+    current_mol_name : str, optional
         name of the first molecule
-    ref_mol_name : str, optional
+    proposed_mol_name : str, optional
         name of the second molecule
 
     Returns
@@ -209,14 +209,16 @@ def generate_solvated_hybrid_test_topology(mol_name="naphthalene", ref_mol_name=
 
     from perses.tests.utils import createOEMolFromIUPAC, createSystemFromIUPAC, get_data_filename
 
-    m, unsolv_old_system, pos_old, top_old = createSystemFromIUPAC(mol_name)
-    refmol = createOEMolFromIUPAC(ref_mol_name)
+    current_mol, unsolv_old_system, pos_old, top_old = createSystemFromIUPAC(current_mol_name)
+    proposed_mol = createOEMolFromIUPAC(proposed_mol_name)
 
-    initial_smiles = oechem.OEMolToSmiles(m)
-    final_smiles = oechem.OEMolToSmiles(refmol)
+    initial_smiles = oechem.OEMolToSmiles(current_mol)
+    final_smiles = oechem.OEMolToSmiles(proposed_mol)
 
     gaff_xml_filename = get_data_filename("data/gaff.xml")
     forcefield = app.ForceField(gaff_xml_filename, 'tip3p.xml')
+    #ffxml = forcefield_generators.generateForceFieldFromMolecules([current_mol, proposed_mol])
+    #forcefield.loadFile(StringIO(ffxml))
     forcefield.registerTemplateGenerator(forcefield_generators.gaffTemplateGenerator)
 
     modeller = app.Modeller(top_old, pos_old)
@@ -228,13 +230,13 @@ def generate_solvated_hybrid_test_topology(mol_name="naphthalene", ref_mol_name=
 
     solvated_system.addForce(barostat)
 
-
     gaff_filename = get_data_filename('data/gaff.xml')
 
     system_generator = SystemGenerator([gaff_filename, 'amber99sbildn.xml', 'tip3p.xml'], barostat=barostat, forcefield_kwargs={'removeCMMotion': False, 'nonbondedMethod': app.PME})
+    #system_generator._forcefield.loadFile(StringIO(ffxml))
     geometry_engine = FFAllAngleGeometryEngine()
     proposal_engine = SmallMoleculeSetProposalEngine(
-        [initial_smiles, final_smiles], system_generator, residue_name=mol_name)
+        [initial_smiles, final_smiles], system_generator, residue_name=current_mol_name)
 
     #generate topology proposal
     topology_proposal = proposal_engine.propose(solvated_system, solvated_topology)
@@ -315,7 +317,7 @@ def check_result(results, threshold=3.0, neffmin=10):
 
 def test_simple_overlap():
     """Test that the variance of the endpoint->nonalchemical perturbation is sufficiently small for pentane->butane in vacuum"""
-    topology_proposal, current_positions, new_positions = generate_vacuum_topology_proposal()
+    topology_proposal, current_positions, new_positions = generate_vacuum_topology_proposal(current_mol_name='imatinib', proposed_mol_name='nilotinib')
     results = run_hybrid_endpoint_overlap(topology_proposal, current_positions, new_positions)
 
     for idx, lambda_result in enumerate(results):
@@ -329,7 +331,7 @@ def test_simple_overlap():
 @skipIf(istravis, "Skip expensive test on travis")
 def test_difficult_overlap():
     """Test that the variance of the endpoint->nonalchemical perturbation is sufficiently small for imatinib->nilotinib in solvent"""
-    topology_proposal, solvated_positions, new_positions = generate_solvated_hybrid_test_topology(mol_name='imatinib', ref_mol_name='nilotinib')
+    topology_proposal, solvated_positions, new_positions = generate_solvated_hybrid_test_topology(current_mol_name='imatinib', proposed_mol_name='nilotinib')
     results = run_hybrid_endpoint_overlap(topology_proposal, solvated_positions, new_positions)
 
     for idx, lambda_result in enumerate(results):

--- a/scripts/setup_relative_calculation.py
+++ b/scripts/setup_relative_calculation.py
@@ -98,13 +98,17 @@ if __name__ == "__main__":
                 setup_dict['hybrid_topology_factories'])
 
         hss = setup_dict['hybrid_sams_samplers']
+        logZ = dict()
         free_energies = dict()
         for phase in phases:
             hss_run = hss[phase]
             hss_run.minimize()
             hss_run.equilibrate(n_equilibration_iterations)
-            hss_run.extend(1000)
-            free_energies[phase] = hss_run._logZ[-1] - hss_run._logZ[0]
-            print("Finished phase %s with dG estimated as %.4f kT" % (phase, free_energies[phase]))
+            hss_run.extend(setup_options['n_cycles'])
+            logZ[phase] = hss_run._logZ[-1] - hss_run._logZ[0]
+            free_energies[phase] = hss_run._last_mbar_f_k[-1] - hss_run._last_mbar_f_k[0]
+            print("Finished phase %s with dG estimated as %.4f +/- %.4f kT" % (
+            phase, free_energies[phase], hss_run._last_err_free_energy))
+            print("Finished phase %s with logZ dG estimated as %.4f kT" % (phase, logZ[phase]))
 
         print("Total ddG is estimated as %.4f kT" % (free_energies['complex'] - free_energies['solvent']))

--- a/scripts/setup_relative_calculation.py
+++ b/scripts/setup_relative_calculation.py
@@ -32,8 +32,9 @@ if __name__ == "__main__":
 
     setup_dict = relative_setup.run_setup(setup_options)
     print("setup complete")
+    print('setup_dict keys: {}'.format(setup_dict.keys()))
 
-    n_equilibration_iterations = setup_dict['n_equilibration_iterations']
+    n_equilibration_iterations = setup_options['n_equilibration_iterations']
 
     trajectory_prefix = setup_options['trajectory_prefix']
     #write out topology proposals


### PR DESCRIPTION
@pgrinaway : I think I've made all the changes necessary to use the new ['offset' OpenMM feature](https://github.com/pandegroup/openmm/pull/2105) for near-exact nonbonded electrostatics, but I can't figure out which overlap tests I can run to test that this is actually working. Can you help?

At first, I thought [`test_simple_overlap()`](https://github.com/choderalab/perses/blob/master/perses/tests/test_hybrid_builder.py#L307-L318) may work, but it appears to use several broken functions. Is there another test that is supposed to work for checking overlap with the physical endpoints?

The `offset` feature is being built as `openmm==7.3.0` right now.

This PR would replace #469 since we would no longer need that solution.