### PR TITLE
Add ffxml file with C-terminal protonated termini

### DIFF
--- a/perses/data/protein.ff14SB.protonated-termini.xml
+++ b/perses/data/protein.ff14SB.protonated-termini.xml
@@ -1,0 +1,2691 @@
+<ForceField><Residues><Residue name="ALA-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0337" name="CA" type="protein-CX" />
+      <Atom charge="0.0823" name="HA" type="protein-H1" />
+      <Atom charge="-0.1825" name="CB" type="protein-CT" />
+      <Atom charge="0.0603" name="HB1" type="protein-HC" />
+      <Atom charge="0.0603" name="HB2" type="protein-HC" />
+      <Atom charge="0.0603" name="HB3" type="protein-HC" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB1" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="ARG-CTER-PROT">
+      <Atom charge="-0.3479" name="N" type="protein-N" />
+      <Atom charge="0.2747" name="H" type="protein-H" />
+      <Atom charge="-0.2637" name="CA" type="protein-CX" />
+      <Atom charge="0.156" name="HA" type="protein-H1" />
+      <Atom charge="-0.0007" name="CB" type="protein-C8" />
+      <Atom charge="0.0327" name="HB2" type="protein-HC" />
+      <Atom charge="0.0327" name="HB3" type="protein-HC" />
+      <Atom charge="0.039" name="CG" type="protein-C8" />
+      <Atom charge="0.0285" name="HG2" type="protein-HC" />
+      <Atom charge="0.0285" name="HG3" type="protein-HC" />
+      <Atom charge="0.0486" name="CD" type="protein-C8" />
+      <Atom charge="0.0687" name="HD2" type="protein-H1" />
+      <Atom charge="0.0687" name="HD3" type="protein-H1" />
+      <Atom charge="-0.5295" name="NE" type="protein-N2" />
+      <Atom charge="0.3456" name="HE" type="protein-H" />
+      <Atom charge="0.8076" name="CZ" type="protein-CA" />
+      <Atom charge="-0.8627" name="NH1" type="protein-N2" />
+      <Atom charge="0.4478" name="HH11" type="protein-H" />
+      <Atom charge="0.4478" name="HH12" type="protein-H" />
+      <Atom charge="-0.8627" name="NH2" type="protein-N2" />
+      <Atom charge="0.4478" name="HH21" type="protein-H" />
+      <Atom charge="0.4478" name="HH22" type="protein-H" />
+      <Atom charge="0.7341" name="C" type="protein-C" />
+      <Atom charge="-0.5894" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="NE" />
+      <Bond atomName1="NE" atomName2="HE" />
+      <Bond atomName1="NE" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="NH1" />
+      <Bond atomName1="CZ" atomName2="NH2" />
+      <Bond atomName1="NH1" atomName2="HH11" />
+      <Bond atomName1="NH1" atomName2="HH12" />
+      <Bond atomName1="NH2" atomName2="HH21" />
+      <Bond atomName1="NH2" atomName2="HH22" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="ASH-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0341" name="CA" type="protein-CX" />
+      <Atom charge="0.0864" name="HA" type="protein-H1" />
+      <Atom charge="-0.0316" name="CB" type="protein-2C" />
+      <Atom charge="0.0488" name="HB2" type="protein-HC" />
+      <Atom charge="0.0488" name="HB3" type="protein-HC" />
+      <Atom charge="0.6462" name="CG" type="protein-C" />
+      <Atom charge="-0.5554" name="OD1" type="protein-O" />
+      <Atom charge="-0.6376" name="OD2" type="protein-OH" />
+      <Atom charge="0.4747" name="HD2" type="protein-HO" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="OD2" />
+      <Bond atomName1="OD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="ASN-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0143" name="CA" type="protein-CX" />
+      <Atom charge="0.1048" name="HA" type="protein-H1" />
+      <Atom charge="-0.2041" name="CB" type="protein-2C" />
+      <Atom charge="0.0797" name="HB2" type="protein-HC" />
+      <Atom charge="0.0797" name="HB3" type="protein-HC" />
+      <Atom charge="0.713" name="CG" type="protein-C" />
+      <Atom charge="-0.5931" name="OD1" type="protein-O" />
+      <Atom charge="-0.9191" name="ND2" type="protein-N" />
+      <Atom charge="0.4196" name="HD21" type="protein-H" />
+      <Atom charge="0.4196" name="HD22" type="protein-H" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="ND2" />
+      <Bond atomName1="ND2" atomName2="HD21" />
+      <Bond atomName1="ND2" atomName2="HD22" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="ASP-CTER-PROT">
+      <Atom charge="-0.5163" name="N" type="protein-N" />
+      <Atom charge="0.2936" name="H" type="protein-H" />
+      <Atom charge="0.0381" name="CA" type="protein-CX" />
+      <Atom charge="0.088" name="HA" type="protein-H1" />
+      <Atom charge="-0.0303" name="CB" type="protein-2C" />
+      <Atom charge="-0.0122" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0122" name="HB3" type="protein-HC" />
+      <Atom charge="0.7994" name="CG" type="protein-CO" />
+      <Atom charge="-0.8014" name="OD1" type="protein-O2" />
+      <Atom charge="-0.8014" name="OD2" type="protein-O2" />
+      <Atom charge="0.5366" name="C" type="protein-C" />
+      <Atom charge="-0.5819" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="OD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CYM-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0351" name="CA" type="protein-CX" />
+      <Atom charge="0.0508" name="HA" type="protein-H1" />
+      <Atom charge="-0.2413" name="CB" type="protein-CT" />
+      <Atom charge="0.1122" name="HB3" type="protein-H1" />
+      <Atom charge="0.1122" name="HB2" type="protein-H1" />
+      <Atom charge="-0.8844" name="SG" type="protein-SH" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CYS-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0213" name="CA" type="protein-CX" />
+      <Atom charge="0.1124" name="HA" type="protein-H1" />
+      <Atom charge="-0.1231" name="CB" type="protein-2C" />
+      <Atom charge="0.1112" name="HB2" type="protein-H1" />
+      <Atom charge="0.1112" name="HB3" type="protein-H1" />
+      <Atom charge="-0.3119" name="SG" type="protein-SH" />
+      <Atom charge="0.1933" name="HG" type="protein-HS" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="SG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CYX-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0429" name="CA" type="protein-CX" />
+      <Atom charge="0.0766" name="HA" type="protein-H1" />
+      <Atom charge="-0.079" name="CB" type="protein-2C" />
+      <Atom charge="0.091" name="HB2" type="protein-H1" />
+      <Atom charge="0.091" name="HB3" type="protein-H1" />
+      <Atom charge="-0.1081" name="SG" type="protein-S" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="SG" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="GLH-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0145" name="CA" type="protein-CX" />
+      <Atom charge="0.0779" name="HA" type="protein-H1" />
+      <Atom charge="-0.0071" name="CB" type="protein-2C" />
+      <Atom charge="0.0256" name="HB2" type="protein-HC" />
+      <Atom charge="0.0256" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0174" name="CG" type="protein-2C" />
+      <Atom charge="0.043" name="HG2" type="protein-HC" />
+      <Atom charge="0.043" name="HG3" type="protein-HC" />
+      <Atom charge="0.6801" name="CD" type="protein-C" />
+      <Atom charge="-0.5838" name="OE1" type="protein-O" />
+      <Atom charge="-0.6511" name="OE2" type="protein-OH" />
+      <Atom charge="0.4641" name="HE2" type="protein-HO" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="OE2" />
+      <Bond atomName1="OE2" atomName2="HE2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="GLN-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0031" name="CA" type="protein-CX" />
+      <Atom charge="0.085" name="HA" type="protein-H1" />
+      <Atom charge="-0.0036" name="CB" type="protein-2C" />
+      <Atom charge="0.0171" name="HB2" type="protein-HC" />
+      <Atom charge="0.0171" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0645" name="CG" type="protein-2C" />
+      <Atom charge="0.0352" name="HG2" type="protein-HC" />
+      <Atom charge="0.0352" name="HG3" type="protein-HC" />
+      <Atom charge="0.6951" name="CD" type="protein-C" />
+      <Atom charge="-0.6086" name="OE1" type="protein-O" />
+      <Atom charge="-0.9407" name="NE2" type="protein-N" />
+      <Atom charge="0.4251" name="HE21" type="protein-H" />
+      <Atom charge="0.4251" name="HE22" type="protein-H" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE21" />
+      <Bond atomName1="NE2" atomName2="HE22" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="GLU-CTER-PROT">
+      <Atom charge="-0.5163" name="N" type="protein-N" />
+      <Atom charge="0.2936" name="H" type="protein-H" />
+      <Atom charge="0.0397" name="CA" type="protein-CX" />
+      <Atom charge="0.1105" name="HA" type="protein-H1" />
+      <Atom charge="0.056" name="CB" type="protein-2C" />
+      <Atom charge="-0.0173" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0173" name="HB3" type="protein-HC" />
+      <Atom charge="0.0136" name="CG" type="protein-2C" />
+      <Atom charge="-0.0425" name="HG2" type="protein-HC" />
+      <Atom charge="-0.0425" name="HG3" type="protein-HC" />
+      <Atom charge="0.8054" name="CD" type="protein-CO" />
+      <Atom charge="-0.8188" name="OE1" type="protein-O2" />
+      <Atom charge="-0.8188" name="OE2" type="protein-O2" />
+      <Atom charge="0.5366" name="C" type="protein-C" />
+      <Atom charge="-0.5819" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="OE2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="GLY-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0252" name="CA" type="protein-CX" />
+      <Atom charge="0.0698" name="HA2" type="protein-H1" />
+      <Atom charge="0.0698" name="HA3" type="protein-H1" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA2" />
+      <Bond atomName1="CA" atomName2="HA3" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="HID-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="0.0188" name="CA" type="protein-CX" />
+      <Atom charge="0.0881" name="HA" type="protein-H1" />
+      <Atom charge="-0.0462" name="CB" type="protein-CT" />
+      <Atom charge="0.0402" name="HB2" type="protein-HC" />
+      <Atom charge="0.0402" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0266" name="CG" type="protein-CC" />
+      <Atom charge="-0.3811" name="ND1" type="protein-NA" />
+      <Atom charge="0.3649" name="HD1" type="protein-H" />
+      <Atom charge="0.2057" name="CE1" type="protein-CR" />
+      <Atom charge="0.1392" name="HE1" type="protein-H5" />
+      <Atom charge="-0.5727" name="NE2" type="protein-NB" />
+      <Atom charge="0.1292" name="CD2" type="protein-CV" />
+      <Atom charge="0.1147" name="HD2" type="protein-H4" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="HIE-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0581" name="CA" type="protein-CX" />
+      <Atom charge="0.136" name="HA" type="protein-H1" />
+      <Atom charge="-0.0074" name="CB" type="protein-CT" />
+      <Atom charge="0.0367" name="HB2" type="protein-HC" />
+      <Atom charge="0.0367" name="HB3" type="protein-HC" />
+      <Atom charge="0.1868" name="CG" type="protein-CC" />
+      <Atom charge="-0.5432" name="ND1" type="protein-NB" />
+      <Atom charge="0.1635" name="CE1" type="protein-CR" />
+      <Atom charge="0.1435" name="HE1" type="protein-H5" />
+      <Atom charge="-0.2795" name="NE2" type="protein-NA" />
+      <Atom charge="0.3339" name="HE2" type="protein-H" />
+      <Atom charge="-0.2207" name="CD2" type="protein-CW" />
+      <Atom charge="0.1862" name="HD2" type="protein-H4" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="HIP-CTER-PROT">
+      <Atom charge="-0.3479" name="N" type="protein-N" />
+      <Atom charge="0.2747" name="H" type="protein-H" />
+      <Atom charge="-0.1354" name="CA" type="protein-CX" />
+      <Atom charge="0.1212" name="HA" type="protein-H1" />
+      <Atom charge="-0.0414" name="CB" type="protein-CT" />
+      <Atom charge="0.081" name="HB2" type="protein-HC" />
+      <Atom charge="0.081" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0012" name="CG" type="protein-CC" />
+      <Atom charge="-0.1513" name="ND1" type="protein-NA" />
+      <Atom charge="0.3866" name="HD1" type="protein-H" />
+      <Atom charge="-0.017" name="CE1" type="protein-CR" />
+      <Atom charge="0.2681" name="HE1" type="protein-H5" />
+      <Atom charge="-0.1718" name="NE2" type="protein-NA" />
+      <Atom charge="0.3911" name="HE2" type="protein-H" />
+      <Atom charge="-0.1141" name="CD2" type="protein-CW" />
+      <Atom charge="0.2317" name="HD2" type="protein-H4" />
+      <Atom charge="0.7341" name="C" type="protein-C" />
+      <Atom charge="-0.5894" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="HYP-CTER-PROT">
+      <Atom charge="-0.2548" name="N" type="protein-N" />
+      <Atom charge="0.0595" name="CD" type="protein-CT" />
+      <Atom charge="0.07" name="HD22" type="protein-H1" />
+      <Atom charge="0.07" name="HD23" type="protein-H1" />
+      <Atom charge="0.04" name="CG" type="protein-CT" />
+      <Atom charge="0.0416" name="HG" type="protein-H1" />
+      <Atom charge="-0.6134" name="OD1" type="protein-OH" />
+      <Atom charge="0.3851" name="HD1" type="protein-HO" />
+      <Atom charge="0.0203" name="CB" type="protein-CT" />
+      <Atom charge="0.0426" name="HB2" type="protein-HC" />
+      <Atom charge="0.0426" name="HB3" type="protein-HC" />
+      <Atom charge="0.0047" name="CA" type="protein-CX" />
+      <Atom charge="0.077" name="HA" type="protein-H1" />
+      <Atom charge="0.5896" name="C" type="protein-C" />
+      <Atom charge="-0.5748" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="CD" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CD" atomName2="HD22" />
+      <Bond atomName1="CD" atomName2="HD23" />
+      <Bond atomName1="CD" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="CB" />
+      <Bond atomName1="OD1" atomName2="HD1" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="ILE-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0597" name="CA" type="protein-CX" />
+      <Atom charge="0.0869" name="HA" type="protein-H1" />
+      <Atom charge="0.1303" name="CB" type="protein-3C" />
+      <Atom charge="0.0187" name="HB" type="protein-HC" />
+      <Atom charge="-0.3204" name="CG2" type="protein-CT" />
+      <Atom charge="0.0882" name="HG21" type="protein-HC" />
+      <Atom charge="0.0882" name="HG22" type="protein-HC" />
+      <Atom charge="0.0882" name="HG23" type="protein-HC" />
+      <Atom charge="-0.043" name="CG1" type="protein-2C" />
+      <Atom charge="0.0236" name="HG12" type="protein-HC" />
+      <Atom charge="0.0236" name="HG13" type="protein-HC" />
+      <Atom charge="-0.066" name="CD1" type="protein-CT" />
+      <Atom charge="0.0186" name="HD11" type="protein-HC" />
+      <Atom charge="0.0186" name="HD12" type="protein-HC" />
+      <Atom charge="0.0186" name="HD13" type="protein-HC" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG1" atomName2="CD1" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="LEU-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0518" name="CA" type="protein-CX" />
+      <Atom charge="0.0922" name="HA" type="protein-H1" />
+      <Atom charge="-0.1102" name="CB" type="protein-2C" />
+      <Atom charge="0.0457" name="HB2" type="protein-HC" />
+      <Atom charge="0.0457" name="HB3" type="protein-HC" />
+      <Atom charge="0.3531" name="CG" type="protein-3C" />
+      <Atom charge="-0.0361" name="HG" type="protein-HC" />
+      <Atom charge="-0.4121" name="CD1" type="protein-CT" />
+      <Atom charge="0.1" name="HD11" type="protein-HC" />
+      <Atom charge="0.1" name="HD12" type="protein-HC" />
+      <Atom charge="0.1" name="HD13" type="protein-HC" />
+      <Atom charge="-0.4121" name="CD2" type="protein-CT" />
+      <Atom charge="0.1" name="HD21" type="protein-HC" />
+      <Atom charge="0.1" name="HD22" type="protein-HC" />
+      <Atom charge="0.1" name="HD23" type="protein-HC" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="CD2" atomName2="HD21" />
+      <Bond atomName1="CD2" atomName2="HD22" />
+      <Bond atomName1="CD2" atomName2="HD23" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="LYN-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.07206" name="CA" type="protein-CX" />
+      <Atom charge="0.0994" name="HA" type="protein-H1" />
+      <Atom charge="-0.04845" name="CB" type="protein-CT" />
+      <Atom charge="0.034" name="HB2" type="protein-HC" />
+      <Atom charge="0.034" name="HB3" type="protein-HC" />
+      <Atom charge="0.06612" name="CG" type="protein-CT" />
+      <Atom charge="0.01041" name="HG2" type="protein-HC" />
+      <Atom charge="0.01041" name="HG3" type="protein-HC" />
+      <Atom charge="-0.03768" name="CD" type="protein-CT" />
+      <Atom charge="0.01155" name="HD2" type="protein-HC" />
+      <Atom charge="0.01155" name="HD3" type="protein-HC" />
+      <Atom charge="0.32604" name="CE" type="protein-CT" />
+      <Atom charge="-0.03358" name="HE2" type="protein-HP" />
+      <Atom charge="-0.03358" name="HE3" type="protein-HP" />
+      <Atom charge="-1.03581" name="NZ" type="protein-N3" />
+      <Atom charge="0.38604" name="HZ2" type="protein-H" />
+      <Atom charge="0.38604" name="HZ3" type="protein-H" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="CE" atomName2="NZ" />
+      <Bond atomName1="NZ" atomName2="HZ2" />
+      <Bond atomName1="NZ" atomName2="HZ3" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="LYS-CTER-PROT">
+      <Atom charge="-0.3479" name="N" type="protein-N" />
+      <Atom charge="0.2747" name="H" type="protein-H" />
+      <Atom charge="-0.24" name="CA" type="protein-CX" />
+      <Atom charge="0.1426" name="HA" type="protein-H1" />
+      <Atom charge="-0.0094" name="CB" type="protein-C8" />
+      <Atom charge="0.0362" name="HB2" type="protein-HC" />
+      <Atom charge="0.0362" name="HB3" type="protein-HC" />
+      <Atom charge="0.0187" name="CG" type="protein-C8" />
+      <Atom charge="0.0103" name="HG2" type="protein-HC" />
+      <Atom charge="0.0103" name="HG3" type="protein-HC" />
+      <Atom charge="-0.0479" name="CD" type="protein-C8" />
+      <Atom charge="0.0621" name="HD2" type="protein-HC" />
+      <Atom charge="0.0621" name="HD3" type="protein-HC" />
+      <Atom charge="-0.0143" name="CE" type="protein-C8" />
+      <Atom charge="0.1135" name="HE2" type="protein-HP" />
+      <Atom charge="0.1135" name="HE3" type="protein-HP" />
+      <Atom charge="-0.3854" name="NZ" type="protein-N3" />
+      <Atom charge="0.34" name="HZ1" type="protein-H" />
+      <Atom charge="0.34" name="HZ2" type="protein-H" />
+      <Atom charge="0.34" name="HZ3" type="protein-H" />
+      <Atom charge="0.7341" name="C" type="protein-C" />
+      <Atom charge="-0.5894" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="CE" atomName2="NZ" />
+      <Bond atomName1="NZ" atomName2="HZ1" />
+      <Bond atomName1="NZ" atomName2="HZ2" />
+      <Bond atomName1="NZ" atomName2="HZ3" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="MET-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0237" name="CA" type="protein-CX" />
+      <Atom charge="0.088" name="HA" type="protein-H1" />
+      <Atom charge="0.0342" name="CB" type="protein-2C" />
+      <Atom charge="0.0241" name="HB2" type="protein-HC" />
+      <Atom charge="0.0241" name="HB3" type="protein-HC" />
+      <Atom charge="0.0018" name="CG" type="protein-2C" />
+      <Atom charge="0.044" name="HG2" type="protein-H1" />
+      <Atom charge="0.044" name="HG3" type="protein-H1" />
+      <Atom charge="-0.2737" name="SD" type="protein-S" />
+      <Atom charge="-0.0536" name="CE" type="protein-CT" />
+      <Atom charge="0.0684" name="HE1" type="protein-H1" />
+      <Atom charge="0.0684" name="HE2" type="protein-H1" />
+      <Atom charge="0.0684" name="HE3" type="protein-H1" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="SD" />
+      <Bond atomName1="SD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE1" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="PHE-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0024" name="CA" type="protein-CX" />
+      <Atom charge="0.0978" name="HA" type="protein-H1" />
+      <Atom charge="-0.0343" name="CB" type="protein-CT" />
+      <Atom charge="0.0295" name="HB2" type="protein-HC" />
+      <Atom charge="0.0295" name="HB3" type="protein-HC" />
+      <Atom charge="0.0118" name="CG" type="protein-CA" />
+      <Atom charge="-0.1256" name="CD1" type="protein-CA" />
+      <Atom charge="0.133" name="HD1" type="protein-HA" />
+      <Atom charge="-0.1704" name="CE1" type="protein-CA" />
+      <Atom charge="0.143" name="HE1" type="protein-HA" />
+      <Atom charge="-0.1072" name="CZ" type="protein-CA" />
+      <Atom charge="0.1297" name="HZ" type="protein-HA" />
+      <Atom charge="-0.1704" name="CE2" type="protein-CA" />
+      <Atom charge="0.143" name="HE2" type="protein-HA" />
+      <Atom charge="-0.1256" name="CD2" type="protein-CA" />
+      <Atom charge="0.133" name="HD2" type="protein-HA" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="HZ" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="PRO-CTER-PROT">
+      <Atom charge="-0.2548" name="N" type="protein-N" />
+      <Atom charge="0.0192" name="CD" type="protein-CT" />
+      <Atom charge="0.0391" name="HD2" type="protein-H1" />
+      <Atom charge="0.0391" name="HD3" type="protein-H1" />
+      <Atom charge="0.0189" name="CG" type="protein-CT" />
+      <Atom charge="0.0213" name="HG2" type="protein-HC" />
+      <Atom charge="0.0213" name="HG3" type="protein-HC" />
+      <Atom charge="-0.007" name="CB" type="protein-CT" />
+      <Atom charge="0.0253" name="HB2" type="protein-HC" />
+      <Atom charge="0.0253" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0266" name="CA" type="protein-CX" />
+      <Atom charge="0.0641" name="HA" type="protein-H1" />
+      <Atom charge="0.5896" name="C" type="protein-C" />
+      <Atom charge="-0.5748" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="CD" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CB" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="SER-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0249" name="CA" type="protein-CX" />
+      <Atom charge="0.0843" name="HA" type="protein-H1" />
+      <Atom charge="0.2117" name="CB" type="protein-2C" />
+      <Atom charge="0.0352" name="HB2" type="protein-H1" />
+      <Atom charge="0.0352" name="HB3" type="protein-H1" />
+      <Atom charge="-0.6546" name="OG" type="protein-OH" />
+      <Atom charge="0.4275" name="HG" type="protein-HO" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="OG" />
+      <Bond atomName1="OG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="THR-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0389" name="CA" type="protein-CX" />
+      <Atom charge="0.1007" name="HA" type="protein-H1" />
+      <Atom charge="0.3654" name="CB" type="protein-3C" />
+      <Atom charge="0.0043" name="HB" type="protein-H1" />
+      <Atom charge="-0.2438" name="CG2" type="protein-CT" />
+      <Atom charge="0.0642" name="HG21" type="protein-HC" />
+      <Atom charge="0.0642" name="HG22" type="protein-HC" />
+      <Atom charge="0.0642" name="HG23" type="protein-HC" />
+      <Atom charge="-0.6761" name="OG1" type="protein-OH" />
+      <Atom charge="0.4102" name="HG1" type="protein-HO" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="OG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="OG1" atomName2="HG1" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="TRP-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0275" name="CA" type="protein-CX" />
+      <Atom charge="0.1123" name="HA" type="protein-H1" />
+      <Atom charge="-0.005" name="CB" type="protein-CT" />
+      <Atom charge="0.0339" name="HB2" type="protein-HC" />
+      <Atom charge="0.0339" name="HB3" type="protein-HC" />
+      <Atom charge="-0.1415" name="CG" type="protein-C*" />
+      <Atom charge="-0.1638" name="CD1" type="protein-CW" />
+      <Atom charge="0.2062" name="HD1" type="protein-H4" />
+      <Atom charge="-0.3418" name="NE1" type="protein-NA" />
+      <Atom charge="0.3412" name="HE1" type="protein-H" />
+      <Atom charge="0.138" name="CE2" type="protein-CN" />
+      <Atom charge="-0.2601" name="CZ2" type="protein-CA" />
+      <Atom charge="0.1572" name="HZ2" type="protein-HA" />
+      <Atom charge="-0.1134" name="CH2" type="protein-CA" />
+      <Atom charge="0.1417" name="HH2" type="protein-HA" />
+      <Atom charge="-0.1972" name="CZ3" type="protein-CA" />
+      <Atom charge="0.1447" name="HZ3" type="protein-HA" />
+      <Atom charge="-0.2387" name="CE3" type="protein-CA" />
+      <Atom charge="0.17" name="HE3" type="protein-HA" />
+      <Atom charge="0.1243" name="CD2" type="protein-CB" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="NE1" />
+      <Bond atomName1="NE1" atomName2="HE1" />
+      <Bond atomName1="NE1" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="CZ2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CZ2" atomName2="HZ2" />
+      <Bond atomName1="CZ2" atomName2="CH2" />
+      <Bond atomName1="CH2" atomName2="HH2" />
+      <Bond atomName1="CH2" atomName2="CZ3" />
+      <Bond atomName1="CZ3" atomName2="HZ3" />
+      <Bond atomName1="CZ3" atomName2="CE3" />
+      <Bond atomName1="CE3" atomName2="HE3" />
+      <Bond atomName1="CE3" atomName2="CD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="TYR-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0014" name="CA" type="protein-CX" />
+      <Atom charge="0.0876" name="HA" type="protein-H1" />
+      <Atom charge="-0.0152" name="CB" type="protein-CT" />
+      <Atom charge="0.0295" name="HB2" type="protein-HC" />
+      <Atom charge="0.0295" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0011" name="CG" type="protein-CA" />
+      <Atom charge="-0.1906" name="CD1" type="protein-CA" />
+      <Atom charge="0.1699" name="HD1" type="protein-HA" />
+      <Atom charge="-0.2341" name="CE1" type="protein-CA" />
+      <Atom charge="0.1656" name="HE1" type="protein-HA" />
+      <Atom charge="0.3226" name="CZ" type="protein-C" />
+      <Atom charge="-0.5579" name="OH" type="protein-OH" />
+      <Atom charge="0.3992" name="HH" type="protein-HO" />
+      <Atom charge="-0.2341" name="CE2" type="protein-CA" />
+      <Atom charge="0.1656" name="HE2" type="protein-HA" />
+      <Atom charge="-0.1906" name="CD2" type="protein-CA" />
+      <Atom charge="0.1699" name="HD2" type="protein-HA" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="OH" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="OH" atomName2="HH" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="VAL-CTER-PROT">
+      <Atom charge="-0.4157" name="N" type="protein-N" />
+      <Atom charge="0.2719" name="H" type="protein-H" />
+      <Atom charge="-0.0875" name="CA" type="protein-CX" />
+      <Atom charge="0.0969" name="HA" type="protein-H1" />
+      <Atom charge="0.2985" name="CB" type="protein-3C" />
+      <Atom charge="-0.0297" name="HB" type="protein-HC" />
+      <Atom charge="-0.3192" name="CG1" type="protein-CT" />
+      <Atom charge="0.0791" name="HG11" type="protein-HC" />
+      <Atom charge="0.0791" name="HG12" type="protein-HC" />
+      <Atom charge="0.0791" name="HG13" type="protein-HC" />
+      <Atom charge="-0.3192" name="CG2" type="protein-CT" />
+      <Atom charge="0.0791" name="HG21" type="protein-HC" />
+      <Atom charge="0.0791" name="HG22" type="protein-HC" />
+      <Atom charge="0.0791" name="HG23" type="protein-HC" />
+      <Atom charge="0.5973" name="C" type="protein-C" />
+      <Atom charge="-0.5679" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CG1" atomName2="HG11" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="N" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CALA-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.1747" name="CA" type="protein-CX" />
+      <Atom charge="0.1067" name="HA" type="protein-H1" />
+      <Atom charge="-0.2093" name="CB" type="protein-CT" />
+      <Atom charge="0.0764" name="HB1" type="protein-HC" />
+      <Atom charge="0.0764" name="HB2" type="protein-HC" />
+      <Atom charge="0.0764" name="HB3" type="protein-HC" />
+      <Atom charge="0.7731" name="C" type="protein-C" />
+      <Atom charge="-0.8055" name="O" type="protein-O2" />
+      <Atom charge="-0.8055" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB1" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CARG-CTER-PROT">
+      <Atom charge="-0.3481" name="N" type="protein-N" />
+      <Atom charge="0.2764" name="H" type="protein-H" />
+      <Atom charge="-0.3068" name="CA" type="protein-CX" />
+      <Atom charge="0.1447" name="HA" type="protein-H1" />
+      <Atom charge="-0.0374" name="CB" type="protein-C8" />
+      <Atom charge="0.0371" name="HB2" type="protein-HC" />
+      <Atom charge="0.0371" name="HB3" type="protein-HC" />
+      <Atom charge="0.0744" name="CG" type="protein-C8" />
+      <Atom charge="0.0185" name="HG2" type="protein-HC" />
+      <Atom charge="0.0185" name="HG3" type="protein-HC" />
+      <Atom charge="0.1114" name="CD" type="protein-C8" />
+      <Atom charge="0.0468" name="HD2" type="protein-H1" />
+      <Atom charge="0.0468" name="HD3" type="protein-H1" />
+      <Atom charge="-0.5564" name="NE" type="protein-N2" />
+      <Atom charge="0.3479" name="HE" type="protein-H" />
+      <Atom charge="0.8368" name="CZ" type="protein-CA" />
+      <Atom charge="-0.8737" name="NH1" type="protein-N2" />
+      <Atom charge="0.4493" name="HH11" type="protein-H" />
+      <Atom charge="0.4493" name="HH12" type="protein-H" />
+      <Atom charge="-0.8737" name="NH2" type="protein-N2" />
+      <Atom charge="0.4493" name="HH21" type="protein-H" />
+      <Atom charge="0.4493" name="HH22" type="protein-H" />
+      <Atom charge="0.8557" name="C" type="protein-C" />
+      <Atom charge="-0.8266" name="O" type="protein-O2" />
+      <Atom charge="-0.8266" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="NE" />
+      <Bond atomName1="NE" atomName2="HE" />
+      <Bond atomName1="NE" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="NH1" />
+      <Bond atomName1="CZ" atomName2="NH2" />
+      <Bond atomName1="NH1" atomName2="HH11" />
+      <Bond atomName1="NH1" atomName2="HH12" />
+      <Bond atomName1="NH2" atomName2="HH21" />
+      <Bond atomName1="NH2" atomName2="HH22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CASN-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.208" name="CA" type="protein-CX" />
+      <Atom charge="0.1358" name="HA" type="protein-H1" />
+      <Atom charge="-0.2299" name="CB" type="protein-2C" />
+      <Atom charge="0.1023" name="HB2" type="protein-HC" />
+      <Atom charge="0.1023" name="HB3" type="protein-HC" />
+      <Atom charge="0.7153" name="CG" type="protein-C" />
+      <Atom charge="-0.601" name="OD1" type="protein-O" />
+      <Atom charge="-0.9084" name="ND2" type="protein-N" />
+      <Atom charge="0.415" name="HD21" type="protein-H" />
+      <Atom charge="0.415" name="HD22" type="protein-H" />
+      <Atom charge="0.805" name="C" type="protein-C" />
+      <Atom charge="-0.8147" name="O" type="protein-O2" />
+      <Atom charge="-0.8147" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="ND2" />
+      <Bond atomName1="ND2" atomName2="HD21" />
+      <Bond atomName1="ND2" atomName2="HD22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CASP-CTER-PROT">
+      <Atom charge="-0.5192" name="N" type="protein-N" />
+      <Atom charge="0.3055" name="H" type="protein-H" />
+      <Atom charge="-0.1817" name="CA" type="protein-CX" />
+      <Atom charge="0.1046" name="HA" type="protein-H1" />
+      <Atom charge="-0.0677" name="CB" type="protein-2C" />
+      <Atom charge="-0.0212" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0212" name="HB3" type="protein-HC" />
+      <Atom charge="0.8851" name="CG" type="protein-CO" />
+      <Atom charge="-0.8162" name="OD1" type="protein-O2" />
+      <Atom charge="-0.8162" name="OD2" type="protein-O2" />
+      <Atom charge="0.7256" name="C" type="protein-C" />
+      <Atom charge="-0.7887" name="O" type="protein-O2" />
+      <Atom charge="-0.7887" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="OD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CCYS-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.1635" name="CA" type="protein-CX" />
+      <Atom charge="0.1396" name="HA" type="protein-H1" />
+      <Atom charge="-0.1996" name="CB" type="protein-2C" />
+      <Atom charge="0.1437" name="HB2" type="protein-H1" />
+      <Atom charge="0.1437" name="HB3" type="protein-H1" />
+      <Atom charge="-0.3102" name="SG" type="protein-SH" />
+      <Atom charge="0.2068" name="HG" type="protein-HS" />
+      <Atom charge="0.7497" name="C" type="protein-C" />
+      <Atom charge="-0.7981" name="O" type="protein-O2" />
+      <Atom charge="-0.7981" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="SG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CCYX-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.1318" name="CA" type="protein-CX" />
+      <Atom charge="0.0938" name="HA" type="protein-H1" />
+      <Atom charge="-0.1943" name="CB" type="protein-2C" />
+      <Atom charge="0.1228" name="HB2" type="protein-H1" />
+      <Atom charge="0.1228" name="HB3" type="protein-H1" />
+      <Atom charge="-0.0529" name="SG" type="protein-S" />
+      <Atom charge="0.7618" name="C" type="protein-C" />
+      <Atom charge="-0.8041" name="O" type="protein-O2" />
+      <Atom charge="-0.8041" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="SG" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CGLN-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2248" name="CA" type="protein-CX" />
+      <Atom charge="0.1232" name="HA" type="protein-H1" />
+      <Atom charge="-0.0664" name="CB" type="protein-2C" />
+      <Atom charge="0.0452" name="HB2" type="protein-HC" />
+      <Atom charge="0.0452" name="HB3" type="protein-HC" />
+      <Atom charge="-0.021" name="CG" type="protein-2C" />
+      <Atom charge="0.0203" name="HG2" type="protein-HC" />
+      <Atom charge="0.0203" name="HG3" type="protein-HC" />
+      <Atom charge="0.7093" name="CD" type="protein-C" />
+      <Atom charge="-0.6098" name="OE1" type="protein-O" />
+      <Atom charge="-0.9574" name="NE2" type="protein-N" />
+      <Atom charge="0.4304" name="HE21" type="protein-H" />
+      <Atom charge="0.4304" name="HE22" type="protein-H" />
+      <Atom charge="0.7775" name="C" type="protein-C" />
+      <Atom charge="-0.8042" name="O" type="protein-O2" />
+      <Atom charge="-0.8042" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE21" />
+      <Bond atomName1="NE2" atomName2="HE22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CGLU-CTER-PROT">
+      <Atom charge="-0.5192" name="N" type="protein-N" />
+      <Atom charge="0.3055" name="H" type="protein-H" />
+      <Atom charge="-0.2059" name="CA" type="protein-CX" />
+      <Atom charge="0.1399" name="HA" type="protein-H1" />
+      <Atom charge="0.0071" name="CB" type="protein-2C" />
+      <Atom charge="-0.0078" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0078" name="HB3" type="protein-HC" />
+      <Atom charge="0.0675" name="CG" type="protein-2C" />
+      <Atom charge="-0.0548" name="HG2" type="protein-HC" />
+      <Atom charge="-0.0548" name="HG3" type="protein-HC" />
+      <Atom charge="0.8183" name="CD" type="protein-CO" />
+      <Atom charge="-0.822" name="OE1" type="protein-O2" />
+      <Atom charge="-0.822" name="OE2" type="protein-O2" />
+      <Atom charge="0.742" name="C" type="protein-C" />
+      <Atom charge="-0.793" name="O" type="protein-O2" />
+      <Atom charge="-0.793" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="OE2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CGLY-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2493" name="CA" type="protein-CX" />
+      <Atom charge="0.1056" name="HA2" type="protein-H1" />
+      <Atom charge="0.1056" name="HA3" type="protein-H1" />
+      <Atom charge="0.7231" name="C" type="protein-C" />
+      <Atom charge="-0.7855" name="O" type="protein-O2" />
+      <Atom charge="-0.7855" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA2" />
+      <Bond atomName1="CA" atomName2="HA3" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CHID-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.1739" name="CA" type="protein-CX" />
+      <Atom charge="0.11" name="HA" type="protein-H1" />
+      <Atom charge="-0.1046" name="CB" type="protein-CT" />
+      <Atom charge="0.0565" name="HB2" type="protein-HC" />
+      <Atom charge="0.0565" name="HB3" type="protein-HC" />
+      <Atom charge="0.0293" name="CG" type="protein-CC" />
+      <Atom charge="-0.3892" name="ND1" type="protein-NA" />
+      <Atom charge="0.3755" name="HD1" type="protein-H" />
+      <Atom charge="0.1925" name="CE1" type="protein-CR" />
+      <Atom charge="0.1418" name="HE1" type="protein-H5" />
+      <Atom charge="-0.5629" name="NE2" type="protein-NB" />
+      <Atom charge="0.1001" name="CD2" type="protein-CV" />
+      <Atom charge="0.1241" name="HD2" type="protein-H4" />
+      <Atom charge="0.7615" name="C" type="protein-C" />
+      <Atom charge="-0.8016" name="O" type="protein-O2" />
+      <Atom charge="-0.8016" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CHIE-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2699" name="CA" type="protein-CX" />
+      <Atom charge="0.165" name="HA" type="protein-H1" />
+      <Atom charge="-0.1068" name="CB" type="protein-CT" />
+      <Atom charge="0.062" name="HB2" type="protein-HC" />
+      <Atom charge="0.062" name="HB3" type="protein-HC" />
+      <Atom charge="0.2724" name="CG" type="protein-CC" />
+      <Atom charge="-0.5517" name="ND1" type="protein-NB" />
+      <Atom charge="0.1558" name="CE1" type="protein-CR" />
+      <Atom charge="0.1448" name="HE1" type="protein-H5" />
+      <Atom charge="-0.267" name="NE2" type="protein-NA" />
+      <Atom charge="0.3319" name="HE2" type="protein-H" />
+      <Atom charge="-0.2588" name="CD2" type="protein-CW" />
+      <Atom charge="0.1957" name="HD2" type="protein-H4" />
+      <Atom charge="0.7916" name="C" type="protein-C" />
+      <Atom charge="-0.8065" name="O" type="protein-O2" />
+      <Atom charge="-0.8065" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CHIP-CTER-PROT">
+      <Atom charge="-0.3481" name="N" type="protein-N" />
+      <Atom charge="0.2764" name="H" type="protein-H" />
+      <Atom charge="-0.1445" name="CA" type="protein-CX" />
+      <Atom charge="0.1115" name="HA" type="protein-H1" />
+      <Atom charge="-0.08" name="CB" type="protein-CT" />
+      <Atom charge="0.0868" name="HB2" type="protein-HC" />
+      <Atom charge="0.0868" name="HB3" type="protein-HC" />
+      <Atom charge="0.0298" name="CG" type="protein-CC" />
+      <Atom charge="-0.1501" name="ND1" type="protein-NA" />
+      <Atom charge="0.3883" name="HD1" type="protein-H" />
+      <Atom charge="-0.0251" name="CE1" type="protein-CR" />
+      <Atom charge="0.2694" name="HE1" type="protein-H5" />
+      <Atom charge="-0.1683" name="NE2" type="protein-NA" />
+      <Atom charge="0.3913" name="HE2" type="protein-H" />
+      <Atom charge="-0.1256" name="CD2" type="protein-CW" />
+      <Atom charge="0.2336" name="HD2" type="protein-H4" />
+      <Atom charge="0.8032" name="C" type="protein-C" />
+      <Atom charge="-0.8177" name="O" type="protein-O2" />
+      <Atom charge="-0.8177" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CHYP-CTER-PROT">
+      <Atom charge="-0.2802" name="N" type="protein-N" />
+      <Atom charge="0.0778" name="CD" type="protein-CT" />
+      <Atom charge="0.0331" name="HD22" type="protein-H1" />
+      <Atom charge="0.0331" name="HD23" type="protein-H1" />
+      <Atom charge="0.081" name="CG" type="protein-CT" />
+      <Atom charge="0.0416" name="HG" type="protein-H1" />
+      <Atom charge="-0.6134" name="OD1" type="protein-OH" />
+      <Atom charge="0.3851" name="HD1" type="protein-HO" />
+      <Atom charge="0.0547" name="CB" type="protein-CT" />
+      <Atom charge="0.0426" name="HB2" type="protein-HC" />
+      <Atom charge="0.0426" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0993" name="CA" type="protein-CX" />
+      <Atom charge="0.0776" name="HA" type="protein-H1" />
+      <Atom charge="0.6631" name="C" type="protein-C" />
+      <Atom charge="-0.7697" name="O" type="protein-O2" />
+      <Atom charge="-0.7697" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="CD" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CD" atomName2="HD22" />
+      <Bond atomName1="CD" atomName2="HD23" />
+      <Bond atomName1="CD" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="CB" />
+      <Bond atomName1="OD1" atomName2="HD1" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CILE-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.31" name="CA" type="protein-CX" />
+      <Atom charge="0.1375" name="HA" type="protein-H1" />
+      <Atom charge="0.0363" name="CB" type="protein-3C" />
+      <Atom charge="0.0766" name="HB" type="protein-HC" />
+      <Atom charge="-0.3498" name="CG2" type="protein-CT" />
+      <Atom charge="0.1021" name="HG21" type="protein-HC" />
+      <Atom charge="0.1021" name="HG22" type="protein-HC" />
+      <Atom charge="0.1021" name="HG23" type="protein-HC" />
+      <Atom charge="-0.0323" name="CG1" type="protein-2C" />
+      <Atom charge="0.0321" name="HG12" type="protein-HC" />
+      <Atom charge="0.0321" name="HG13" type="protein-HC" />
+      <Atom charge="-0.0699" name="CD1" type="protein-CT" />
+      <Atom charge="0.0196" name="HD11" type="protein-HC" />
+      <Atom charge="0.0196" name="HD12" type="protein-HC" />
+      <Atom charge="0.0196" name="HD13" type="protein-HC" />
+      <Atom charge="0.8343" name="C" type="protein-C" />
+      <Atom charge="-0.819" name="O" type="protein-O2" />
+      <Atom charge="-0.819" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG1" atomName2="CD1" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CLEU-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2847" name="CA" type="protein-CX" />
+      <Atom charge="0.1346" name="HA" type="protein-H1" />
+      <Atom charge="-0.2469" name="CB" type="protein-2C" />
+      <Atom charge="0.0974" name="HB2" type="protein-HC" />
+      <Atom charge="0.0974" name="HB3" type="protein-HC" />
+      <Atom charge="0.3706" name="CG" type="protein-3C" />
+      <Atom charge="-0.0374" name="HG" type="protein-HC" />
+      <Atom charge="-0.4163" name="CD1" type="protein-CT" />
+      <Atom charge="0.1038" name="HD11" type="protein-HC" />
+      <Atom charge="0.1038" name="HD12" type="protein-HC" />
+      <Atom charge="0.1038" name="HD13" type="protein-HC" />
+      <Atom charge="-0.4163" name="CD2" type="protein-CT" />
+      <Atom charge="0.1038" name="HD21" type="protein-HC" />
+      <Atom charge="0.1038" name="HD22" type="protein-HC" />
+      <Atom charge="0.1038" name="HD23" type="protein-HC" />
+      <Atom charge="0.8326" name="C" type="protein-C" />
+      <Atom charge="-0.8199" name="O" type="protein-O2" />
+      <Atom charge="-0.8199" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="CD2" atomName2="HD21" />
+      <Bond atomName1="CD2" atomName2="HD22" />
+      <Bond atomName1="CD2" atomName2="HD23" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CLYS-CTER-PROT">
+      <Atom charge="-0.3481" name="N" type="protein-N" />
+      <Atom charge="0.2764" name="H" type="protein-H" />
+      <Atom charge="-0.2903" name="CA" type="protein-CX" />
+      <Atom charge="0.1438" name="HA" type="protein-H1" />
+      <Atom charge="-0.0538" name="CB" type="protein-C8" />
+      <Atom charge="0.0482" name="HB2" type="protein-HC" />
+      <Atom charge="0.0482" name="HB3" type="protein-HC" />
+      <Atom charge="0.0227" name="CG" type="protein-C8" />
+      <Atom charge="0.0134" name="HG2" type="protein-HC" />
+      <Atom charge="0.0134" name="HG3" type="protein-HC" />
+      <Atom charge="-0.0392" name="CD" type="protein-C8" />
+      <Atom charge="0.0611" name="HD2" type="protein-HC" />
+      <Atom charge="0.0611" name="HD3" type="protein-HC" />
+      <Atom charge="-0.0176" name="CE" type="protein-C8" />
+      <Atom charge="0.1121" name="HE2" type="protein-HP" />
+      <Atom charge="0.1121" name="HE3" type="protein-HP" />
+      <Atom charge="-0.3741" name="NZ" type="protein-N3" />
+      <Atom charge="0.3374" name="HZ1" type="protein-H" />
+      <Atom charge="0.3374" name="HZ2" type="protein-H" />
+      <Atom charge="0.3374" name="HZ3" type="protein-H" />
+      <Atom charge="0.8488" name="C" type="protein-C" />
+      <Atom charge="-0.8252" name="O" type="protein-O2" />
+      <Atom charge="-0.8252" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="CE" atomName2="NZ" />
+      <Bond atomName1="NZ" atomName2="HZ1" />
+      <Bond atomName1="NZ" atomName2="HZ2" />
+      <Bond atomName1="NZ" atomName2="HZ3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CMET-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2597" name="CA" type="protein-CX" />
+      <Atom charge="0.1277" name="HA" type="protein-H1" />
+      <Atom charge="-0.0236" name="CB" type="protein-2C" />
+      <Atom charge="0.048" name="HB2" type="protein-HC" />
+      <Atom charge="0.048" name="HB3" type="protein-HC" />
+      <Atom charge="0.0492" name="CG" type="protein-2C" />
+      <Atom charge="0.0317" name="HG2" type="protein-H1" />
+      <Atom charge="0.0317" name="HG3" type="protein-H1" />
+      <Atom charge="-0.2692" name="SD" type="protein-S" />
+      <Atom charge="-0.0376" name="CE" type="protein-CT" />
+      <Atom charge="0.0625" name="HE1" type="protein-H1" />
+      <Atom charge="0.0625" name="HE2" type="protein-H1" />
+      <Atom charge="0.0625" name="HE3" type="protein-H1" />
+      <Atom charge="0.8013" name="C" type="protein-C" />
+      <Atom charge="-0.8105" name="O" type="protein-O2" />
+      <Atom charge="-0.8105" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="SD" />
+      <Bond atomName1="SD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE1" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CPHE-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.1825" name="CA" type="protein-CX" />
+      <Atom charge="0.1098" name="HA" type="protein-H1" />
+      <Atom charge="-0.0959" name="CB" type="protein-CT" />
+      <Atom charge="0.0443" name="HB2" type="protein-HC" />
+      <Atom charge="0.0443" name="HB3" type="protein-HC" />
+      <Atom charge="0.0552" name="CG" type="protein-CA" />
+      <Atom charge="-0.13" name="CD1" type="protein-CA" />
+      <Atom charge="0.1408" name="HD1" type="protein-HA" />
+      <Atom charge="-0.1847" name="CE1" type="protein-CA" />
+      <Atom charge="0.1461" name="HE1" type="protein-HA" />
+      <Atom charge="-0.0944" name="CZ" type="protein-CA" />
+      <Atom charge="0.128" name="HZ" type="protein-HA" />
+      <Atom charge="-0.1847" name="CE2" type="protein-CA" />
+      <Atom charge="0.1461" name="HE2" type="protein-HA" />
+      <Atom charge="-0.13" name="CD2" type="protein-CA" />
+      <Atom charge="0.1408" name="HD2" type="protein-HA" />
+      <Atom charge="0.766" name="C" type="protein-C" />
+      <Atom charge="-0.8026" name="O" type="protein-O2" />
+      <Atom charge="-0.8026" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="HZ" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CPRO-CTER-PROT">
+      <Atom charge="-0.2802" name="N" type="protein-N" />
+      <Atom charge="0.0434" name="CD" type="protein-CT" />
+      <Atom charge="0.0331" name="HD2" type="protein-H1" />
+      <Atom charge="0.0331" name="HD3" type="protein-H1" />
+      <Atom charge="0.0466" name="CG" type="protein-CT" />
+      <Atom charge="0.0172" name="HG2" type="protein-HC" />
+      <Atom charge="0.0172" name="HG3" type="protein-HC" />
+      <Atom charge="-0.0543" name="CB" type="protein-CT" />
+      <Atom charge="0.0381" name="HB2" type="protein-HC" />
+      <Atom charge="0.0381" name="HB3" type="protein-HC" />
+      <Atom charge="-0.1336" name="CA" type="protein-CX" />
+      <Atom charge="0.0776" name="HA" type="protein-H1" />
+      <Atom charge="0.6631" name="C" type="protein-C" />
+      <Atom charge="-0.7697" name="O" type="protein-O2" />
+      <Atom charge="-0.7697" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="CD" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CB" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CSER-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2722" name="CA" type="protein-CX" />
+      <Atom charge="0.1304" name="HA" type="protein-H1" />
+      <Atom charge="0.1123" name="CB" type="protein-2C" />
+      <Atom charge="0.0813" name="HB2" type="protein-H1" />
+      <Atom charge="0.0813" name="HB3" type="protein-H1" />
+      <Atom charge="-0.6514" name="OG" type="protein-OH" />
+      <Atom charge="0.4474" name="HG" type="protein-HO" />
+      <Atom charge="0.8113" name="C" type="protein-C" />
+      <Atom charge="-0.8132" name="O" type="protein-O2" />
+      <Atom charge="-0.8132" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="OG" />
+      <Bond atomName1="OG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CTHR-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.242" name="CA" type="protein-CX" />
+      <Atom charge="0.1207" name="HA" type="protein-H1" />
+      <Atom charge="0.3025" name="CB" type="protein-3C" />
+      <Atom charge="0.0078" name="HB" type="protein-H1" />
+      <Atom charge="-0.1853" name="CG2" type="protein-CT" />
+      <Atom charge="0.0586" name="HG21" type="protein-HC" />
+      <Atom charge="0.0586" name="HG22" type="protein-HC" />
+      <Atom charge="0.0586" name="HG23" type="protein-HC" />
+      <Atom charge="-0.6496" name="OG1" type="protein-OH" />
+      <Atom charge="0.4119" name="HG1" type="protein-HO" />
+      <Atom charge="0.781" name="C" type="protein-C" />
+      <Atom charge="-0.8044" name="O" type="protein-O2" />
+      <Atom charge="-0.8044" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="OG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="OG1" atomName2="HG1" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CTRP-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2084" name="CA" type="protein-CX" />
+      <Atom charge="0.1272" name="HA" type="protein-H1" />
+      <Atom charge="-0.0742" name="CB" type="protein-CT" />
+      <Atom charge="0.0497" name="HB2" type="protein-HC" />
+      <Atom charge="0.0497" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0796" name="CG" type="protein-C*" />
+      <Atom charge="-0.1808" name="CD1" type="protein-CW" />
+      <Atom charge="0.2043" name="HD1" type="protein-H4" />
+      <Atom charge="-0.3316" name="NE1" type="protein-NA" />
+      <Atom charge="0.3413" name="HE1" type="protein-H" />
+      <Atom charge="0.1222" name="CE2" type="protein-CN" />
+      <Atom charge="-0.2594" name="CZ2" type="protein-CA" />
+      <Atom charge="0.1567" name="HZ2" type="protein-HA" />
+      <Atom charge="-0.102" name="CH2" type="protein-CA" />
+      <Atom charge="0.1401" name="HH2" type="protein-HA" />
+      <Atom charge="-0.2287" name="CZ3" type="protein-CA" />
+      <Atom charge="0.1507" name="HZ3" type="protein-HA" />
+      <Atom charge="-0.1837" name="CE3" type="protein-CA" />
+      <Atom charge="0.1491" name="HE3" type="protein-HA" />
+      <Atom charge="0.1078" name="CD2" type="protein-CB" />
+      <Atom charge="0.7658" name="C" type="protein-C" />
+      <Atom charge="-0.8011" name="O" type="protein-O2" />
+      <Atom charge="-0.8011" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="NE1" />
+      <Bond atomName1="NE1" atomName2="HE1" />
+      <Bond atomName1="NE1" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="CZ2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CZ2" atomName2="HZ2" />
+      <Bond atomName1="CZ2" atomName2="CH2" />
+      <Bond atomName1="CH2" atomName2="HH2" />
+      <Bond atomName1="CH2" atomName2="CZ3" />
+      <Bond atomName1="CZ3" atomName2="HZ3" />
+      <Bond atomName1="CZ3" atomName2="CE3" />
+      <Bond atomName1="CE3" atomName2="HE3" />
+      <Bond atomName1="CE3" atomName2="CD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CTYR-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.2015" name="CA" type="protein-CX" />
+      <Atom charge="0.1092" name="HA" type="protein-H1" />
+      <Atom charge="-0.0752" name="CB" type="protein-CT" />
+      <Atom charge="0.049" name="HB2" type="protein-HC" />
+      <Atom charge="0.049" name="HB3" type="protein-HC" />
+      <Atom charge="0.0243" name="CG" type="protein-CA" />
+      <Atom charge="-0.1922" name="CD1" type="protein-CA" />
+      <Atom charge="0.178" name="HD1" type="protein-HA" />
+      <Atom charge="-0.2458" name="CE1" type="protein-CA" />
+      <Atom charge="0.1673" name="HE1" type="protein-HA" />
+      <Atom charge="0.3395" name="CZ" type="protein-C" />
+      <Atom charge="-0.5643" name="OH" type="protein-OH" />
+      <Atom charge="0.4017" name="HH" type="protein-HO" />
+      <Atom charge="-0.2458" name="CE2" type="protein-CA" />
+      <Atom charge="0.1673" name="HE2" type="protein-HA" />
+      <Atom charge="-0.1922" name="CD2" type="protein-CA" />
+      <Atom charge="0.178" name="HD2" type="protein-HA" />
+      <Atom charge="0.7817" name="C" type="protein-C" />
+      <Atom charge="-0.807" name="O" type="protein-O2" />
+      <Atom charge="-0.807" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="OH" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="OH" atomName2="HH" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="CVAL-CTER-PROT">
+      <Atom charge="-0.3821" name="N" type="protein-N" />
+      <Atom charge="0.2681" name="H" type="protein-H" />
+      <Atom charge="-0.3438" name="CA" type="protein-CX" />
+      <Atom charge="0.1438" name="HA" type="protein-H1" />
+      <Atom charge="0.194" name="CB" type="protein-3C" />
+      <Atom charge="0.0308" name="HB" type="protein-HC" />
+      <Atom charge="-0.3064" name="CG1" type="protein-CT" />
+      <Atom charge="0.0836" name="HG11" type="protein-HC" />
+      <Atom charge="0.0836" name="HG12" type="protein-HC" />
+      <Atom charge="0.0836" name="HG13" type="protein-HC" />
+      <Atom charge="-0.3064" name="CG2" type="protein-CT" />
+      <Atom charge="0.0836" name="HG21" type="protein-HC" />
+      <Atom charge="0.0836" name="HG22" type="protein-HC" />
+      <Atom charge="0.0836" name="HG23" type="protein-HC" />
+      <Atom charge="0.835" name="C" type="protein-C" />
+      <Atom charge="-0.8173" name="O" type="protein-O2" />
+      <Atom charge="-0.8173" name="OXT" type="protein-O2" />
+      <Bond atomName1="N" atomName2="H" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CG1" atomName2="HG11" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="C" atomName2="O" />
+      <Bond atomName1="C" atomName2="OXT" />
+      <ExternalBond atomName="N" />
+    <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NALA-CTER-PROT">
+      <Atom charge="0.1414" name="N" type="protein-N3" />
+      <Atom charge="0.1997" name="H1" type="protein-H" />
+      <Atom charge="0.1997" name="H2" type="protein-H" />
+      <Atom charge="0.1997" name="H3" type="protein-H" />
+      <Atom charge="0.0962" name="CA" type="protein-CX" />
+      <Atom charge="0.0889" name="HA" type="protein-HP" />
+      <Atom charge="-0.0597" name="CB" type="protein-CT" />
+      <Atom charge="0.03" name="HB1" type="protein-HC" />
+      <Atom charge="0.03" name="HB2" type="protein-HC" />
+      <Atom charge="0.03" name="HB3" type="protein-HC" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB1" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NARG-CTER-PROT">
+      <Atom charge="0.1305" name="N" type="protein-N3" />
+      <Atom charge="0.2083" name="H1" type="protein-H" />
+      <Atom charge="0.2083" name="H2" type="protein-H" />
+      <Atom charge="0.2083" name="H3" type="protein-H" />
+      <Atom charge="-0.0223" name="CA" type="protein-CX" />
+      <Atom charge="0.1242" name="HA" type="protein-HP" />
+      <Atom charge="0.0118" name="CB" type="protein-C8" />
+      <Atom charge="0.0226" name="HB2" type="protein-HC" />
+      <Atom charge="0.0226" name="HB3" type="protein-HC" />
+      <Atom charge="0.0236" name="CG" type="protein-C8" />
+      <Atom charge="0.0309" name="HG2" type="protein-HC" />
+      <Atom charge="0.0309" name="HG3" type="protein-HC" />
+      <Atom charge="0.0935" name="CD" type="protein-C8" />
+      <Atom charge="0.0527" name="HD2" type="protein-H1" />
+      <Atom charge="0.0527" name="HD3" type="protein-H1" />
+      <Atom charge="-0.565" name="NE" type="protein-N2" />
+      <Atom charge="0.3592" name="HE" type="protein-H" />
+      <Atom charge="0.8281" name="CZ" type="protein-CA" />
+      <Atom charge="-0.8693" name="NH1" type="protein-N2" />
+      <Atom charge="0.4494" name="HH11" type="protein-H" />
+      <Atom charge="0.4494" name="HH12" type="protein-H" />
+      <Atom charge="-0.8693" name="NH2" type="protein-N2" />
+      <Atom charge="0.4494" name="HH21" type="protein-H" />
+      <Atom charge="0.4494" name="HH22" type="protein-H" />
+      <Atom charge="0.7214" name="C" type="protein-C" />
+      <Atom charge="-0.6013" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="NE" />
+      <Bond atomName1="NE" atomName2="HE" />
+      <Bond atomName1="NE" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="NH1" />
+      <Bond atomName1="CZ" atomName2="NH2" />
+      <Bond atomName1="NH1" atomName2="HH11" />
+      <Bond atomName1="NH1" atomName2="HH12" />
+      <Bond atomName1="NH2" atomName2="HH21" />
+      <Bond atomName1="NH2" atomName2="HH22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NASN-CTER-PROT">
+      <Atom charge="0.1801" name="N" type="protein-N3" />
+      <Atom charge="0.1921" name="H1" type="protein-H" />
+      <Atom charge="0.1921" name="H2" type="protein-H" />
+      <Atom charge="0.1921" name="H3" type="protein-H" />
+      <Atom charge="0.0368" name="CA" type="protein-CX" />
+      <Atom charge="0.1231" name="HA" type="protein-HP" />
+      <Atom charge="-0.0283" name="CB" type="protein-2C" />
+      <Atom charge="0.0515" name="HB2" type="protein-HC" />
+      <Atom charge="0.0515" name="HB3" type="protein-HC" />
+      <Atom charge="0.5833" name="CG" type="protein-C" />
+      <Atom charge="-0.5744" name="OD1" type="protein-O" />
+      <Atom charge="-0.8634" name="ND2" type="protein-N" />
+      <Atom charge="0.4097" name="HD21" type="protein-H" />
+      <Atom charge="0.4097" name="HD22" type="protein-H" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="ND2" />
+      <Bond atomName1="ND2" atomName2="HD21" />
+      <Bond atomName1="ND2" atomName2="HD22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NASP-CTER-PROT">
+      <Atom charge="0.0782" name="N" type="protein-N3" />
+      <Atom charge="0.22" name="H1" type="protein-H" />
+      <Atom charge="0.22" name="H2" type="protein-H" />
+      <Atom charge="0.22" name="H3" type="protein-H" />
+      <Atom charge="0.0292" name="CA" type="protein-CX" />
+      <Atom charge="0.1141" name="HA" type="protein-HP" />
+      <Atom charge="-0.0235" name="CB" type="protein-2C" />
+      <Atom charge="-0.0169" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0169" name="HB3" type="protein-HC" />
+      <Atom charge="0.8194" name="CG" type="protein-CO" />
+      <Atom charge="-0.8084" name="OD1" type="protein-O2" />
+      <Atom charge="-0.8084" name="OD2" type="protein-O2" />
+      <Atom charge="0.5621" name="C" type="protein-C" />
+      <Atom charge="-0.5889" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="OD1" />
+      <Bond atomName1="CG" atomName2="OD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NCYS-CTER-PROT">
+      <Atom charge="0.1325" name="N" type="protein-N3" />
+      <Atom charge="0.2023" name="H1" type="protein-H" />
+      <Atom charge="0.2023" name="H2" type="protein-H" />
+      <Atom charge="0.2023" name="H3" type="protein-H" />
+      <Atom charge="0.0927" name="CA" type="protein-CX" />
+      <Atom charge="0.1411" name="HA" type="protein-HP" />
+      <Atom charge="-0.1195" name="CB" type="protein-2C" />
+      <Atom charge="0.1188" name="HB2" type="protein-H1" />
+      <Atom charge="0.1188" name="HB3" type="protein-H1" />
+      <Atom charge="-0.3298" name="SG" type="protein-SH" />
+      <Atom charge="0.1975" name="HG" type="protein-HS" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="SG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NCYX-CTER-PROT">
+      <Atom charge="0.2069" name="N" type="protein-N3" />
+      <Atom charge="0.1815" name="H1" type="protein-H" />
+      <Atom charge="0.1815" name="H2" type="protein-H" />
+      <Atom charge="0.1815" name="H3" type="protein-H" />
+      <Atom charge="0.1055" name="CA" type="protein-CX" />
+      <Atom charge="0.0922" name="HA" type="protein-HP" />
+      <Atom charge="-0.0277" name="CB" type="protein-2C" />
+      <Atom charge="0.068" name="HB2" type="protein-H1" />
+      <Atom charge="0.068" name="HB3" type="protein-H1" />
+      <Atom charge="-0.0984" name="SG" type="protein-S" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="SG" />
+      <Bond atomName1="C" atomName2="O" />
+      <ExternalBond atomName="SG" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NGLN-CTER-PROT">
+      <Atom charge="0.1493" name="N" type="protein-N3" />
+      <Atom charge="0.1996" name="H1" type="protein-H" />
+      <Atom charge="0.1996" name="H2" type="protein-H" />
+      <Atom charge="0.1996" name="H3" type="protein-H" />
+      <Atom charge="0.0536" name="CA" type="protein-CX" />
+      <Atom charge="0.1015" name="HA" type="protein-HP" />
+      <Atom charge="0.0651" name="CB" type="protein-2C" />
+      <Atom charge="0.005" name="HB2" type="protein-HC" />
+      <Atom charge="0.005" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0903" name="CG" type="protein-2C" />
+      <Atom charge="0.0331" name="HG2" type="protein-HC" />
+      <Atom charge="0.0331" name="HG3" type="protein-HC" />
+      <Atom charge="0.7354" name="CD" type="protein-C" />
+      <Atom charge="-0.6133" name="OE1" type="protein-O" />
+      <Atom charge="-1.0031" name="NE2" type="protein-N" />
+      <Atom charge="0.4429" name="HE21" type="protein-H" />
+      <Atom charge="0.4429" name="HE22" type="protein-H" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE21" />
+      <Bond atomName1="NE2" atomName2="HE22" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NGLU-CTER-PROT">
+      <Atom charge="0.0017" name="N" type="protein-N3" />
+      <Atom charge="0.2391" name="H1" type="protein-H" />
+      <Atom charge="0.2391" name="H2" type="protein-H" />
+      <Atom charge="0.2391" name="H3" type="protein-H" />
+      <Atom charge="0.0588" name="CA" type="protein-CX" />
+      <Atom charge="0.1202" name="HA" type="protein-HP" />
+      <Atom charge="0.0909" name="CB" type="protein-2C" />
+      <Atom charge="-0.0232" name="HB2" type="protein-HC" />
+      <Atom charge="-0.0232" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0236" name="CG" type="protein-2C" />
+      <Atom charge="-0.0315" name="HG2" type="protein-HC" />
+      <Atom charge="-0.0315" name="HG3" type="protein-HC" />
+      <Atom charge="0.8087" name="CD" type="protein-CO" />
+      <Atom charge="-0.8189" name="OE1" type="protein-O2" />
+      <Atom charge="-0.8189" name="OE2" type="protein-O2" />
+      <Atom charge="0.5621" name="C" type="protein-C" />
+      <Atom charge="-0.5889" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="OE1" />
+      <Bond atomName1="CD" atomName2="OE2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NGLY-CTER-PROT">
+      <Atom charge="0.2943" name="N" type="protein-N3" />
+      <Atom charge="0.1642" name="H1" type="protein-H" />
+      <Atom charge="0.1642" name="H2" type="protein-H" />
+      <Atom charge="0.1642" name="H3" type="protein-H" />
+      <Atom charge="-0.01" name="CA" type="protein-CX" />
+      <Atom charge="0.0895" name="HA2" type="protein-HP" />
+      <Atom charge="0.0895" name="HA3" type="protein-HP" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA2" />
+      <Bond atomName1="CA" atomName2="HA3" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NHID-CTER-PROT">
+      <Atom charge="0.1542" name="N" type="protein-N3" />
+      <Atom charge="0.1963" name="H1" type="protein-H" />
+      <Atom charge="0.1963" name="H2" type="protein-H" />
+      <Atom charge="0.1963" name="H3" type="protein-H" />
+      <Atom charge="0.0964" name="CA" type="protein-CX" />
+      <Atom charge="0.0958" name="HA" type="protein-HP" />
+      <Atom charge="0.0259" name="CB" type="protein-CT" />
+      <Atom charge="0.0209" name="HB2" type="protein-HC" />
+      <Atom charge="0.0209" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0399" name="CG" type="protein-CC" />
+      <Atom charge="-0.3819" name="ND1" type="protein-NA" />
+      <Atom charge="0.3632" name="HD1" type="protein-H" />
+      <Atom charge="0.2127" name="CE1" type="protein-CR" />
+      <Atom charge="0.1385" name="HE1" type="protein-H5" />
+      <Atom charge="-0.5711" name="NE2" type="protein-NB" />
+      <Atom charge="0.1046" name="CD2" type="protein-CV" />
+      <Atom charge="0.1299" name="HD2" type="protein-H4" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NHIE-CTER-PROT">
+      <Atom charge="0.1472" name="N" type="protein-N3" />
+      <Atom charge="0.2016" name="H1" type="protein-H" />
+      <Atom charge="0.2016" name="H2" type="protein-H" />
+      <Atom charge="0.2016" name="H3" type="protein-H" />
+      <Atom charge="0.0236" name="CA" type="protein-CX" />
+      <Atom charge="0.138" name="HA" type="protein-HP" />
+      <Atom charge="0.0489" name="CB" type="protein-CT" />
+      <Atom charge="0.0223" name="HB2" type="protein-HC" />
+      <Atom charge="0.0223" name="HB3" type="protein-HC" />
+      <Atom charge="0.174" name="CG" type="protein-CC" />
+      <Atom charge="-0.5579" name="ND1" type="protein-NB" />
+      <Atom charge="0.1804" name="CE1" type="protein-CR" />
+      <Atom charge="0.1397" name="HE1" type="protein-H5" />
+      <Atom charge="-0.2781" name="NE2" type="protein-NA" />
+      <Atom charge="0.3324" name="HE2" type="protein-H" />
+      <Atom charge="-0.2349" name="CD2" type="protein-CW" />
+      <Atom charge="0.1963" name="HD2" type="protein-H4" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NHIP-CTER-PROT">
+      <Atom charge="0.256" name="N" type="protein-N3" />
+      <Atom charge="0.1704" name="H1" type="protein-H" />
+      <Atom charge="0.1704" name="H2" type="protein-H" />
+      <Atom charge="0.1704" name="H3" type="protein-H" />
+      <Atom charge="0.0581" name="CA" type="protein-CX" />
+      <Atom charge="0.1047" name="HA" type="protein-HP" />
+      <Atom charge="0.0484" name="CB" type="protein-CT" />
+      <Atom charge="0.0531" name="HB2" type="protein-HC" />
+      <Atom charge="0.0531" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0236" name="CG" type="protein-CC" />
+      <Atom charge="-0.151" name="ND1" type="protein-NA" />
+      <Atom charge="0.3821" name="HD1" type="protein-H" />
+      <Atom charge="-0.0011" name="CE1" type="protein-CR" />
+      <Atom charge="0.2645" name="HE1" type="protein-H5" />
+      <Atom charge="-0.1739" name="NE2" type="protein-NA" />
+      <Atom charge="0.3921" name="HE2" type="protein-H" />
+      <Atom charge="-0.1433" name="CD2" type="protein-CW" />
+      <Atom charge="0.2495" name="HD2" type="protein-H4" />
+      <Atom charge="0.7214" name="C" type="protein-C" />
+      <Atom charge="-0.6013" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="ND1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="ND1" atomName2="HD1" />
+      <Bond atomName1="ND1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="NE2" />
+      <Bond atomName1="NE2" atomName2="HE2" />
+      <Bond atomName1="NE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NILE-CTER-PROT">
+      <Atom charge="0.0311" name="N" type="protein-N3" />
+      <Atom charge="0.2329" name="H1" type="protein-H" />
+      <Atom charge="0.2329" name="H2" type="protein-H" />
+      <Atom charge="0.2329" name="H3" type="protein-H" />
+      <Atom charge="0.0257" name="CA" type="protein-CX" />
+      <Atom charge="0.1031" name="HA" type="protein-HP" />
+      <Atom charge="0.1885" name="CB" type="protein-3C" />
+      <Atom charge="0.0213" name="HB" type="protein-HC" />
+      <Atom charge="-0.372" name="CG2" type="protein-CT" />
+      <Atom charge="0.0947" name="HG21" type="protein-HC" />
+      <Atom charge="0.0947" name="HG22" type="protein-HC" />
+      <Atom charge="0.0947" name="HG23" type="protein-HC" />
+      <Atom charge="-0.0387" name="CG1" type="protein-2C" />
+      <Atom charge="0.0201" name="HG12" type="protein-HC" />
+      <Atom charge="0.0201" name="HG13" type="protein-HC" />
+      <Atom charge="-0.0908" name="CD1" type="protein-CT" />
+      <Atom charge="0.0226" name="HD11" type="protein-HC" />
+      <Atom charge="0.0226" name="HD12" type="protein-HC" />
+      <Atom charge="0.0226" name="HD13" type="protein-HC" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG1" atomName2="CD1" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NLEU-CTER-PROT">
+      <Atom charge="0.101" name="N" type="protein-N3" />
+      <Atom charge="0.2148" name="H1" type="protein-H" />
+      <Atom charge="0.2148" name="H2" type="protein-H" />
+      <Atom charge="0.2148" name="H3" type="protein-H" />
+      <Atom charge="0.0104" name="CA" type="protein-CX" />
+      <Atom charge="0.1053" name="HA" type="protein-HP" />
+      <Atom charge="-0.0244" name="CB" type="protein-2C" />
+      <Atom charge="0.0256" name="HB2" type="protein-HC" />
+      <Atom charge="0.0256" name="HB3" type="protein-HC" />
+      <Atom charge="0.3421" name="CG" type="protein-3C" />
+      <Atom charge="-0.038" name="HG" type="protein-HC" />
+      <Atom charge="-0.4106" name="CD1" type="protein-CT" />
+      <Atom charge="0.098" name="HD11" type="protein-HC" />
+      <Atom charge="0.098" name="HD12" type="protein-HC" />
+      <Atom charge="0.098" name="HD13" type="protein-HC" />
+      <Atom charge="-0.4104" name="CD2" type="protein-CT" />
+      <Atom charge="0.098" name="HD21" type="protein-HC" />
+      <Atom charge="0.098" name="HD22" type="protein-HC" />
+      <Atom charge="0.098" name="HD23" type="protein-HC" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD11" />
+      <Bond atomName1="CD1" atomName2="HD12" />
+      <Bond atomName1="CD1" atomName2="HD13" />
+      <Bond atomName1="CD2" atomName2="HD21" />
+      <Bond atomName1="CD2" atomName2="HD22" />
+      <Bond atomName1="CD2" atomName2="HD23" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NLYS-CTER-PROT">
+      <Atom charge="0.0966" name="N" type="protein-N3" />
+      <Atom charge="0.2165" name="H1" type="protein-H" />
+      <Atom charge="0.2165" name="H2" type="protein-H" />
+      <Atom charge="0.2165" name="H3" type="protein-H" />
+      <Atom charge="-0.0015" name="CA" type="protein-CX" />
+      <Atom charge="0.118" name="HA" type="protein-HP" />
+      <Atom charge="0.0212" name="CB" type="protein-C8" />
+      <Atom charge="0.0283" name="HB2" type="protein-HC" />
+      <Atom charge="0.0283" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0048" name="CG" type="protein-C8" />
+      <Atom charge="0.0121" name="HG2" type="protein-HC" />
+      <Atom charge="0.0121" name="HG3" type="protein-HC" />
+      <Atom charge="-0.0608" name="CD" type="protein-C8" />
+      <Atom charge="0.0633" name="HD2" type="protein-HC" />
+      <Atom charge="0.0633" name="HD3" type="protein-HC" />
+      <Atom charge="-0.0181" name="CE" type="protein-C8" />
+      <Atom charge="0.1171" name="HE2" type="protein-HP" />
+      <Atom charge="0.1171" name="HE3" type="protein-HP" />
+      <Atom charge="-0.3764" name="NZ" type="protein-N3" />
+      <Atom charge="0.3382" name="HZ1" type="protein-H" />
+      <Atom charge="0.3382" name="HZ2" type="protein-H" />
+      <Atom charge="0.3382" name="HZ3" type="protein-H" />
+      <Atom charge="0.7214" name="C" type="protein-C" />
+      <Atom charge="-0.6013" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CD" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="CE" atomName2="NZ" />
+      <Bond atomName1="NZ" atomName2="HZ1" />
+      <Bond atomName1="NZ" atomName2="HZ2" />
+      <Bond atomName1="NZ" atomName2="HZ3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NMET-CTER-PROT">
+      <Atom charge="0.1592" name="N" type="protein-N3" />
+      <Atom charge="0.1984" name="H1" type="protein-H" />
+      <Atom charge="0.1984" name="H2" type="protein-H" />
+      <Atom charge="0.1984" name="H3" type="protein-H" />
+      <Atom charge="0.0221" name="CA" type="protein-CX" />
+      <Atom charge="0.1116" name="HA" type="protein-HP" />
+      <Atom charge="0.0865" name="CB" type="protein-2C" />
+      <Atom charge="0.0125" name="HB2" type="protein-HC" />
+      <Atom charge="0.0125" name="HB3" type="protein-HC" />
+      <Atom charge="0.0334" name="CG" type="protein-2C" />
+      <Atom charge="0.0292" name="HG2" type="protein-H1" />
+      <Atom charge="0.0292" name="HG3" type="protein-H1" />
+      <Atom charge="-0.2774" name="SD" type="protein-S" />
+      <Atom charge="-0.0341" name="CE" type="protein-CT" />
+      <Atom charge="0.0597" name="HE1" type="protein-H1" />
+      <Atom charge="0.0597" name="HE2" type="protein-H1" />
+      <Atom charge="0.0597" name="HE3" type="protein-H1" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="SD" />
+      <Bond atomName1="SD" atomName2="CE" />
+      <Bond atomName1="CE" atomName2="HE1" />
+      <Bond atomName1="CE" atomName2="HE2" />
+      <Bond atomName1="CE" atomName2="HE3" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NPHE-CTER-PROT">
+      <Atom charge="0.1737" name="N" type="protein-N3" />
+      <Atom charge="0.1921" name="H1" type="protein-H" />
+      <Atom charge="0.1921" name="H2" type="protein-H" />
+      <Atom charge="0.1921" name="H3" type="protein-H" />
+      <Atom charge="0.0733" name="CA" type="protein-CX" />
+      <Atom charge="0.1041" name="HA" type="protein-HP" />
+      <Atom charge="0.033" name="CB" type="protein-CT" />
+      <Atom charge="0.0104" name="HB2" type="protein-HC" />
+      <Atom charge="0.0104" name="HB3" type="protein-HC" />
+      <Atom charge="0.0031" name="CG" type="protein-CA" />
+      <Atom charge="-0.1392" name="CD1" type="protein-CA" />
+      <Atom charge="0.1374" name="HD1" type="protein-HA" />
+      <Atom charge="-0.1602" name="CE1" type="protein-CA" />
+      <Atom charge="0.1433" name="HE1" type="protein-HA" />
+      <Atom charge="-0.1208" name="CZ" type="protein-CA" />
+      <Atom charge="0.1329" name="HZ" type="protein-HA" />
+      <Atom charge="-0.1603" name="CE2" type="protein-CA" />
+      <Atom charge="0.1433" name="HE2" type="protein-HA" />
+      <Atom charge="-0.1391" name="CD2" type="protein-CA" />
+      <Atom charge="0.1374" name="HD2" type="protein-HA" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="HZ" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NPRO-CTER-PROT">
+      <Atom charge="-0.202" name="N" type="protein-N3" />
+      <Atom charge="0.312" name="H2" type="protein-H" />
+      <Atom charge="0.312" name="H3" type="protein-H" />
+      <Atom charge="-0.012" name="CD" type="protein-CT" />
+      <Atom charge="0.1" name="HD2" type="protein-HP" />
+      <Atom charge="0.1" name="HD3" type="protein-HP" />
+      <Atom charge="-0.121" name="CG" type="protein-CT" />
+      <Atom charge="0.1" name="HG2" type="protein-HC" />
+      <Atom charge="0.1" name="HG3" type="protein-HC" />
+      <Atom charge="-0.115" name="CB" type="protein-CT" />
+      <Atom charge="0.1" name="HB2" type="protein-HC" />
+      <Atom charge="0.1" name="HB3" type="protein-HC" />
+      <Atom charge="0.1" name="CA" type="protein-CX" />
+      <Atom charge="0.1" name="HA" type="protein-HP" />
+      <Atom charge="0.526" name="C" type="protein-C" />
+      <Atom charge="-0.5" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CD" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CD" atomName2="HD2" />
+      <Bond atomName1="CD" atomName2="HD3" />
+      <Bond atomName1="CD" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="HG2" />
+      <Bond atomName1="CG" atomName2="HG3" />
+      <Bond atomName1="CG" atomName2="CB" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NSER-CTER-PROT">
+      <Atom charge="0.1849" name="N" type="protein-N3" />
+      <Atom charge="0.1898" name="H1" type="protein-H" />
+      <Atom charge="0.1898" name="H2" type="protein-H" />
+      <Atom charge="0.1898" name="H3" type="protein-H" />
+      <Atom charge="0.0567" name="CA" type="protein-CX" />
+      <Atom charge="0.0782" name="HA" type="protein-HP" />
+      <Atom charge="0.2596" name="CB" type="protein-2C" />
+      <Atom charge="0.0273" name="HB2" type="protein-H1" />
+      <Atom charge="0.0273" name="HB3" type="protein-H1" />
+      <Atom charge="-0.6714" name="OG" type="protein-OH" />
+      <Atom charge="0.4239" name="HG" type="protein-HO" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="OG" />
+      <Bond atomName1="OG" atomName2="HG" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NTHR-CTER-PROT">
+      <Atom charge="0.1812" name="N" type="protein-N3" />
+      <Atom charge="0.1934" name="H1" type="protein-H" />
+      <Atom charge="0.1934" name="H2" type="protein-H" />
+      <Atom charge="0.1934" name="H3" type="protein-H" />
+      <Atom charge="0.0034" name="CA" type="protein-CX" />
+      <Atom charge="0.1087" name="HA" type="protein-HP" />
+      <Atom charge="0.4514" name="CB" type="protein-3C" />
+      <Atom charge="-0.0323" name="HB" type="protein-H1" />
+      <Atom charge="-0.2554" name="CG2" type="protein-CT" />
+      <Atom charge="0.0627" name="HG21" type="protein-HC" />
+      <Atom charge="0.0627" name="HG22" type="protein-HC" />
+      <Atom charge="0.0627" name="HG23" type="protein-HC" />
+      <Atom charge="-0.6764" name="OG1" type="protein-OH" />
+      <Atom charge="0.407" name="HG1" type="protein-HO" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CB" atomName2="OG1" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="OG1" atomName2="HG1" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NTRP-CTER-PROT">
+      <Atom charge="0.1913" name="N" type="protein-N3" />
+      <Atom charge="0.1888" name="H1" type="protein-H" />
+      <Atom charge="0.1888" name="H2" type="protein-H" />
+      <Atom charge="0.1888" name="H3" type="protein-H" />
+      <Atom charge="0.0421" name="CA" type="protein-CX" />
+      <Atom charge="0.1162" name="HA" type="protein-HP" />
+      <Atom charge="0.0543" name="CB" type="protein-CT" />
+      <Atom charge="0.0222" name="HB2" type="protein-HC" />
+      <Atom charge="0.0222" name="HB3" type="protein-HC" />
+      <Atom charge="-0.1654" name="CG" type="protein-C*" />
+      <Atom charge="-0.1788" name="CD1" type="protein-CW" />
+      <Atom charge="0.2195" name="HD1" type="protein-H4" />
+      <Atom charge="-0.3444" name="NE1" type="protein-NA" />
+      <Atom charge="0.3412" name="HE1" type="protein-H" />
+      <Atom charge="0.1575" name="CE2" type="protein-CN" />
+      <Atom charge="-0.271" name="CZ2" type="protein-CA" />
+      <Atom charge="0.1589" name="HZ2" type="protein-HA" />
+      <Atom charge="-0.108" name="CH2" type="protein-CA" />
+      <Atom charge="0.1411" name="HH2" type="protein-HA" />
+      <Atom charge="-0.2034" name="CZ3" type="protein-CA" />
+      <Atom charge="0.1458" name="HZ3" type="protein-HA" />
+      <Atom charge="-0.2265" name="CE3" type="protein-CA" />
+      <Atom charge="0.1646" name="HE3" type="protein-HA" />
+      <Atom charge="0.1132" name="CD2" type="protein-CB" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="NE1" />
+      <Bond atomName1="NE1" atomName2="HE1" />
+      <Bond atomName1="NE1" atomName2="CE2" />
+      <Bond atomName1="CE2" atomName2="CZ2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CZ2" atomName2="HZ2" />
+      <Bond atomName1="CZ2" atomName2="CH2" />
+      <Bond atomName1="CH2" atomName2="HH2" />
+      <Bond atomName1="CH2" atomName2="CZ3" />
+      <Bond atomName1="CZ3" atomName2="HZ3" />
+      <Bond atomName1="CZ3" atomName2="CE3" />
+      <Bond atomName1="CE3" atomName2="HE3" />
+      <Bond atomName1="CE3" atomName2="CD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NTYR-CTER-PROT">
+      <Atom charge="0.194" name="N" type="protein-N3" />
+      <Atom charge="0.1873" name="H1" type="protein-H" />
+      <Atom charge="0.1873" name="H2" type="protein-H" />
+      <Atom charge="0.1873" name="H3" type="protein-H" />
+      <Atom charge="0.057" name="CA" type="protein-CX" />
+      <Atom charge="0.0983" name="HA" type="protein-HP" />
+      <Atom charge="0.0659" name="CB" type="protein-CT" />
+      <Atom charge="0.0102" name="HB2" type="protein-HC" />
+      <Atom charge="0.0102" name="HB3" type="protein-HC" />
+      <Atom charge="-0.0205" name="CG" type="protein-CA" />
+      <Atom charge="-0.2002" name="CD1" type="protein-CA" />
+      <Atom charge="0.172" name="HD1" type="protein-HA" />
+      <Atom charge="-0.2239" name="CE1" type="protein-CA" />
+      <Atom charge="0.165" name="HE1" type="protein-HA" />
+      <Atom charge="0.3139" name="CZ" type="protein-C" />
+      <Atom charge="-0.5578" name="OH" type="protein-OH" />
+      <Atom charge="0.4001" name="HH" type="protein-HO" />
+      <Atom charge="-0.2239" name="CE2" type="protein-CA" />
+      <Atom charge="0.165" name="HE2" type="protein-HA" />
+      <Atom charge="-0.2002" name="CD2" type="protein-CA" />
+      <Atom charge="0.172" name="HD2" type="protein-HA" />
+      <Atom charge="0.6123" name="C" type="protein-C" />
+      <Atom charge="-0.5713" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB2" />
+      <Bond atomName1="CB" atomName2="HB3" />
+      <Bond atomName1="CB" atomName2="CG" />
+      <Bond atomName1="CG" atomName2="CD1" />
+      <Bond atomName1="CG" atomName2="CD2" />
+      <Bond atomName1="CD1" atomName2="HD1" />
+      <Bond atomName1="CD1" atomName2="CE1" />
+      <Bond atomName1="CE1" atomName2="HE1" />
+      <Bond atomName1="CE1" atomName2="CZ" />
+      <Bond atomName1="CZ" atomName2="OH" />
+      <Bond atomName1="CZ" atomName2="CE2" />
+      <Bond atomName1="OH" atomName2="HH" />
+      <Bond atomName1="CE2" atomName2="HE2" />
+      <Bond atomName1="CE2" atomName2="CD2" />
+      <Bond atomName1="CD2" atomName2="HD2" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+    <Residue name="NVAL-CTER-PROT">
+      <Atom charge="0.0577" name="N" type="protein-N3" />
+      <Atom charge="0.2272" name="H1" type="protein-H" />
+      <Atom charge="0.2272" name="H2" type="protein-H" />
+      <Atom charge="0.2272" name="H3" type="protein-H" />
+      <Atom charge="-0.0054" name="CA" type="protein-CX" />
+      <Atom charge="0.1093" name="HA" type="protein-HP" />
+      <Atom charge="0.3196" name="CB" type="protein-3C" />
+      <Atom charge="-0.0221" name="HB" type="protein-HC" />
+      <Atom charge="-0.3129" name="CG1" type="protein-CT" />
+      <Atom charge="0.0735" name="HG11" type="protein-HC" />
+      <Atom charge="0.0735" name="HG12" type="protein-HC" />
+      <Atom charge="0.0735" name="HG13" type="protein-HC" />
+      <Atom charge="-0.3129" name="CG2" type="protein-CT" />
+      <Atom charge="0.0735" name="HG21" type="protein-HC" />
+      <Atom charge="0.0735" name="HG22" type="protein-HC" />
+      <Atom charge="0.0735" name="HG23" type="protein-HC" />
+      <Atom charge="0.6163" name="C" type="protein-C" />
+      <Atom charge="-0.5722" name="O" type="protein-O" />
+      <Bond atomName1="N" atomName2="H1" />
+      <Bond atomName1="N" atomName2="H2" />
+      <Bond atomName1="N" atomName2="H3" />
+      <Bond atomName1="N" atomName2="CA" />
+      <Bond atomName1="CA" atomName2="HA" />
+      <Bond atomName1="CA" atomName2="CB" />
+      <Bond atomName1="CA" atomName2="C" />
+      <Bond atomName1="CB" atomName2="HB" />
+      <Bond atomName1="CB" atomName2="CG1" />
+      <Bond atomName1="CB" atomName2="CG2" />
+      <Bond atomName1="CG1" atomName2="HG11" />
+      <Bond atomName1="CG1" atomName2="HG12" />
+      <Bond atomName1="CG1" atomName2="HG13" />
+      <Bond atomName1="CG2" atomName2="HG21" />
+      <Bond atomName1="CG2" atomName2="HG22" />
+      <Bond atomName1="CG2" atomName2="HG23" />
+      <Bond atomName1="C" atomName2="O" />
+      <Atom charge="0.0000" name="HXT" type="protein-HA" /><Bond atomName1="C" atomName2="HXT" /></Residue>
+  </Residues></ForceField>

--- a/perses/data/protein.ff14SB.xml
+++ b/perses/data/protein.ff14SB.xml
@@ -1,0 +1,3444 @@
+<ForceField>
+  <Info>
+    <DateGenerated>2018-03-02</DateGenerated>
+    <Source Source="leaprc.protein.ff14SB" md5hash="2fbe80b999846068f2a1b6f3c50fcbb9" sourcePackage="AmberTools" sourcePackageVersion="17.6">leaprc.protein.ff14SB</Source>
+    <Reference>Maier, J.A., Martinez, C., Kasavajhala, K., Wickstrom, L., Hauser, K.E., and Simmerling, C. (2015). ff14SB: Improving the Accuracy of Protein Side Chain and Backbone Parameters from ff99SB. J. Chem. Theory Comput. 11, 3696-3713.</Reference>
+  </Info>
+  <AtomTypes>
+    <Type class="C" element="C" mass="12.01" name="protein-C"/>
+    <Type class="CA" element="C" mass="12.01" name="protein-CA"/>
+    <Type class="CB" element="C" mass="12.01" name="protein-CB"/>
+    <Type class="CC" element="C" mass="12.01" name="protein-CC"/>
+    <Type class="CN" element="C" mass="12.01" name="protein-CN"/>
+    <Type class="CR" element="C" mass="12.01" name="protein-CR"/>
+    <Type class="CT" element="C" mass="12.01" name="protein-CT"/>
+    <Type class="CV" element="C" mass="12.01" name="protein-CV"/>
+    <Type class="CW" element="C" mass="12.01" name="protein-CW"/>
+    <Type class="C*" element="C" mass="12.01" name="protein-C*"/>
+    <Type class="CX" element="C" mass="12.01" name="protein-CX"/>
+    <Type class="H" element="H" mass="1.008" name="protein-H"/>
+    <Type class="HC" element="H" mass="1.008" name="protein-HC"/>
+    <Type class="H1" element="H" mass="1.008" name="protein-H1"/>
+    <Type class="HA" element="H" mass="1.008" name="protein-HA"/>
+    <Type class="H4" element="H" mass="1.008" name="protein-H4"/>
+    <Type class="H5" element="H" mass="1.008" name="protein-H5"/>
+    <Type class="HO" element="H" mass="1.008" name="protein-HO"/>
+    <Type class="HS" element="H" mass="1.008" name="protein-HS"/>
+    <Type class="HP" element="H" mass="1.008" name="protein-HP"/>
+    <Type class="N" element="N" mass="14.01" name="protein-N"/>
+    <Type class="NA" element="N" mass="14.01" name="protein-NA"/>
+    <Type class="NB" element="N" mass="14.01" name="protein-NB"/>
+    <Type class="N2" element="N" mass="14.01" name="protein-N2"/>
+    <Type class="N3" element="N" mass="14.01" name="protein-N3"/>
+    <Type class="O" element="O" mass="16.0" name="protein-O"/>
+    <Type class="O2" element="O" mass="16.0" name="protein-O2"/>
+    <Type class="OH" element="O" mass="16.0" name="protein-OH"/>
+    <Type class="S" element="S" mass="32.06" name="protein-S"/>
+    <Type class="SH" element="S" mass="32.06" name="protein-SH"/>
+    <Type class="CO" element="C" mass="12.01" name="protein-CO"/>
+    <Type class="2C" element="C" mass="12.01" name="protein-2C"/>
+    <Type class="3C" element="C" mass="12.01" name="protein-3C"/>
+    <Type class="C8" element="C" mass="12.01" name="protein-C8"/>
+  </AtomTypes>
+  <Residues>
+    <Residue name="ALA">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0337" name="CA" type="protein-CX"/>
+      <Atom charge="0.0823" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1825" name="CB" type="protein-CT"/>
+      <Atom charge="0.0603" name="HB1" type="protein-HC"/>
+      <Atom charge="0.0603" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0603" name="HB3" type="protein-HC"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ARG">
+      <Atom charge="-0.3479" name="N" type="protein-N"/>
+      <Atom charge="0.2747" name="H" type="protein-H"/>
+      <Atom charge="-0.2637" name="CA" type="protein-CX"/>
+      <Atom charge="0.156" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0007" name="CB" type="protein-C8"/>
+      <Atom charge="0.0327" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0327" name="HB3" type="protein-HC"/>
+      <Atom charge="0.039" name="CG" type="protein-C8"/>
+      <Atom charge="0.0285" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0285" name="HG3" type="protein-HC"/>
+      <Atom charge="0.0486" name="CD" type="protein-C8"/>
+      <Atom charge="0.0687" name="HD2" type="protein-H1"/>
+      <Atom charge="0.0687" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.5295" name="NE" type="protein-N2"/>
+      <Atom charge="0.3456" name="HE" type="protein-H"/>
+      <Atom charge="0.8076" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.8627" name="NH1" type="protein-N2"/>
+      <Atom charge="0.4478" name="HH11" type="protein-H"/>
+      <Atom charge="0.4478" name="HH12" type="protein-H"/>
+      <Atom charge="-0.8627" name="NH2" type="protein-N2"/>
+      <Atom charge="0.4478" name="HH21" type="protein-H"/>
+      <Atom charge="0.4478" name="HH22" type="protein-H"/>
+      <Atom charge="0.7341" name="C" type="protein-C"/>
+      <Atom charge="-0.5894" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASH">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0341" name="CA" type="protein-CX"/>
+      <Atom charge="0.0864" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0316" name="CB" type="protein-2C"/>
+      <Atom charge="0.0488" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0488" name="HB3" type="protein-HC"/>
+      <Atom charge="0.6462" name="CG" type="protein-C"/>
+      <Atom charge="-0.5554" name="OD1" type="protein-O"/>
+      <Atom charge="-0.6376" name="OD2" type="protein-OH"/>
+      <Atom charge="0.4747" name="HD2" type="protein-HO"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="OD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASN">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0143" name="CA" type="protein-CX"/>
+      <Atom charge="0.1048" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2041" name="CB" type="protein-2C"/>
+      <Atom charge="0.0797" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0797" name="HB3" type="protein-HC"/>
+      <Atom charge="0.713" name="CG" type="protein-C"/>
+      <Atom charge="-0.5931" name="OD1" type="protein-O"/>
+      <Atom charge="-0.9191" name="ND2" type="protein-N"/>
+      <Atom charge="0.4196" name="HD21" type="protein-H"/>
+      <Atom charge="0.4196" name="HD22" type="protein-H"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ASP">
+      <Atom charge="-0.5163" name="N" type="protein-N"/>
+      <Atom charge="0.2936" name="H" type="protein-H"/>
+      <Atom charge="0.0381" name="CA" type="protein-CX"/>
+      <Atom charge="0.088" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0303" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0122" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0122" name="HB3" type="protein-HC"/>
+      <Atom charge="0.7994" name="CG" type="protein-CO"/>
+      <Atom charge="-0.8014" name="OD1" type="protein-O2"/>
+      <Atom charge="-0.8014" name="OD2" type="protein-O2"/>
+      <Atom charge="0.5366" name="C" type="protein-C"/>
+      <Atom charge="-0.5819" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYM">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0351" name="CA" type="protein-CX"/>
+      <Atom charge="0.0508" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2413" name="CB" type="protein-CT"/>
+      <Atom charge="0.1122" name="HB3" type="protein-H1"/>
+      <Atom charge="0.1122" name="HB2" type="protein-H1"/>
+      <Atom charge="-0.8844" name="SG" type="protein-SH"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYS">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0213" name="CA" type="protein-CX"/>
+      <Atom charge="0.1124" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1231" name="CB" type="protein-2C"/>
+      <Atom charge="0.1112" name="HB2" type="protein-H1"/>
+      <Atom charge="0.1112" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.3119" name="SG" type="protein-SH"/>
+      <Atom charge="0.1933" name="HG" type="protein-HS"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CYX">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0429" name="CA" type="protein-CX"/>
+      <Atom charge="0.0766" name="HA" type="protein-H1"/>
+      <Atom charge="-0.079" name="CB" type="protein-2C"/>
+      <Atom charge="0.091" name="HB2" type="protein-H1"/>
+      <Atom charge="0.091" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.1081" name="SG" type="protein-S"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLH">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0145" name="CA" type="protein-CX"/>
+      <Atom charge="0.0779" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0071" name="CB" type="protein-2C"/>
+      <Atom charge="0.0256" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0256" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0174" name="CG" type="protein-2C"/>
+      <Atom charge="0.043" name="HG2" type="protein-HC"/>
+      <Atom charge="0.043" name="HG3" type="protein-HC"/>
+      <Atom charge="0.6801" name="CD" type="protein-C"/>
+      <Atom charge="-0.5838" name="OE1" type="protein-O"/>
+      <Atom charge="-0.6511" name="OE2" type="protein-OH"/>
+      <Atom charge="0.4641" name="HE2" type="protein-HO"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="OE2" atomName2="HE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLN">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0031" name="CA" type="protein-CX"/>
+      <Atom charge="0.085" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0036" name="CB" type="protein-2C"/>
+      <Atom charge="0.0171" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0171" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0645" name="CG" type="protein-2C"/>
+      <Atom charge="0.0352" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0352" name="HG3" type="protein-HC"/>
+      <Atom charge="0.6951" name="CD" type="protein-C"/>
+      <Atom charge="-0.6086" name="OE1" type="protein-O"/>
+      <Atom charge="-0.9407" name="NE2" type="protein-N"/>
+      <Atom charge="0.4251" name="HE21" type="protein-H"/>
+      <Atom charge="0.4251" name="HE22" type="protein-H"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLU">
+      <Atom charge="-0.5163" name="N" type="protein-N"/>
+      <Atom charge="0.2936" name="H" type="protein-H"/>
+      <Atom charge="0.0397" name="CA" type="protein-CX"/>
+      <Atom charge="0.1105" name="HA" type="protein-H1"/>
+      <Atom charge="0.056" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0173" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0173" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0136" name="CG" type="protein-2C"/>
+      <Atom charge="-0.0425" name="HG2" type="protein-HC"/>
+      <Atom charge="-0.0425" name="HG3" type="protein-HC"/>
+      <Atom charge="0.8054" name="CD" type="protein-CO"/>
+      <Atom charge="-0.8188" name="OE1" type="protein-O2"/>
+      <Atom charge="-0.8188" name="OE2" type="protein-O2"/>
+      <Atom charge="0.5366" name="C" type="protein-C"/>
+      <Atom charge="-0.5819" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="GLY">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0252" name="CA" type="protein-CX"/>
+      <Atom charge="0.0698" name="HA2" type="protein-H1"/>
+      <Atom charge="0.0698" name="HA3" type="protein-H1"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HID">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="0.0188" name="CA" type="protein-CX"/>
+      <Atom charge="0.0881" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0462" name="CB" type="protein-CT"/>
+      <Atom charge="0.0402" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0402" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0266" name="CG" type="protein-CC"/>
+      <Atom charge="-0.3811" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3649" name="HD1" type="protein-H"/>
+      <Atom charge="0.2057" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1392" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.5727" name="NE2" type="protein-NB"/>
+      <Atom charge="0.1292" name="CD2" type="protein-CV"/>
+      <Atom charge="0.1147" name="HD2" type="protein-H4"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HIE">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0581" name="CA" type="protein-CX"/>
+      <Atom charge="0.136" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0074" name="CB" type="protein-CT"/>
+      <Atom charge="0.0367" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0367" name="HB3" type="protein-HC"/>
+      <Atom charge="0.1868" name="CG" type="protein-CC"/>
+      <Atom charge="-0.5432" name="ND1" type="protein-NB"/>
+      <Atom charge="0.1635" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1435" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.2795" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3339" name="HE2" type="protein-H"/>
+      <Atom charge="-0.2207" name="CD2" type="protein-CW"/>
+      <Atom charge="0.1862" name="HD2" type="protein-H4"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HIP">
+      <Atom charge="-0.3479" name="N" type="protein-N"/>
+      <Atom charge="0.2747" name="H" type="protein-H"/>
+      <Atom charge="-0.1354" name="CA" type="protein-CX"/>
+      <Atom charge="0.1212" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0414" name="CB" type="protein-CT"/>
+      <Atom charge="0.081" name="HB2" type="protein-HC"/>
+      <Atom charge="0.081" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0012" name="CG" type="protein-CC"/>
+      <Atom charge="-0.1513" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3866" name="HD1" type="protein-H"/>
+      <Atom charge="-0.017" name="CE1" type="protein-CR"/>
+      <Atom charge="0.2681" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.1718" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3911" name="HE2" type="protein-H"/>
+      <Atom charge="-0.1141" name="CD2" type="protein-CW"/>
+      <Atom charge="0.2317" name="HD2" type="protein-H4"/>
+      <Atom charge="0.7341" name="C" type="protein-C"/>
+      <Atom charge="-0.5894" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="HYP">
+      <Atom charge="-0.2548" name="N" type="protein-N"/>
+      <Atom charge="0.0595" name="CD" type="protein-CT"/>
+      <Atom charge="0.07" name="HD22" type="protein-H1"/>
+      <Atom charge="0.07" name="HD23" type="protein-H1"/>
+      <Atom charge="0.04" name="CG" type="protein-CT"/>
+      <Atom charge="0.0416" name="HG" type="protein-H1"/>
+      <Atom charge="-0.6134" name="OD1" type="protein-OH"/>
+      <Atom charge="0.3851" name="HD1" type="protein-HO"/>
+      <Atom charge="0.0203" name="CB" type="protein-CT"/>
+      <Atom charge="0.0426" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0426" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0047" name="CA" type="protein-CX"/>
+      <Atom charge="0.077" name="HA" type="protein-H1"/>
+      <Atom charge="0.5896" name="C" type="protein-C"/>
+      <Atom charge="-0.5748" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD22"/>
+      <Bond atomName1="CD" atomName2="HD23"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="OD1" atomName2="HD1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="ILE">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0597" name="CA" type="protein-CX"/>
+      <Atom charge="0.0869" name="HA" type="protein-H1"/>
+      <Atom charge="0.1303" name="CB" type="protein-3C"/>
+      <Atom charge="0.0187" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3204" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0882" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0882" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0882" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.043" name="CG1" type="protein-2C"/>
+      <Atom charge="0.0236" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0236" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.066" name="CD1" type="protein-CT"/>
+      <Atom charge="0.0186" name="HD11" type="protein-HC"/>
+      <Atom charge="0.0186" name="HD12" type="protein-HC"/>
+      <Atom charge="0.0186" name="HD13" type="protein-HC"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LEU">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0518" name="CA" type="protein-CX"/>
+      <Atom charge="0.0922" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1102" name="CB" type="protein-2C"/>
+      <Atom charge="0.0457" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0457" name="HB3" type="protein-HC"/>
+      <Atom charge="0.3531" name="CG" type="protein-3C"/>
+      <Atom charge="-0.0361" name="HG" type="protein-HC"/>
+      <Atom charge="-0.4121" name="CD1" type="protein-CT"/>
+      <Atom charge="0.1" name="HD11" type="protein-HC"/>
+      <Atom charge="0.1" name="HD12" type="protein-HC"/>
+      <Atom charge="0.1" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.4121" name="CD2" type="protein-CT"/>
+      <Atom charge="0.1" name="HD21" type="protein-HC"/>
+      <Atom charge="0.1" name="HD22" type="protein-HC"/>
+      <Atom charge="0.1" name="HD23" type="protein-HC"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LYN">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.07206" name="CA" type="protein-CX"/>
+      <Atom charge="0.0994" name="HA" type="protein-H1"/>
+      <Atom charge="-0.04845" name="CB" type="protein-CT"/>
+      <Atom charge="0.034" name="HB2" type="protein-HC"/>
+      <Atom charge="0.034" name="HB3" type="protein-HC"/>
+      <Atom charge="0.06612" name="CG" type="protein-CT"/>
+      <Atom charge="0.01041" name="HG2" type="protein-HC"/>
+      <Atom charge="0.01041" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.03768" name="CD" type="protein-CT"/>
+      <Atom charge="0.01155" name="HD2" type="protein-HC"/>
+      <Atom charge="0.01155" name="HD3" type="protein-HC"/>
+      <Atom charge="0.32604" name="CE" type="protein-CT"/>
+      <Atom charge="-0.03358" name="HE2" type="protein-HP"/>
+      <Atom charge="-0.03358" name="HE3" type="protein-HP"/>
+      <Atom charge="-1.03581" name="NZ" type="protein-N3"/>
+      <Atom charge="0.38604" name="HZ2" type="protein-H"/>
+      <Atom charge="0.38604" name="HZ3" type="protein-H"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="LYS">
+      <Atom charge="-0.3479" name="N" type="protein-N"/>
+      <Atom charge="0.2747" name="H" type="protein-H"/>
+      <Atom charge="-0.24" name="CA" type="protein-CX"/>
+      <Atom charge="0.1426" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0094" name="CB" type="protein-C8"/>
+      <Atom charge="0.0362" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0362" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0187" name="CG" type="protein-C8"/>
+      <Atom charge="0.0103" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0103" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.0479" name="CD" type="protein-C8"/>
+      <Atom charge="0.0621" name="HD2" type="protein-HC"/>
+      <Atom charge="0.0621" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.0143" name="CE" type="protein-C8"/>
+      <Atom charge="0.1135" name="HE2" type="protein-HP"/>
+      <Atom charge="0.1135" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.3854" name="NZ" type="protein-N3"/>
+      <Atom charge="0.34" name="HZ1" type="protein-H"/>
+      <Atom charge="0.34" name="HZ2" type="protein-H"/>
+      <Atom charge="0.34" name="HZ3" type="protein-H"/>
+      <Atom charge="0.7341" name="C" type="protein-C"/>
+      <Atom charge="-0.5894" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="MET">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0237" name="CA" type="protein-CX"/>
+      <Atom charge="0.088" name="HA" type="protein-H1"/>
+      <Atom charge="0.0342" name="CB" type="protein-2C"/>
+      <Atom charge="0.0241" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0241" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0018" name="CG" type="protein-2C"/>
+      <Atom charge="0.044" name="HG2" type="protein-H1"/>
+      <Atom charge="0.044" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.2737" name="SD" type="protein-S"/>
+      <Atom charge="-0.0536" name="CE" type="protein-CT"/>
+      <Atom charge="0.0684" name="HE1" type="protein-H1"/>
+      <Atom charge="0.0684" name="HE2" type="protein-H1"/>
+      <Atom charge="0.0684" name="HE3" type="protein-H1"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="PHE">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0024" name="CA" type="protein-CX"/>
+      <Atom charge="0.0978" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0343" name="CB" type="protein-CT"/>
+      <Atom charge="0.0295" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0295" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0118" name="CG" type="protein-CA"/>
+      <Atom charge="-0.1256" name="CD1" type="protein-CA"/>
+      <Atom charge="0.133" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.1704" name="CE1" type="protein-CA"/>
+      <Atom charge="0.143" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.1072" name="CZ" type="protein-CA"/>
+      <Atom charge="0.1297" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.1704" name="CE2" type="protein-CA"/>
+      <Atom charge="0.143" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.1256" name="CD2" type="protein-CA"/>
+      <Atom charge="0.133" name="HD2" type="protein-HA"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="PRO">
+      <Atom charge="-0.2548" name="N" type="protein-N"/>
+      <Atom charge="0.0192" name="CD" type="protein-CT"/>
+      <Atom charge="0.0391" name="HD2" type="protein-H1"/>
+      <Atom charge="0.0391" name="HD3" type="protein-H1"/>
+      <Atom charge="0.0189" name="CG" type="protein-CT"/>
+      <Atom charge="0.0213" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0213" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.007" name="CB" type="protein-CT"/>
+      <Atom charge="0.0253" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0253" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0266" name="CA" type="protein-CX"/>
+      <Atom charge="0.0641" name="HA" type="protein-H1"/>
+      <Atom charge="0.5896" name="C" type="protein-C"/>
+      <Atom charge="-0.5748" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="SER">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0249" name="CA" type="protein-CX"/>
+      <Atom charge="0.0843" name="HA" type="protein-H1"/>
+      <Atom charge="0.2117" name="CB" type="protein-2C"/>
+      <Atom charge="0.0352" name="HB2" type="protein-H1"/>
+      <Atom charge="0.0352" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.6546" name="OG" type="protein-OH"/>
+      <Atom charge="0.4275" name="HG" type="protein-HO"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="THR">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0389" name="CA" type="protein-CX"/>
+      <Atom charge="0.1007" name="HA" type="protein-H1"/>
+      <Atom charge="0.3654" name="CB" type="protein-3C"/>
+      <Atom charge="0.0043" name="HB" type="protein-H1"/>
+      <Atom charge="-0.2438" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0642" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0642" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0642" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.6761" name="OG1" type="protein-OH"/>
+      <Atom charge="0.4102" name="HG1" type="protein-HO"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="TRP">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0275" name="CA" type="protein-CX"/>
+      <Atom charge="0.1123" name="HA" type="protein-H1"/>
+      <Atom charge="-0.005" name="CB" type="protein-CT"/>
+      <Atom charge="0.0339" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0339" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.1415" name="CG" type="protein-C*"/>
+      <Atom charge="-0.1638" name="CD1" type="protein-CW"/>
+      <Atom charge="0.2062" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.3418" name="NE1" type="protein-NA"/>
+      <Atom charge="0.3412" name="HE1" type="protein-H"/>
+      <Atom charge="0.138" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.2601" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.1572" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.1134" name="CH2" type="protein-CA"/>
+      <Atom charge="0.1417" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.1972" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.1447" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.2387" name="CE3" type="protein-CA"/>
+      <Atom charge="0.17" name="HE3" type="protein-HA"/>
+      <Atom charge="0.1243" name="CD2" type="protein-CB"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="TYR">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0014" name="CA" type="protein-CX"/>
+      <Atom charge="0.0876" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0152" name="CB" type="protein-CT"/>
+      <Atom charge="0.0295" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0295" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0011" name="CG" type="protein-CA"/>
+      <Atom charge="-0.1906" name="CD1" type="protein-CA"/>
+      <Atom charge="0.1699" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.2341" name="CE1" type="protein-CA"/>
+      <Atom charge="0.1656" name="HE1" type="protein-HA"/>
+      <Atom charge="0.3226" name="CZ" type="protein-C"/>
+      <Atom charge="-0.5579" name="OH" type="protein-OH"/>
+      <Atom charge="0.3992" name="HH" type="protein-HO"/>
+      <Atom charge="-0.2341" name="CE2" type="protein-CA"/>
+      <Atom charge="0.1656" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.1906" name="CD2" type="protein-CA"/>
+      <Atom charge="0.1699" name="HD2" type="protein-HA"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="VAL">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.0875" name="CA" type="protein-CX"/>
+      <Atom charge="0.0969" name="HA" type="protein-H1"/>
+      <Atom charge="0.2985" name="CB" type="protein-3C"/>
+      <Atom charge="-0.0297" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3192" name="CG1" type="protein-CT"/>
+      <Atom charge="0.0791" name="HG11" type="protein-HC"/>
+      <Atom charge="0.0791" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0791" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.3192" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0791" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0791" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0791" name="HG23" type="protein-HC"/>
+      <Atom charge="0.5973" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="N"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="CALA">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.1747" name="CA" type="protein-CX"/>
+      <Atom charge="0.1067" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2093" name="CB" type="protein-CT"/>
+      <Atom charge="0.0764" name="HB1" type="protein-HC"/>
+      <Atom charge="0.0764" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0764" name="HB3" type="protein-HC"/>
+      <Atom charge="0.7731" name="C" type="protein-C"/>
+      <Atom charge="-0.8055" name="O" type="protein-O2"/>
+      <Atom charge="-0.8055" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CARG">
+      <Atom charge="-0.3481" name="N" type="protein-N"/>
+      <Atom charge="0.2764" name="H" type="protein-H"/>
+      <Atom charge="-0.3068" name="CA" type="protein-CX"/>
+      <Atom charge="0.1447" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0374" name="CB" type="protein-C8"/>
+      <Atom charge="0.0371" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0371" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0744" name="CG" type="protein-C8"/>
+      <Atom charge="0.0185" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0185" name="HG3" type="protein-HC"/>
+      <Atom charge="0.1114" name="CD" type="protein-C8"/>
+      <Atom charge="0.0468" name="HD2" type="protein-H1"/>
+      <Atom charge="0.0468" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.5564" name="NE" type="protein-N2"/>
+      <Atom charge="0.3479" name="HE" type="protein-H"/>
+      <Atom charge="0.8368" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.8737" name="NH1" type="protein-N2"/>
+      <Atom charge="0.4493" name="HH11" type="protein-H"/>
+      <Atom charge="0.4493" name="HH12" type="protein-H"/>
+      <Atom charge="-0.8737" name="NH2" type="protein-N2"/>
+      <Atom charge="0.4493" name="HH21" type="protein-H"/>
+      <Atom charge="0.4493" name="HH22" type="protein-H"/>
+      <Atom charge="0.8557" name="C" type="protein-C"/>
+      <Atom charge="-0.8266" name="O" type="protein-O2"/>
+      <Atom charge="-0.8266" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CASN">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.208" name="CA" type="protein-CX"/>
+      <Atom charge="0.1358" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2299" name="CB" type="protein-2C"/>
+      <Atom charge="0.1023" name="HB2" type="protein-HC"/>
+      <Atom charge="0.1023" name="HB3" type="protein-HC"/>
+      <Atom charge="0.7153" name="CG" type="protein-C"/>
+      <Atom charge="-0.601" name="OD1" type="protein-O"/>
+      <Atom charge="-0.9084" name="ND2" type="protein-N"/>
+      <Atom charge="0.415" name="HD21" type="protein-H"/>
+      <Atom charge="0.415" name="HD22" type="protein-H"/>
+      <Atom charge="0.805" name="C" type="protein-C"/>
+      <Atom charge="-0.8147" name="O" type="protein-O2"/>
+      <Atom charge="-0.8147" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CASP">
+      <Atom charge="-0.5192" name="N" type="protein-N"/>
+      <Atom charge="0.3055" name="H" type="protein-H"/>
+      <Atom charge="-0.1817" name="CA" type="protein-CX"/>
+      <Atom charge="0.1046" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0677" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0212" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0212" name="HB3" type="protein-HC"/>
+      <Atom charge="0.8851" name="CG" type="protein-CO"/>
+      <Atom charge="-0.8162" name="OD1" type="protein-O2"/>
+      <Atom charge="-0.8162" name="OD2" type="protein-O2"/>
+      <Atom charge="0.7256" name="C" type="protein-C"/>
+      <Atom charge="-0.7887" name="O" type="protein-O2"/>
+      <Atom charge="-0.7887" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CCYS">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.1635" name="CA" type="protein-CX"/>
+      <Atom charge="0.1396" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1996" name="CB" type="protein-2C"/>
+      <Atom charge="0.1437" name="HB2" type="protein-H1"/>
+      <Atom charge="0.1437" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.3102" name="SG" type="protein-SH"/>
+      <Atom charge="0.2068" name="HG" type="protein-HS"/>
+      <Atom charge="0.7497" name="C" type="protein-C"/>
+      <Atom charge="-0.7981" name="O" type="protein-O2"/>
+      <Atom charge="-0.7981" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CCYX">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.1318" name="CA" type="protein-CX"/>
+      <Atom charge="0.0938" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1943" name="CB" type="protein-2C"/>
+      <Atom charge="0.1228" name="HB2" type="protein-H1"/>
+      <Atom charge="0.1228" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.0529" name="SG" type="protein-S"/>
+      <Atom charge="0.7618" name="C" type="protein-C"/>
+      <Atom charge="-0.8041" name="O" type="protein-O2"/>
+      <Atom charge="-0.8041" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLN">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2248" name="CA" type="protein-CX"/>
+      <Atom charge="0.1232" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0664" name="CB" type="protein-2C"/>
+      <Atom charge="0.0452" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0452" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.021" name="CG" type="protein-2C"/>
+      <Atom charge="0.0203" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0203" name="HG3" type="protein-HC"/>
+      <Atom charge="0.7093" name="CD" type="protein-C"/>
+      <Atom charge="-0.6098" name="OE1" type="protein-O"/>
+      <Atom charge="-0.9574" name="NE2" type="protein-N"/>
+      <Atom charge="0.4304" name="HE21" type="protein-H"/>
+      <Atom charge="0.4304" name="HE22" type="protein-H"/>
+      <Atom charge="0.7775" name="C" type="protein-C"/>
+      <Atom charge="-0.8042" name="O" type="protein-O2"/>
+      <Atom charge="-0.8042" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLU">
+      <Atom charge="-0.5192" name="N" type="protein-N"/>
+      <Atom charge="0.3055" name="H" type="protein-H"/>
+      <Atom charge="-0.2059" name="CA" type="protein-CX"/>
+      <Atom charge="0.1399" name="HA" type="protein-H1"/>
+      <Atom charge="0.0071" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0078" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0078" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0675" name="CG" type="protein-2C"/>
+      <Atom charge="-0.0548" name="HG2" type="protein-HC"/>
+      <Atom charge="-0.0548" name="HG3" type="protein-HC"/>
+      <Atom charge="0.8183" name="CD" type="protein-CO"/>
+      <Atom charge="-0.822" name="OE1" type="protein-O2"/>
+      <Atom charge="-0.822" name="OE2" type="protein-O2"/>
+      <Atom charge="0.742" name="C" type="protein-C"/>
+      <Atom charge="-0.793" name="O" type="protein-O2"/>
+      <Atom charge="-0.793" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CGLY">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2493" name="CA" type="protein-CX"/>
+      <Atom charge="0.1056" name="HA2" type="protein-H1"/>
+      <Atom charge="0.1056" name="HA3" type="protein-H1"/>
+      <Atom charge="0.7231" name="C" type="protein-C"/>
+      <Atom charge="-0.7855" name="O" type="protein-O2"/>
+      <Atom charge="-0.7855" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHID">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.1739" name="CA" type="protein-CX"/>
+      <Atom charge="0.11" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1046" name="CB" type="protein-CT"/>
+      <Atom charge="0.0565" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0565" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0293" name="CG" type="protein-CC"/>
+      <Atom charge="-0.3892" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3755" name="HD1" type="protein-H"/>
+      <Atom charge="0.1925" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1418" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.5629" name="NE2" type="protein-NB"/>
+      <Atom charge="0.1001" name="CD2" type="protein-CV"/>
+      <Atom charge="0.1241" name="HD2" type="protein-H4"/>
+      <Atom charge="0.7615" name="C" type="protein-C"/>
+      <Atom charge="-0.8016" name="O" type="protein-O2"/>
+      <Atom charge="-0.8016" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHIE">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2699" name="CA" type="protein-CX"/>
+      <Atom charge="0.165" name="HA" type="protein-H1"/>
+      <Atom charge="-0.1068" name="CB" type="protein-CT"/>
+      <Atom charge="0.062" name="HB2" type="protein-HC"/>
+      <Atom charge="0.062" name="HB3" type="protein-HC"/>
+      <Atom charge="0.2724" name="CG" type="protein-CC"/>
+      <Atom charge="-0.5517" name="ND1" type="protein-NB"/>
+      <Atom charge="0.1558" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1448" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.267" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3319" name="HE2" type="protein-H"/>
+      <Atom charge="-0.2588" name="CD2" type="protein-CW"/>
+      <Atom charge="0.1957" name="HD2" type="protein-H4"/>
+      <Atom charge="0.7916" name="C" type="protein-C"/>
+      <Atom charge="-0.8065" name="O" type="protein-O2"/>
+      <Atom charge="-0.8065" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHIP">
+      <Atom charge="-0.3481" name="N" type="protein-N"/>
+      <Atom charge="0.2764" name="H" type="protein-H"/>
+      <Atom charge="-0.1445" name="CA" type="protein-CX"/>
+      <Atom charge="0.1115" name="HA" type="protein-H1"/>
+      <Atom charge="-0.08" name="CB" type="protein-CT"/>
+      <Atom charge="0.0868" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0868" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0298" name="CG" type="protein-CC"/>
+      <Atom charge="-0.1501" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3883" name="HD1" type="protein-H"/>
+      <Atom charge="-0.0251" name="CE1" type="protein-CR"/>
+      <Atom charge="0.2694" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.1683" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3913" name="HE2" type="protein-H"/>
+      <Atom charge="-0.1256" name="CD2" type="protein-CW"/>
+      <Atom charge="0.2336" name="HD2" type="protein-H4"/>
+      <Atom charge="0.8032" name="C" type="protein-C"/>
+      <Atom charge="-0.8177" name="O" type="protein-O2"/>
+      <Atom charge="-0.8177" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CHYP">
+      <Atom charge="-0.2802" name="N" type="protein-N"/>
+      <Atom charge="0.0778" name="CD" type="protein-CT"/>
+      <Atom charge="0.0331" name="HD22" type="protein-H1"/>
+      <Atom charge="0.0331" name="HD23" type="protein-H1"/>
+      <Atom charge="0.081" name="CG" type="protein-CT"/>
+      <Atom charge="0.0416" name="HG" type="protein-H1"/>
+      <Atom charge="-0.6134" name="OD1" type="protein-OH"/>
+      <Atom charge="0.3851" name="HD1" type="protein-HO"/>
+      <Atom charge="0.0547" name="CB" type="protein-CT"/>
+      <Atom charge="0.0426" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0426" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0993" name="CA" type="protein-CX"/>
+      <Atom charge="0.0776" name="HA" type="protein-H1"/>
+      <Atom charge="0.6631" name="C" type="protein-C"/>
+      <Atom charge="-0.7697" name="O" type="protein-O2"/>
+      <Atom charge="-0.7697" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD22"/>
+      <Bond atomName1="CD" atomName2="HD23"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="OD1" atomName2="HD1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CILE">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.31" name="CA" type="protein-CX"/>
+      <Atom charge="0.1375" name="HA" type="protein-H1"/>
+      <Atom charge="0.0363" name="CB" type="protein-3C"/>
+      <Atom charge="0.0766" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3498" name="CG2" type="protein-CT"/>
+      <Atom charge="0.1021" name="HG21" type="protein-HC"/>
+      <Atom charge="0.1021" name="HG22" type="protein-HC"/>
+      <Atom charge="0.1021" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.0323" name="CG1" type="protein-2C"/>
+      <Atom charge="0.0321" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0321" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.0699" name="CD1" type="protein-CT"/>
+      <Atom charge="0.0196" name="HD11" type="protein-HC"/>
+      <Atom charge="0.0196" name="HD12" type="protein-HC"/>
+      <Atom charge="0.0196" name="HD13" type="protein-HC"/>
+      <Atom charge="0.8343" name="C" type="protein-C"/>
+      <Atom charge="-0.819" name="O" type="protein-O2"/>
+      <Atom charge="-0.819" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CLEU">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2847" name="CA" type="protein-CX"/>
+      <Atom charge="0.1346" name="HA" type="protein-H1"/>
+      <Atom charge="-0.2469" name="CB" type="protein-2C"/>
+      <Atom charge="0.0974" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0974" name="HB3" type="protein-HC"/>
+      <Atom charge="0.3706" name="CG" type="protein-3C"/>
+      <Atom charge="-0.0374" name="HG" type="protein-HC"/>
+      <Atom charge="-0.4163" name="CD1" type="protein-CT"/>
+      <Atom charge="0.1038" name="HD11" type="protein-HC"/>
+      <Atom charge="0.1038" name="HD12" type="protein-HC"/>
+      <Atom charge="0.1038" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.4163" name="CD2" type="protein-CT"/>
+      <Atom charge="0.1038" name="HD21" type="protein-HC"/>
+      <Atom charge="0.1038" name="HD22" type="protein-HC"/>
+      <Atom charge="0.1038" name="HD23" type="protein-HC"/>
+      <Atom charge="0.8326" name="C" type="protein-C"/>
+      <Atom charge="-0.8199" name="O" type="protein-O2"/>
+      <Atom charge="-0.8199" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CLYS">
+      <Atom charge="-0.3481" name="N" type="protein-N"/>
+      <Atom charge="0.2764" name="H" type="protein-H"/>
+      <Atom charge="-0.2903" name="CA" type="protein-CX"/>
+      <Atom charge="0.1438" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0538" name="CB" type="protein-C8"/>
+      <Atom charge="0.0482" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0482" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0227" name="CG" type="protein-C8"/>
+      <Atom charge="0.0134" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0134" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.0392" name="CD" type="protein-C8"/>
+      <Atom charge="0.0611" name="HD2" type="protein-HC"/>
+      <Atom charge="0.0611" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.0176" name="CE" type="protein-C8"/>
+      <Atom charge="0.1121" name="HE2" type="protein-HP"/>
+      <Atom charge="0.1121" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.3741" name="NZ" type="protein-N3"/>
+      <Atom charge="0.3374" name="HZ1" type="protein-H"/>
+      <Atom charge="0.3374" name="HZ2" type="protein-H"/>
+      <Atom charge="0.3374" name="HZ3" type="protein-H"/>
+      <Atom charge="0.8488" name="C" type="protein-C"/>
+      <Atom charge="-0.8252" name="O" type="protein-O2"/>
+      <Atom charge="-0.8252" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CMET">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2597" name="CA" type="protein-CX"/>
+      <Atom charge="0.1277" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0236" name="CB" type="protein-2C"/>
+      <Atom charge="0.048" name="HB2" type="protein-HC"/>
+      <Atom charge="0.048" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0492" name="CG" type="protein-2C"/>
+      <Atom charge="0.0317" name="HG2" type="protein-H1"/>
+      <Atom charge="0.0317" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.2692" name="SD" type="protein-S"/>
+      <Atom charge="-0.0376" name="CE" type="protein-CT"/>
+      <Atom charge="0.0625" name="HE1" type="protein-H1"/>
+      <Atom charge="0.0625" name="HE2" type="protein-H1"/>
+      <Atom charge="0.0625" name="HE3" type="protein-H1"/>
+      <Atom charge="0.8013" name="C" type="protein-C"/>
+      <Atom charge="-0.8105" name="O" type="protein-O2"/>
+      <Atom charge="-0.8105" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CPHE">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.1825" name="CA" type="protein-CX"/>
+      <Atom charge="0.1098" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0959" name="CB" type="protein-CT"/>
+      <Atom charge="0.0443" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0443" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0552" name="CG" type="protein-CA"/>
+      <Atom charge="-0.13" name="CD1" type="protein-CA"/>
+      <Atom charge="0.1408" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.1847" name="CE1" type="protein-CA"/>
+      <Atom charge="0.1461" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.0944" name="CZ" type="protein-CA"/>
+      <Atom charge="0.128" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.1847" name="CE2" type="protein-CA"/>
+      <Atom charge="0.1461" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.13" name="CD2" type="protein-CA"/>
+      <Atom charge="0.1408" name="HD2" type="protein-HA"/>
+      <Atom charge="0.766" name="C" type="protein-C"/>
+      <Atom charge="-0.8026" name="O" type="protein-O2"/>
+      <Atom charge="-0.8026" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CPRO">
+      <Atom charge="-0.2802" name="N" type="protein-N"/>
+      <Atom charge="0.0434" name="CD" type="protein-CT"/>
+      <Atom charge="0.0331" name="HD2" type="protein-H1"/>
+      <Atom charge="0.0331" name="HD3" type="protein-H1"/>
+      <Atom charge="0.0466" name="CG" type="protein-CT"/>
+      <Atom charge="0.0172" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0172" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.0543" name="CB" type="protein-CT"/>
+      <Atom charge="0.0381" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0381" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.1336" name="CA" type="protein-CX"/>
+      <Atom charge="0.0776" name="HA" type="protein-H1"/>
+      <Atom charge="0.6631" name="C" type="protein-C"/>
+      <Atom charge="-0.7697" name="O" type="protein-O2"/>
+      <Atom charge="-0.7697" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CSER">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2722" name="CA" type="protein-CX"/>
+      <Atom charge="0.1304" name="HA" type="protein-H1"/>
+      <Atom charge="0.1123" name="CB" type="protein-2C"/>
+      <Atom charge="0.0813" name="HB2" type="protein-H1"/>
+      <Atom charge="0.0813" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.6514" name="OG" type="protein-OH"/>
+      <Atom charge="0.4474" name="HG" type="protein-HO"/>
+      <Atom charge="0.8113" name="C" type="protein-C"/>
+      <Atom charge="-0.8132" name="O" type="protein-O2"/>
+      <Atom charge="-0.8132" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTHR">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.242" name="CA" type="protein-CX"/>
+      <Atom charge="0.1207" name="HA" type="protein-H1"/>
+      <Atom charge="0.3025" name="CB" type="protein-3C"/>
+      <Atom charge="0.0078" name="HB" type="protein-H1"/>
+      <Atom charge="-0.1853" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0586" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0586" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0586" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.6496" name="OG1" type="protein-OH"/>
+      <Atom charge="0.4119" name="HG1" type="protein-HO"/>
+      <Atom charge="0.781" name="C" type="protein-C"/>
+      <Atom charge="-0.8044" name="O" type="protein-O2"/>
+      <Atom charge="-0.8044" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTRP">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2084" name="CA" type="protein-CX"/>
+      <Atom charge="0.1272" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0742" name="CB" type="protein-CT"/>
+      <Atom charge="0.0497" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0497" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0796" name="CG" type="protein-C*"/>
+      <Atom charge="-0.1808" name="CD1" type="protein-CW"/>
+      <Atom charge="0.2043" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.3316" name="NE1" type="protein-NA"/>
+      <Atom charge="0.3413" name="HE1" type="protein-H"/>
+      <Atom charge="0.1222" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.2594" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.1567" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.102" name="CH2" type="protein-CA"/>
+      <Atom charge="0.1401" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.2287" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.1507" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.1837" name="CE3" type="protein-CA"/>
+      <Atom charge="0.1491" name="HE3" type="protein-HA"/>
+      <Atom charge="0.1078" name="CD2" type="protein-CB"/>
+      <Atom charge="0.7658" name="C" type="protein-C"/>
+      <Atom charge="-0.8011" name="O" type="protein-O2"/>
+      <Atom charge="-0.8011" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CTYR">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.2015" name="CA" type="protein-CX"/>
+      <Atom charge="0.1092" name="HA" type="protein-H1"/>
+      <Atom charge="-0.0752" name="CB" type="protein-CT"/>
+      <Atom charge="0.049" name="HB2" type="protein-HC"/>
+      <Atom charge="0.049" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0243" name="CG" type="protein-CA"/>
+      <Atom charge="-0.1922" name="CD1" type="protein-CA"/>
+      <Atom charge="0.178" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.2458" name="CE1" type="protein-CA"/>
+      <Atom charge="0.1673" name="HE1" type="protein-HA"/>
+      <Atom charge="0.3395" name="CZ" type="protein-C"/>
+      <Atom charge="-0.5643" name="OH" type="protein-OH"/>
+      <Atom charge="0.4017" name="HH" type="protein-HO"/>
+      <Atom charge="-0.2458" name="CE2" type="protein-CA"/>
+      <Atom charge="0.1673" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.1922" name="CD2" type="protein-CA"/>
+      <Atom charge="0.178" name="HD2" type="protein-HA"/>
+      <Atom charge="0.7817" name="C" type="protein-C"/>
+      <Atom charge="-0.807" name="O" type="protein-O2"/>
+      <Atom charge="-0.807" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="CVAL">
+      <Atom charge="-0.3821" name="N" type="protein-N"/>
+      <Atom charge="0.2681" name="H" type="protein-H"/>
+      <Atom charge="-0.3438" name="CA" type="protein-CX"/>
+      <Atom charge="0.1438" name="HA" type="protein-H1"/>
+      <Atom charge="0.194" name="CB" type="protein-3C"/>
+      <Atom charge="0.0308" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3064" name="CG1" type="protein-CT"/>
+      <Atom charge="0.0836" name="HG11" type="protein-HC"/>
+      <Atom charge="0.0836" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0836" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.3064" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0836" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0836" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0836" name="HG23" type="protein-HC"/>
+      <Atom charge="0.835" name="C" type="protein-C"/>
+      <Atom charge="-0.8173" name="O" type="protein-O2"/>
+      <Atom charge="-0.8173" name="OXT" type="protein-O2"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <Bond atomName1="C" atomName2="OXT"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="NHE">
+      <Atom charge="-0.463" name="N" type="protein-N"/>
+      <Atom charge="0.2315" name="HN1" type="protein-H"/>
+      <Atom charge="0.2315" name="HN2" type="protein-H"/>
+      <Bond atomName1="N" atomName2="HN1"/>
+      <Bond atomName1="N" atomName2="HN2"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="NME">
+      <Atom charge="-0.4157" name="N" type="protein-N"/>
+      <Atom charge="0.2719" name="H" type="protein-H"/>
+      <Atom charge="-0.149" name="CH3" type="protein-CT"/>
+      <Atom charge="0.0976" name="HH31" type="protein-H1"/>
+      <Atom charge="0.0976" name="HH32" type="protein-H1"/>
+      <Atom charge="0.0976" name="HH33" type="protein-H1"/>
+      <Bond atomName1="N" atomName2="H"/>
+      <Bond atomName1="N" atomName2="CH3"/>
+      <Bond atomName1="CH3" atomName2="HH31"/>
+      <Bond atomName1="CH3" atomName2="HH32"/>
+      <Bond atomName1="CH3" atomName2="HH33"/>
+      <ExternalBond atomName="N"/>
+    </Residue>
+    <Residue name="ACE">
+      <Atom charge="0.1123" name="HH31" type="protein-HC"/>
+      <Atom charge="-0.3662" name="CH3" type="protein-CT"/>
+      <Atom charge="0.1123" name="HH32" type="protein-HC"/>
+      <Atom charge="0.1123" name="HH33" type="protein-HC"/>
+      <Atom charge="0.5972" name="C" type="protein-C"/>
+      <Atom charge="-0.5679" name="O" type="protein-O"/>
+      <Bond atomName1="HH31" atomName2="CH3"/>
+      <Bond atomName1="CH3" atomName2="HH32"/>
+      <Bond atomName1="CH3" atomName2="HH33"/>
+      <Bond atomName1="CH3" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NALA">
+      <Atom charge="0.1414" name="N" type="protein-N3"/>
+      <Atom charge="0.1997" name="H1" type="protein-H"/>
+      <Atom charge="0.1997" name="H2" type="protein-H"/>
+      <Atom charge="0.1997" name="H3" type="protein-H"/>
+      <Atom charge="0.0962" name="CA" type="protein-CX"/>
+      <Atom charge="0.0889" name="HA" type="protein-HP"/>
+      <Atom charge="-0.0597" name="CB" type="protein-CT"/>
+      <Atom charge="0.03" name="HB1" type="protein-HC"/>
+      <Atom charge="0.03" name="HB2" type="protein-HC"/>
+      <Atom charge="0.03" name="HB3" type="protein-HC"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB1"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NARG">
+      <Atom charge="0.1305" name="N" type="protein-N3"/>
+      <Atom charge="0.2083" name="H1" type="protein-H"/>
+      <Atom charge="0.2083" name="H2" type="protein-H"/>
+      <Atom charge="0.2083" name="H3" type="protein-H"/>
+      <Atom charge="-0.0223" name="CA" type="protein-CX"/>
+      <Atom charge="0.1242" name="HA" type="protein-HP"/>
+      <Atom charge="0.0118" name="CB" type="protein-C8"/>
+      <Atom charge="0.0226" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0226" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0236" name="CG" type="protein-C8"/>
+      <Atom charge="0.0309" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0309" name="HG3" type="protein-HC"/>
+      <Atom charge="0.0935" name="CD" type="protein-C8"/>
+      <Atom charge="0.0527" name="HD2" type="protein-H1"/>
+      <Atom charge="0.0527" name="HD3" type="protein-H1"/>
+      <Atom charge="-0.565" name="NE" type="protein-N2"/>
+      <Atom charge="0.3592" name="HE" type="protein-H"/>
+      <Atom charge="0.8281" name="CZ" type="protein-CA"/>
+      <Atom charge="-0.8693" name="NH1" type="protein-N2"/>
+      <Atom charge="0.4494" name="HH11" type="protein-H"/>
+      <Atom charge="0.4494" name="HH12" type="protein-H"/>
+      <Atom charge="-0.8693" name="NH2" type="protein-N2"/>
+      <Atom charge="0.4494" name="HH21" type="protein-H"/>
+      <Atom charge="0.4494" name="HH22" type="protein-H"/>
+      <Atom charge="0.7214" name="C" type="protein-C"/>
+      <Atom charge="-0.6013" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="NE"/>
+      <Bond atomName1="NE" atomName2="HE"/>
+      <Bond atomName1="NE" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="NH1"/>
+      <Bond atomName1="CZ" atomName2="NH2"/>
+      <Bond atomName1="NH1" atomName2="HH11"/>
+      <Bond atomName1="NH1" atomName2="HH12"/>
+      <Bond atomName1="NH2" atomName2="HH21"/>
+      <Bond atomName1="NH2" atomName2="HH22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NASN">
+      <Atom charge="0.1801" name="N" type="protein-N3"/>
+      <Atom charge="0.1921" name="H1" type="protein-H"/>
+      <Atom charge="0.1921" name="H2" type="protein-H"/>
+      <Atom charge="0.1921" name="H3" type="protein-H"/>
+      <Atom charge="0.0368" name="CA" type="protein-CX"/>
+      <Atom charge="0.1231" name="HA" type="protein-HP"/>
+      <Atom charge="-0.0283" name="CB" type="protein-2C"/>
+      <Atom charge="0.0515" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0515" name="HB3" type="protein-HC"/>
+      <Atom charge="0.5833" name="CG" type="protein-C"/>
+      <Atom charge="-0.5744" name="OD1" type="protein-O"/>
+      <Atom charge="-0.8634" name="ND2" type="protein-N"/>
+      <Atom charge="0.4097" name="HD21" type="protein-H"/>
+      <Atom charge="0.4097" name="HD22" type="protein-H"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="ND2"/>
+      <Bond atomName1="ND2" atomName2="HD21"/>
+      <Bond atomName1="ND2" atomName2="HD22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NASP">
+      <Atom charge="0.0782" name="N" type="protein-N3"/>
+      <Atom charge="0.22" name="H1" type="protein-H"/>
+      <Atom charge="0.22" name="H2" type="protein-H"/>
+      <Atom charge="0.22" name="H3" type="protein-H"/>
+      <Atom charge="0.0292" name="CA" type="protein-CX"/>
+      <Atom charge="0.1141" name="HA" type="protein-HP"/>
+      <Atom charge="-0.0235" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0169" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0169" name="HB3" type="protein-HC"/>
+      <Atom charge="0.8194" name="CG" type="protein-CO"/>
+      <Atom charge="-0.8084" name="OD1" type="protein-O2"/>
+      <Atom charge="-0.8084" name="OD2" type="protein-O2"/>
+      <Atom charge="0.5621" name="C" type="protein-C"/>
+      <Atom charge="-0.5889" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="OD1"/>
+      <Bond atomName1="CG" atomName2="OD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NCYS">
+      <Atom charge="0.1325" name="N" type="protein-N3"/>
+      <Atom charge="0.2023" name="H1" type="protein-H"/>
+      <Atom charge="0.2023" name="H2" type="protein-H"/>
+      <Atom charge="0.2023" name="H3" type="protein-H"/>
+      <Atom charge="0.0927" name="CA" type="protein-CX"/>
+      <Atom charge="0.1411" name="HA" type="protein-HP"/>
+      <Atom charge="-0.1195" name="CB" type="protein-2C"/>
+      <Atom charge="0.1188" name="HB2" type="protein-H1"/>
+      <Atom charge="0.1188" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.3298" name="SG" type="protein-SH"/>
+      <Atom charge="0.1975" name="HG" type="protein-HS"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="SG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NCYX">
+      <Atom charge="0.2069" name="N" type="protein-N3"/>
+      <Atom charge="0.1815" name="H1" type="protein-H"/>
+      <Atom charge="0.1815" name="H2" type="protein-H"/>
+      <Atom charge="0.1815" name="H3" type="protein-H"/>
+      <Atom charge="0.1055" name="CA" type="protein-CX"/>
+      <Atom charge="0.0922" name="HA" type="protein-HP"/>
+      <Atom charge="-0.0277" name="CB" type="protein-2C"/>
+      <Atom charge="0.068" name="HB2" type="protein-H1"/>
+      <Atom charge="0.068" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.0984" name="SG" type="protein-S"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="SG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="SG"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLN">
+      <Atom charge="0.1493" name="N" type="protein-N3"/>
+      <Atom charge="0.1996" name="H1" type="protein-H"/>
+      <Atom charge="0.1996" name="H2" type="protein-H"/>
+      <Atom charge="0.1996" name="H3" type="protein-H"/>
+      <Atom charge="0.0536" name="CA" type="protein-CX"/>
+      <Atom charge="0.1015" name="HA" type="protein-HP"/>
+      <Atom charge="0.0651" name="CB" type="protein-2C"/>
+      <Atom charge="0.005" name="HB2" type="protein-HC"/>
+      <Atom charge="0.005" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0903" name="CG" type="protein-2C"/>
+      <Atom charge="0.0331" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0331" name="HG3" type="protein-HC"/>
+      <Atom charge="0.7354" name="CD" type="protein-C"/>
+      <Atom charge="-0.6133" name="OE1" type="protein-O"/>
+      <Atom charge="-1.0031" name="NE2" type="protein-N"/>
+      <Atom charge="0.4429" name="HE21" type="protein-H"/>
+      <Atom charge="0.4429" name="HE22" type="protein-H"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE21"/>
+      <Bond atomName1="NE2" atomName2="HE22"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLU">
+      <Atom charge="0.0017" name="N" type="protein-N3"/>
+      <Atom charge="0.2391" name="H1" type="protein-H"/>
+      <Atom charge="0.2391" name="H2" type="protein-H"/>
+      <Atom charge="0.2391" name="H3" type="protein-H"/>
+      <Atom charge="0.0588" name="CA" type="protein-CX"/>
+      <Atom charge="0.1202" name="HA" type="protein-HP"/>
+      <Atom charge="0.0909" name="CB" type="protein-2C"/>
+      <Atom charge="-0.0232" name="HB2" type="protein-HC"/>
+      <Atom charge="-0.0232" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0236" name="CG" type="protein-2C"/>
+      <Atom charge="-0.0315" name="HG2" type="protein-HC"/>
+      <Atom charge="-0.0315" name="HG3" type="protein-HC"/>
+      <Atom charge="0.8087" name="CD" type="protein-CO"/>
+      <Atom charge="-0.8189" name="OE1" type="protein-O2"/>
+      <Atom charge="-0.8189" name="OE2" type="protein-O2"/>
+      <Atom charge="0.5621" name="C" type="protein-C"/>
+      <Atom charge="-0.5889" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="OE1"/>
+      <Bond atomName1="CD" atomName2="OE2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NGLY">
+      <Atom charge="0.2943" name="N" type="protein-N3"/>
+      <Atom charge="0.1642" name="H1" type="protein-H"/>
+      <Atom charge="0.1642" name="H2" type="protein-H"/>
+      <Atom charge="0.1642" name="H3" type="protein-H"/>
+      <Atom charge="-0.01" name="CA" type="protein-CX"/>
+      <Atom charge="0.0895" name="HA2" type="protein-HP"/>
+      <Atom charge="0.0895" name="HA3" type="protein-HP"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA2"/>
+      <Bond atomName1="CA" atomName2="HA3"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHID">
+      <Atom charge="0.1542" name="N" type="protein-N3"/>
+      <Atom charge="0.1963" name="H1" type="protein-H"/>
+      <Atom charge="0.1963" name="H2" type="protein-H"/>
+      <Atom charge="0.1963" name="H3" type="protein-H"/>
+      <Atom charge="0.0964" name="CA" type="protein-CX"/>
+      <Atom charge="0.0958" name="HA" type="protein-HP"/>
+      <Atom charge="0.0259" name="CB" type="protein-CT"/>
+      <Atom charge="0.0209" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0209" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0399" name="CG" type="protein-CC"/>
+      <Atom charge="-0.3819" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3632" name="HD1" type="protein-H"/>
+      <Atom charge="0.2127" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1385" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.5711" name="NE2" type="protein-NB"/>
+      <Atom charge="0.1046" name="CD2" type="protein-CV"/>
+      <Atom charge="0.1299" name="HD2" type="protein-H4"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHIE">
+      <Atom charge="0.1472" name="N" type="protein-N3"/>
+      <Atom charge="0.2016" name="H1" type="protein-H"/>
+      <Atom charge="0.2016" name="H2" type="protein-H"/>
+      <Atom charge="0.2016" name="H3" type="protein-H"/>
+      <Atom charge="0.0236" name="CA" type="protein-CX"/>
+      <Atom charge="0.138" name="HA" type="protein-HP"/>
+      <Atom charge="0.0489" name="CB" type="protein-CT"/>
+      <Atom charge="0.0223" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0223" name="HB3" type="protein-HC"/>
+      <Atom charge="0.174" name="CG" type="protein-CC"/>
+      <Atom charge="-0.5579" name="ND1" type="protein-NB"/>
+      <Atom charge="0.1804" name="CE1" type="protein-CR"/>
+      <Atom charge="0.1397" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.2781" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3324" name="HE2" type="protein-H"/>
+      <Atom charge="-0.2349" name="CD2" type="protein-CW"/>
+      <Atom charge="0.1963" name="HD2" type="protein-H4"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NHIP">
+      <Atom charge="0.256" name="N" type="protein-N3"/>
+      <Atom charge="0.1704" name="H1" type="protein-H"/>
+      <Atom charge="0.1704" name="H2" type="protein-H"/>
+      <Atom charge="0.1704" name="H3" type="protein-H"/>
+      <Atom charge="0.0581" name="CA" type="protein-CX"/>
+      <Atom charge="0.1047" name="HA" type="protein-HP"/>
+      <Atom charge="0.0484" name="CB" type="protein-CT"/>
+      <Atom charge="0.0531" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0531" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0236" name="CG" type="protein-CC"/>
+      <Atom charge="-0.151" name="ND1" type="protein-NA"/>
+      <Atom charge="0.3821" name="HD1" type="protein-H"/>
+      <Atom charge="-0.0011" name="CE1" type="protein-CR"/>
+      <Atom charge="0.2645" name="HE1" type="protein-H5"/>
+      <Atom charge="-0.1739" name="NE2" type="protein-NA"/>
+      <Atom charge="0.3921" name="HE2" type="protein-H"/>
+      <Atom charge="-0.1433" name="CD2" type="protein-CW"/>
+      <Atom charge="0.2495" name="HD2" type="protein-H4"/>
+      <Atom charge="0.7214" name="C" type="protein-C"/>
+      <Atom charge="-0.6013" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="ND1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="ND1" atomName2="HD1"/>
+      <Bond atomName1="ND1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="NE2"/>
+      <Bond atomName1="NE2" atomName2="HE2"/>
+      <Bond atomName1="NE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NILE">
+      <Atom charge="0.0311" name="N" type="protein-N3"/>
+      <Atom charge="0.2329" name="H1" type="protein-H"/>
+      <Atom charge="0.2329" name="H2" type="protein-H"/>
+      <Atom charge="0.2329" name="H3" type="protein-H"/>
+      <Atom charge="0.0257" name="CA" type="protein-CX"/>
+      <Atom charge="0.1031" name="HA" type="protein-HP"/>
+      <Atom charge="0.1885" name="CB" type="protein-3C"/>
+      <Atom charge="0.0213" name="HB" type="protein-HC"/>
+      <Atom charge="-0.372" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0947" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0947" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0947" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.0387" name="CG1" type="protein-2C"/>
+      <Atom charge="0.0201" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0201" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.0908" name="CD1" type="protein-CT"/>
+      <Atom charge="0.0226" name="HD11" type="protein-HC"/>
+      <Atom charge="0.0226" name="HD12" type="protein-HC"/>
+      <Atom charge="0.0226" name="HD13" type="protein-HC"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG1" atomName2="CD1"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NLEU">
+      <Atom charge="0.101" name="N" type="protein-N3"/>
+      <Atom charge="0.2148" name="H1" type="protein-H"/>
+      <Atom charge="0.2148" name="H2" type="protein-H"/>
+      <Atom charge="0.2148" name="H3" type="protein-H"/>
+      <Atom charge="0.0104" name="CA" type="protein-CX"/>
+      <Atom charge="0.1053" name="HA" type="protein-HP"/>
+      <Atom charge="-0.0244" name="CB" type="protein-2C"/>
+      <Atom charge="0.0256" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0256" name="HB3" type="protein-HC"/>
+      <Atom charge="0.3421" name="CG" type="protein-3C"/>
+      <Atom charge="-0.038" name="HG" type="protein-HC"/>
+      <Atom charge="-0.4106" name="CD1" type="protein-CT"/>
+      <Atom charge="0.098" name="HD11" type="protein-HC"/>
+      <Atom charge="0.098" name="HD12" type="protein-HC"/>
+      <Atom charge="0.098" name="HD13" type="protein-HC"/>
+      <Atom charge="-0.4104" name="CD2" type="protein-CT"/>
+      <Atom charge="0.098" name="HD21" type="protein-HC"/>
+      <Atom charge="0.098" name="HD22" type="protein-HC"/>
+      <Atom charge="0.098" name="HD23" type="protein-HC"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD11"/>
+      <Bond atomName1="CD1" atomName2="HD12"/>
+      <Bond atomName1="CD1" atomName2="HD13"/>
+      <Bond atomName1="CD2" atomName2="HD21"/>
+      <Bond atomName1="CD2" atomName2="HD22"/>
+      <Bond atomName1="CD2" atomName2="HD23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NLYS">
+      <Atom charge="0.0966" name="N" type="protein-N3"/>
+      <Atom charge="0.2165" name="H1" type="protein-H"/>
+      <Atom charge="0.2165" name="H2" type="protein-H"/>
+      <Atom charge="0.2165" name="H3" type="protein-H"/>
+      <Atom charge="-0.0015" name="CA" type="protein-CX"/>
+      <Atom charge="0.118" name="HA" type="protein-HP"/>
+      <Atom charge="0.0212" name="CB" type="protein-C8"/>
+      <Atom charge="0.0283" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0283" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0048" name="CG" type="protein-C8"/>
+      <Atom charge="0.0121" name="HG2" type="protein-HC"/>
+      <Atom charge="0.0121" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.0608" name="CD" type="protein-C8"/>
+      <Atom charge="0.0633" name="HD2" type="protein-HC"/>
+      <Atom charge="0.0633" name="HD3" type="protein-HC"/>
+      <Atom charge="-0.0181" name="CE" type="protein-C8"/>
+      <Atom charge="0.1171" name="HE2" type="protein-HP"/>
+      <Atom charge="0.1171" name="HE3" type="protein-HP"/>
+      <Atom charge="-0.3764" name="NZ" type="protein-N3"/>
+      <Atom charge="0.3382" name="HZ1" type="protein-H"/>
+      <Atom charge="0.3382" name="HZ2" type="protein-H"/>
+      <Atom charge="0.3382" name="HZ3" type="protein-H"/>
+      <Atom charge="0.7214" name="C" type="protein-C"/>
+      <Atom charge="-0.6013" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CD"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="CE" atomName2="NZ"/>
+      <Bond atomName1="NZ" atomName2="HZ1"/>
+      <Bond atomName1="NZ" atomName2="HZ2"/>
+      <Bond atomName1="NZ" atomName2="HZ3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NMET">
+      <Atom charge="0.1592" name="N" type="protein-N3"/>
+      <Atom charge="0.1984" name="H1" type="protein-H"/>
+      <Atom charge="0.1984" name="H2" type="protein-H"/>
+      <Atom charge="0.1984" name="H3" type="protein-H"/>
+      <Atom charge="0.0221" name="CA" type="protein-CX"/>
+      <Atom charge="0.1116" name="HA" type="protein-HP"/>
+      <Atom charge="0.0865" name="CB" type="protein-2C"/>
+      <Atom charge="0.0125" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0125" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0334" name="CG" type="protein-2C"/>
+      <Atom charge="0.0292" name="HG2" type="protein-H1"/>
+      <Atom charge="0.0292" name="HG3" type="protein-H1"/>
+      <Atom charge="-0.2774" name="SD" type="protein-S"/>
+      <Atom charge="-0.0341" name="CE" type="protein-CT"/>
+      <Atom charge="0.0597" name="HE1" type="protein-H1"/>
+      <Atom charge="0.0597" name="HE2" type="protein-H1"/>
+      <Atom charge="0.0597" name="HE3" type="protein-H1"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="SD"/>
+      <Bond atomName1="SD" atomName2="CE"/>
+      <Bond atomName1="CE" atomName2="HE1"/>
+      <Bond atomName1="CE" atomName2="HE2"/>
+      <Bond atomName1="CE" atomName2="HE3"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NPHE">
+      <Atom charge="0.1737" name="N" type="protein-N3"/>
+      <Atom charge="0.1921" name="H1" type="protein-H"/>
+      <Atom charge="0.1921" name="H2" type="protein-H"/>
+      <Atom charge="0.1921" name="H3" type="protein-H"/>
+      <Atom charge="0.0733" name="CA" type="protein-CX"/>
+      <Atom charge="0.1041" name="HA" type="protein-HP"/>
+      <Atom charge="0.033" name="CB" type="protein-CT"/>
+      <Atom charge="0.0104" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0104" name="HB3" type="protein-HC"/>
+      <Atom charge="0.0031" name="CG" type="protein-CA"/>
+      <Atom charge="-0.1392" name="CD1" type="protein-CA"/>
+      <Atom charge="0.1374" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.1602" name="CE1" type="protein-CA"/>
+      <Atom charge="0.1433" name="HE1" type="protein-HA"/>
+      <Atom charge="-0.1208" name="CZ" type="protein-CA"/>
+      <Atom charge="0.1329" name="HZ" type="protein-HA"/>
+      <Atom charge="-0.1603" name="CE2" type="protein-CA"/>
+      <Atom charge="0.1433" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.1391" name="CD2" type="protein-CA"/>
+      <Atom charge="0.1374" name="HD2" type="protein-HA"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="HZ"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NPRO">
+      <Atom charge="-0.202" name="N" type="protein-N3"/>
+      <Atom charge="0.312" name="H2" type="protein-H"/>
+      <Atom charge="0.312" name="H3" type="protein-H"/>
+      <Atom charge="-0.012" name="CD" type="protein-CT"/>
+      <Atom charge="0.1" name="HD2" type="protein-HP"/>
+      <Atom charge="0.1" name="HD3" type="protein-HP"/>
+      <Atom charge="-0.121" name="CG" type="protein-CT"/>
+      <Atom charge="0.1" name="HG2" type="protein-HC"/>
+      <Atom charge="0.1" name="HG3" type="protein-HC"/>
+      <Atom charge="-0.115" name="CB" type="protein-CT"/>
+      <Atom charge="0.1" name="HB2" type="protein-HC"/>
+      <Atom charge="0.1" name="HB3" type="protein-HC"/>
+      <Atom charge="0.1" name="CA" type="protein-CX"/>
+      <Atom charge="0.1" name="HA" type="protein-HP"/>
+      <Atom charge="0.526" name="C" type="protein-C"/>
+      <Atom charge="-0.5" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CD"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CD" atomName2="HD2"/>
+      <Bond atomName1="CD" atomName2="HD3"/>
+      <Bond atomName1="CD" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="HG2"/>
+      <Bond atomName1="CG" atomName2="HG3"/>
+      <Bond atomName1="CG" atomName2="CB"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NSER">
+      <Atom charge="0.1849" name="N" type="protein-N3"/>
+      <Atom charge="0.1898" name="H1" type="protein-H"/>
+      <Atom charge="0.1898" name="H2" type="protein-H"/>
+      <Atom charge="0.1898" name="H3" type="protein-H"/>
+      <Atom charge="0.0567" name="CA" type="protein-CX"/>
+      <Atom charge="0.0782" name="HA" type="protein-HP"/>
+      <Atom charge="0.2596" name="CB" type="protein-2C"/>
+      <Atom charge="0.0273" name="HB2" type="protein-H1"/>
+      <Atom charge="0.0273" name="HB3" type="protein-H1"/>
+      <Atom charge="-0.6714" name="OG" type="protein-OH"/>
+      <Atom charge="0.4239" name="HG" type="protein-HO"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="OG"/>
+      <Bond atomName1="OG" atomName2="HG"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTHR">
+      <Atom charge="0.1812" name="N" type="protein-N3"/>
+      <Atom charge="0.1934" name="H1" type="protein-H"/>
+      <Atom charge="0.1934" name="H2" type="protein-H"/>
+      <Atom charge="0.1934" name="H3" type="protein-H"/>
+      <Atom charge="0.0034" name="CA" type="protein-CX"/>
+      <Atom charge="0.1087" name="HA" type="protein-HP"/>
+      <Atom charge="0.4514" name="CB" type="protein-3C"/>
+      <Atom charge="-0.0323" name="HB" type="protein-H1"/>
+      <Atom charge="-0.2554" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0627" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0627" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0627" name="HG23" type="protein-HC"/>
+      <Atom charge="-0.6764" name="OG1" type="protein-OH"/>
+      <Atom charge="0.407" name="HG1" type="protein-HO"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CB" atomName2="OG1"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="OG1" atomName2="HG1"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTRP">
+      <Atom charge="0.1913" name="N" type="protein-N3"/>
+      <Atom charge="0.1888" name="H1" type="protein-H"/>
+      <Atom charge="0.1888" name="H2" type="protein-H"/>
+      <Atom charge="0.1888" name="H3" type="protein-H"/>
+      <Atom charge="0.0421" name="CA" type="protein-CX"/>
+      <Atom charge="0.1162" name="HA" type="protein-HP"/>
+      <Atom charge="0.0543" name="CB" type="protein-CT"/>
+      <Atom charge="0.0222" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0222" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.1654" name="CG" type="protein-C*"/>
+      <Atom charge="-0.1788" name="CD1" type="protein-CW"/>
+      <Atom charge="0.2195" name="HD1" type="protein-H4"/>
+      <Atom charge="-0.3444" name="NE1" type="protein-NA"/>
+      <Atom charge="0.3412" name="HE1" type="protein-H"/>
+      <Atom charge="0.1575" name="CE2" type="protein-CN"/>
+      <Atom charge="-0.271" name="CZ2" type="protein-CA"/>
+      <Atom charge="0.1589" name="HZ2" type="protein-HA"/>
+      <Atom charge="-0.108" name="CH2" type="protein-CA"/>
+      <Atom charge="0.1411" name="HH2" type="protein-HA"/>
+      <Atom charge="-0.2034" name="CZ3" type="protein-CA"/>
+      <Atom charge="0.1458" name="HZ3" type="protein-HA"/>
+      <Atom charge="-0.2265" name="CE3" type="protein-CA"/>
+      <Atom charge="0.1646" name="HE3" type="protein-HA"/>
+      <Atom charge="0.1132" name="CD2" type="protein-CB"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="NE1"/>
+      <Bond atomName1="NE1" atomName2="HE1"/>
+      <Bond atomName1="NE1" atomName2="CE2"/>
+      <Bond atomName1="CE2" atomName2="CZ2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CZ2" atomName2="HZ2"/>
+      <Bond atomName1="CZ2" atomName2="CH2"/>
+      <Bond atomName1="CH2" atomName2="HH2"/>
+      <Bond atomName1="CH2" atomName2="CZ3"/>
+      <Bond atomName1="CZ3" atomName2="HZ3"/>
+      <Bond atomName1="CZ3" atomName2="CE3"/>
+      <Bond atomName1="CE3" atomName2="HE3"/>
+      <Bond atomName1="CE3" atomName2="CD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NTYR">
+      <Atom charge="0.194" name="N" type="protein-N3"/>
+      <Atom charge="0.1873" name="H1" type="protein-H"/>
+      <Atom charge="0.1873" name="H2" type="protein-H"/>
+      <Atom charge="0.1873" name="H3" type="protein-H"/>
+      <Atom charge="0.057" name="CA" type="protein-CX"/>
+      <Atom charge="0.0983" name="HA" type="protein-HP"/>
+      <Atom charge="0.0659" name="CB" type="protein-CT"/>
+      <Atom charge="0.0102" name="HB2" type="protein-HC"/>
+      <Atom charge="0.0102" name="HB3" type="protein-HC"/>
+      <Atom charge="-0.0205" name="CG" type="protein-CA"/>
+      <Atom charge="-0.2002" name="CD1" type="protein-CA"/>
+      <Atom charge="0.172" name="HD1" type="protein-HA"/>
+      <Atom charge="-0.2239" name="CE1" type="protein-CA"/>
+      <Atom charge="0.165" name="HE1" type="protein-HA"/>
+      <Atom charge="0.3139" name="CZ" type="protein-C"/>
+      <Atom charge="-0.5578" name="OH" type="protein-OH"/>
+      <Atom charge="0.4001" name="HH" type="protein-HO"/>
+      <Atom charge="-0.2239" name="CE2" type="protein-CA"/>
+      <Atom charge="0.165" name="HE2" type="protein-HA"/>
+      <Atom charge="-0.2002" name="CD2" type="protein-CA"/>
+      <Atom charge="0.172" name="HD2" type="protein-HA"/>
+      <Atom charge="0.6123" name="C" type="protein-C"/>
+      <Atom charge="-0.5713" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB2"/>
+      <Bond atomName1="CB" atomName2="HB3"/>
+      <Bond atomName1="CB" atomName2="CG"/>
+      <Bond atomName1="CG" atomName2="CD1"/>
+      <Bond atomName1="CG" atomName2="CD2"/>
+      <Bond atomName1="CD1" atomName2="HD1"/>
+      <Bond atomName1="CD1" atomName2="CE1"/>
+      <Bond atomName1="CE1" atomName2="HE1"/>
+      <Bond atomName1="CE1" atomName2="CZ"/>
+      <Bond atomName1="CZ" atomName2="OH"/>
+      <Bond atomName1="CZ" atomName2="CE2"/>
+      <Bond atomName1="OH" atomName2="HH"/>
+      <Bond atomName1="CE2" atomName2="HE2"/>
+      <Bond atomName1="CE2" atomName2="CD2"/>
+      <Bond atomName1="CD2" atomName2="HD2"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+    <Residue name="NVAL">
+      <Atom charge="0.0577" name="N" type="protein-N3"/>
+      <Atom charge="0.2272" name="H1" type="protein-H"/>
+      <Atom charge="0.2272" name="H2" type="protein-H"/>
+      <Atom charge="0.2272" name="H3" type="protein-H"/>
+      <Atom charge="-0.0054" name="CA" type="protein-CX"/>
+      <Atom charge="0.1093" name="HA" type="protein-HP"/>
+      <Atom charge="0.3196" name="CB" type="protein-3C"/>
+      <Atom charge="-0.0221" name="HB" type="protein-HC"/>
+      <Atom charge="-0.3129" name="CG1" type="protein-CT"/>
+      <Atom charge="0.0735" name="HG11" type="protein-HC"/>
+      <Atom charge="0.0735" name="HG12" type="protein-HC"/>
+      <Atom charge="0.0735" name="HG13" type="protein-HC"/>
+      <Atom charge="-0.3129" name="CG2" type="protein-CT"/>
+      <Atom charge="0.0735" name="HG21" type="protein-HC"/>
+      <Atom charge="0.0735" name="HG22" type="protein-HC"/>
+      <Atom charge="0.0735" name="HG23" type="protein-HC"/>
+      <Atom charge="0.6163" name="C" type="protein-C"/>
+      <Atom charge="-0.5722" name="O" type="protein-O"/>
+      <Bond atomName1="N" atomName2="H1"/>
+      <Bond atomName1="N" atomName2="H2"/>
+      <Bond atomName1="N" atomName2="H3"/>
+      <Bond atomName1="N" atomName2="CA"/>
+      <Bond atomName1="CA" atomName2="HA"/>
+      <Bond atomName1="CA" atomName2="CB"/>
+      <Bond atomName1="CA" atomName2="C"/>
+      <Bond atomName1="CB" atomName2="HB"/>
+      <Bond atomName1="CB" atomName2="CG1"/>
+      <Bond atomName1="CB" atomName2="CG2"/>
+      <Bond atomName1="CG1" atomName2="HG11"/>
+      <Bond atomName1="CG1" atomName2="HG12"/>
+      <Bond atomName1="CG1" atomName2="HG13"/>
+      <Bond atomName1="CG2" atomName2="HG21"/>
+      <Bond atomName1="CG2" atomName2="HG22"/>
+      <Bond atomName1="CG2" atomName2="HG23"/>
+      <Bond atomName1="C" atomName2="O"/>
+      <ExternalBond atomName="C"/>
+    </Residue>
+  </Residues>
+  <HarmonicBondForce>
+    <Bond k="259407.99999999994" length="0.1525" type1="protein-C" type2="protein-C"/>
+    <Bond k="392459.19999999995" length="0.1409" type1="protein-C" type2="protein-CA"/>
+    <Bond k="374049.5999999999" length="0.1419" type1="protein-C" type2="protein-CB"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-C" type2="protein-CT"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-C" type2="protein-CX"/>
+    <Bond k="410031.99999999994" length="0.1335" type1="protein-C" type2="protein-N"/>
+    <Bond k="349782.3999999999" length="0.1388" type1="protein-C" type2="protein-NA"/>
+    <Bond k="476975.9999999999" length="0.12290000000000001" type1="protein-C" type2="protein-O"/>
+    <Bond k="548940.7999999999" length="0.125" type1="protein-C" type2="protein-O2"/>
+    <Bond k="376559.99999999994" length="0.13640000000000002" type1="protein-C" type2="protein-OH"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C" type2="protein-H4"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C" type2="protein-H5"/>
+    <Bond k="392459.19999999995" length="0.13999999999999999" type1="protein-CA" type2="protein-CA"/>
+    <Bond k="392459.19999999995" length="0.1404" type1="protein-CA" type2="protein-CB"/>
+    <Bond k="392459.19999999995" length="0.13999999999999999" type1="protein-CA" type2="protein-CN"/>
+    <Bond k="265265.6" length="0.15100000000000002" type1="protein-CA" type2="protein-CT"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CA" type2="protein-HA"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CA" type2="protein-H4"/>
+    <Bond k="402500.79999999993" length="0.134" type1="protein-CA" type2="protein-N2"/>
+    <Bond k="357313.5999999999" length="0.1381" type1="protein-CA" type2="protein-NA"/>
+    <Bond k="376559.99999999994" length="0.13640000000000002" type1="protein-CA" type2="protein-OH"/>
+    <Bond k="435135.99999999994" length="0.137" type1="protein-CB" type2="protein-CB"/>
+    <Bond k="346435.19999999995" length="0.1391" type1="protein-CB" type2="protein-NB"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CT" type2="protein-CT"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-CT"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CX" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CT" type2="protein-HP"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-CX" type2="protein-HP"/>
+    <Bond k="282001.5999999999" length="0.1463" type1="protein-CT" type2="protein-N2"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-CT" type2="protein-OH"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-C*" type2="protein-HC"/>
+    <Bond k="324678.39999999997" length="0.1459" type1="protein-C*" type2="protein-CB"/>
+    <Bond k="265265.6" length="0.14950000000000002" type1="protein-C*" type2="protein-CT"/>
+    <Bond k="456892.79999999993" length="0.13520000000000001" type1="protein-C*" type2="protein-CW"/>
+    <Bond k="374049.5999999999" length="0.1419" type1="protein-CB" type2="protein-CN"/>
+    <Bond k="265265.6" length="0.1504" type1="protein-CC" type2="protein-CT"/>
+    <Bond k="428441.5999999999" length="0.1375" type1="protein-CC" type2="protein-CV"/>
+    <Bond k="433462.3999999999" length="0.1371" type1="protein-CC" type2="protein-CW"/>
+    <Bond k="353129.5999999999" length="0.1385" type1="protein-CC" type2="protein-NA"/>
+    <Bond k="343087.99999999994" length="0.1394" type1="protein-CC" type2="protein-NB"/>
+    <Bond k="358150.3999999999" length="0.13799999999999998" type1="protein-CN" type2="protein-NA"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CR" type2="protein-H5"/>
+    <Bond k="399153.5999999999" length="0.1343" type1="protein-CR" type2="protein-NA"/>
+    <Bond k="408358.3999999999" length="0.1335" type1="protein-CR" type2="protein-NB"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-CT" type2="protein-N"/>
+    <Bond k="282001.5999999999" length="0.1449" type1="protein-CX" type2="protein-N"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-CT" type2="protein-N3"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-CX" type2="protein-N3"/>
+    <Bond k="189953.59999999998" length="0.18100000000000002" type1="protein-CT" type2="protein-S"/>
+    <Bond k="198321.59999999998" length="0.18100000000000002" type1="protein-CT" type2="protein-SH"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CV" type2="protein-H4"/>
+    <Bond k="343087.99999999994" length="0.1394" type1="protein-CV" type2="protein-NB"/>
+    <Bond k="307105.5999999999" length="0.10800000000000001" type1="protein-CW" type2="protein-H4"/>
+    <Bond k="357313.5999999999" length="0.1381" type1="protein-CW" type2="protein-NA"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-N2"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-NA"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-N"/>
+    <Bond k="363171.19999999995" length="0.101" type1="protein-H" type2="protein-N3"/>
+    <Bond k="462750.3999999999" length="0.096" type1="protein-HO" type2="protein-OH"/>
+    <Bond k="229283.19999999995" length="0.13360000000000002" type1="protein-HS" type2="protein-SH"/>
+    <Bond k="138908.79999999996" length="0.20379999999999998" type1="protein-S" type2="protein-S"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-C" type2="protein-2C"/>
+    <Bond k="265265.6" length="0.14950000000000002" type1="protein-C*" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-C8" type2="protein-C8"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-C8" type2="protein-CX"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-H1"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-HC"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-C8" type2="protein-HP"/>
+    <Bond k="282001.5999999999" length="0.1463" type1="protein-C8" type2="protein-N2"/>
+    <Bond k="307105.5999999999" length="0.1471" type1="protein-C8" type2="protein-N3"/>
+    <Bond k="265265.6" length="0.15100000000000002" type1="protein-CA" type2="protein-2C"/>
+    <Bond k="265265.6" length="0.1504" type1="protein-CC" type2="protein-2C"/>
+    <Bond k="548940.7999999999" length="0.125" type1="protein-CO" type2="protein-O2"/>
+    <Bond k="265265.6" length="0.1522" type1="protein-CO" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CT" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CT" type2="protein-3C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-CX" type2="protein-3C"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-H1" type2="protein-2C"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-H1" type2="protein-3C"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-HC" type2="protein-2C"/>
+    <Bond k="284511.99999999994" length="0.10900000000000001" type1="protein-HC" type2="protein-3C"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-OH" type2="protein-2C"/>
+    <Bond k="267775.99999999994" length="0.141" type1="protein-OH" type2="protein-3C"/>
+    <Bond k="189953.59999999998" length="0.18100000000000002" type1="protein-S" type2="protein-2C"/>
+    <Bond k="198321.59999999998" length="0.18100000000000002" type1="protein-SH" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-2C" type2="protein-2C"/>
+    <Bond k="259407.99999999994" length="0.1526" type1="protein-2C" type2="protein-3C"/>
+  </HarmonicBondForce>
+  <HarmonicAngleForce>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-C" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-C" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-C" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="1.9425514574696887" k="585.76" type1="protein-CB" type2="protein-C" type3="protein-NA"/>
+    <Angle angle="2.2479840765686965" k="669.44" type1="protein-CB" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-CT" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-CX" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CT" type2="protein-C" type3="protein-O2"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CX" type2="protein-C" type3="protein-O2"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CT" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-CX" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.0420352248333655" k="527.184" type1="protein-CT" type2="protein-C" type3="protein-CT"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-CT" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-CX" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.1048670779051615" k="669.44" type1="protein-NA" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.1450096507010312" k="669.44" type1="protein-N" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.199114857512855" k="669.44" type1="protein-O" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="669.44" type1="protein-O" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.199114857512855" k="669.44" type1="protein-O2" type2="protein-C" type3="protein-O2"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-C"/>
+    <Angle angle="2.007128639793479" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-CT"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-O"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-N"/>
+    <Angle angle="2.076941809873252" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-O"/>
+    <Angle angle="1.8675022996339325" k="418.40000000000003" type1="protein-H5" type2="protein-C" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-C" type2="protein-CA" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CA"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-CA" type3="protein-CT"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-CA" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-CA" type3="protein-OH"/>
+    <Angle angle="2.0943951023931953" k="527.184" type1="protein-CA" type2="protein-CA" type3="protein-CN"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CB" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CB" type2="protein-CA" type3="protein-H4"/>
+    <Angle angle="2.155481626212997" k="585.76" type1="protein-CB" type2="protein-CA" type3="protein-N2"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CN" type2="protein-CA" type3="protein-HA"/>
+    <Angle angle="2.0245819323134224" k="585.76" type1="protein-N2" type2="protein-CA" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-N2" type2="protein-CA" type3="protein-N2"/>
+    <Angle angle="2.080432468377241" k="527.184" type1="protein-C" type2="protein-CB" type3="protein-CB"/>
+    <Angle angle="2.2689280275926285" k="585.76" type1="protein-C" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="2.0472712125893486" k="527.184" type1="protein-CA" type2="protein-CB" type3="protein-CB"/>
+    <Angle angle="2.3108159296404924" k="585.76" type1="protein-CA" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="1.9268434942017398" k="585.76" type1="protein-CB" type2="protein-CB" type3="protein-NB"/>
+    <Angle angle="2.3544491609403506" k="527.184" type1="protein-C*" type2="protein-CB" type3="protein-CA"/>
+    <Angle angle="1.8989182261698305" k="527.184" type1="protein-C*" type2="protein-CB" type3="protein-CN"/>
+    <Angle angle="2.028072590817411" k="527.184" type1="protein-CA" type2="protein-CB" type3="protein-CN"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-N"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CX" type3="protein-N"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-S"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CT" type3="protein-N2"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CX" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-C" type2="protein-CT" type3="protein-N"/>
+    <Angle angle="1.9216075064457567" k="527.184" type1="protein-C" type2="protein-CX" type3="protein-N"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C" type2="protein-CX" type3="protein-N3"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CT" type3="protein-CX"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CX" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CA" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-CC" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-CC" type2="protein-CT" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CC" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-CT" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CX" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-OH"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-S"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-S"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-CT" type2="protein-CT" type3="protein-SH"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-CX" type2="protein-CT" type3="protein-SH"/>
+    <Angle angle="1.9896753472735358" k="527.184" type1="protein-CT" type2="protein-CT" type3="protein-CA"/>
+    <Angle angle="1.9896753472735358" k="527.184" type1="protein-CX" type2="protein-CT" type3="protein-CA"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N2"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-CT" type2="protein-CX" type3="protein-N"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-CT" type2="protein-CT" type3="protein-N3"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-CT" type2="protein-CX" type3="protein-N3"/>
+    <Angle angle="2.0176006153054447" k="527.184" type1="protein-C*" type2="protein-CT" type3="protein-CT"/>
+    <Angle angle="2.0176006153054447" k="527.184" type1="protein-C*" type2="protein-CT" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C*" type2="protein-CT" type3="protein-HC"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CT" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CT" type2="protein-CC" type3="protein-CV"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CT" type2="protein-CC" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CV" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CT" type2="protein-CC" type3="protein-CW"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H5" type2="protein-CR" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H5" type2="protein-CR" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NA" type2="protein-CR" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NA" type2="protein-CR" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-CV" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CC" type2="protein-CV" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-CV" type3="protein-NB"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-CW" type3="protein-H4"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CC" type2="protein-CW" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C*" type2="protein-CW" type3="protein-H4"/>
+    <Angle angle="1.8971728969178363" k="585.76" type1="protein-C*" type2="protein-CW" type3="protein-NA"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-H4" type2="protein-CW" type3="protein-NA"/>
+    <Angle angle="2.2444934180647076" k="585.76" type1="protein-CB" type2="protein-C*" type3="protein-CT"/>
+    <Angle angle="1.8570303241219668" k="527.184" type1="protein-CB" type2="protein-C*" type3="protein-CW"/>
+    <Angle angle="2.181661564992912" k="585.76" type1="protein-CT" type2="protein-C*" type3="protein-CW"/>
+    <Angle angle="2.1415189921970423" k="527.184" type1="protein-CA" type2="protein-CN" type3="protein-CB"/>
+    <Angle angle="2.3177972466484698" k="585.76" type1="protein-CA" type2="protein-CN" type3="protein-NA"/>
+    <Angle angle="1.8221237390820801" k="585.76" type1="protein-CB" type2="protein-CN" type3="protein-NA"/>
+    <Angle angle="2.1275563581810877" k="418.40000000000003" type1="protein-C" type2="protein-N" type3="protein-CT"/>
+    <Angle angle="2.1275563581810877" k="418.40000000000003" type1="protein-C" type2="protein-N" type3="protein-CX"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-C" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.0601866490541068" k="418.40000000000003" type1="protein-CT" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.0601866490541068" k="418.40000000000003" type1="protein-CX" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CT" type2="protein-N" type3="protein-CT"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CT" type2="protein-N" type3="protein-CX"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-H" type2="protein-N" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CA" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="2.150245638457014" k="418.40000000000003" type1="protein-CA" type2="protein-N2" type3="protein-CT"/>
+    <Angle angle="2.0664698343612864" k="418.40000000000003" type1="protein-CT" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="292.88" type1="protein-H" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-N3" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-N3" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="2.2060961745208325" k="585.76" type1="protein-C" type2="protein-NA" type3="protein-C"/>
+    <Angle angle="2.1851522234969005" k="585.76" type1="protein-C" type2="protein-NA" type3="protein-CA"/>
+    <Angle angle="2.038544566329377" k="418.40000000000003" type1="protein-C" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.059488517353309" k="418.40000000000003" type1="protein-CA" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CC" type2="protein-NA" type3="protein-CR"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CC" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CR" type2="protein-NA" type3="protein-CW"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CR" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0943951023931953" k="418.40000000000003" type1="protein-CW" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="1.9477874452256716" k="585.76" type1="protein-CN" type2="protein-NA" type3="protein-CW"/>
+    <Angle angle="2.1485003092050197" k="418.40000000000003" type1="protein-CN" type2="protein-NA" type3="protein-H"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CC" type2="protein-NB" type3="protein-CR"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-CR" type2="protein-NB" type3="protein-CV"/>
+    <Angle angle="1.9722220547535925" k="418.40000000000003" type1="protein-C" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.9722220547535925" k="418.40000000000003" type1="protein-CA" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-CT" type2="protein-OH" type3="protein-HO"/>
+    <Angle angle="1.726130630222392" k="518.816" type1="protein-CT" type2="protein-S" type3="protein-CT"/>
+    <Angle angle="1.8099064343181197" k="569.024" type1="protein-CT" type2="protein-S" type3="protein-S"/>
+    <Angle angle="1.6755160819145565" k="359.824" type1="protein-CT" type2="protein-SH" type3="protein-HS"/>
+    <Angle angle="1.6069246423111792" k="292.88" type1="protein-HS" type2="protein-SH" type3="protein-HS"/>
+    <Angle angle="2.035053907825388" k="585.76" type1="protein-N" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="2.101376419401173" k="669.44" type1="protein-O" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="1.9198621771937625" k="669.44" type1="protein-OH" type2="protein-C" type3="protein-2C"/>
+    <Angle angle="2.2444934180647076" k="585.76" type1="protein-CB" type2="protein-C*" type3="protein-2C"/>
+    <Angle angle="2.181661564992912" k="585.76" type1="protein-CW" type2="protein-C*" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-C8" type2="protein-C8" type3="protein-C8"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-C8" type2="protein-C8" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-C8" type3="protein-HP"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C8" type2="protein-C8" type3="protein-N2"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C8" type2="protein-C8" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-C8" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-C8" type3="protein-N2"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-C8" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HP" type2="protein-C8" type3="protein-HP"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-C8" type3="protein-N3"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CA" type2="protein-CA" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CV" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-CW" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NA" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.0943951023931953" k="585.76" type1="protein-NB" type2="protein-CC" type3="protein-2C"/>
+    <Angle angle="2.199114857512855" k="669.44" type1="protein-O2" type2="protein-CO" type3="protein-O2"/>
+    <Angle angle="2.0420352248333655" k="585.76" type1="protein-O2" type2="protein-CO" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-CT" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-CT" type3="protein-3C"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CX" type3="protein-C8"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-CX" type3="protein-H1"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-C8" type2="protein-CX" type3="protein-N"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-C8" type2="protein-CX" type3="protein-N3"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CX" type3="protein-C8"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HP" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-N" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.9146261894377796" k="669.44" type1="protein-N" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-N3" type2="protein-CX" type3="protein-2C"/>
+    <Angle angle="1.9408061282176945" k="669.44" type1="protein-N3" type2="protein-CX" type3="protein-3C"/>
+    <Angle angle="2.150245638457014" k="418.40000000000003" type1="protein-C8" type2="protein-N2" type3="protein-CA"/>
+    <Angle angle="2.0664698343612864" k="418.40000000000003" type1="protein-C8" type2="protein-N2" type3="protein-H"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C8" type2="protein-N3" type3="protein-H"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OH" type3="protein-2C"/>
+    <Angle angle="1.8936822384138476" k="460.24" type1="protein-HO" type2="protein-OH" type3="protein-3C"/>
+    <Angle angle="1.726130630222392" k="518.816" type1="protein-CT" type2="protein-S" type3="protein-2C"/>
+    <Angle angle="1.8099064343181197" k="569.024" type1="protein-2C" type2="protein-S" type3="protein-S"/>
+    <Angle angle="1.6755160819145565" k="359.824" type1="protein-HS" type2="protein-SH" type3="protein-2C"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-2C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-C" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="2.0176006153054447" k="527.184" type1="protein-C*" type2="protein-2C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-C*" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9896753472735358" k="527.184" type1="protein-CA" type2="protein-2C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CA" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9739673840055867" k="527.184" type1="protein-CC" type2="protein-2C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CC" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CO" type2="protein-2C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CO" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.9390607989657" k="527.184" type1="protein-CO" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-OH"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-S"/>
+    <Angle angle="1.8954275676658419" k="418.40000000000003" type1="protein-CX" type2="protein-2C" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-H1" type2="protein-2C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-S"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-SH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="292.88" type1="protein-HC" type2="protein-2C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-2C" type3="protein-3C"/>
+    <Angle angle="2.0018926520374962" k="418.40000000000003" type1="protein-S" type2="protein-2C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-3C" type3="protein-CT"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-3C" type3="protein-CX"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CT" type2="protein-3C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CT" type2="protein-3C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-H1"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-HC"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-CX" type2="protein-3C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="334.72" type1="protein-CX" type2="protein-3C" type3="protein-2C"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-H1" type2="protein-3C" type3="protein-OH"/>
+    <Angle angle="1.911135530933791" k="418.40000000000003" type1="protein-HC" type2="protein-3C" type3="protein-2C"/>
+  </HarmonicAngleForce>
+  <PeriodicTorsionForce ordering="amber">
+    <Proper k1="15.167" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-C" type4=""/>
+    <Proper k1="15.167" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-CA" type4=""/>
+    <Proper k1="12.552" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-CB" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-C" type3="protein-CT" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-C" type3="protein-CX" type4=""/>
+    <Proper k1="10.46" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-N" type4=""/>
+    <Proper k1="5.6484000000000005" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-NA" type4=""/>
+    <Proper k1="11.7152" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-O" type4=""/>
+    <Proper k1="9.623199999999999" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C" type3="protein-OH" type4=""/>
+    <Proper k1="15.167" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CA" type4=""/>
+    <Proper k1="14.644" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CB" type4=""/>
+    <Proper k1="15.167" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-CN" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-CA" type3="protein-CT" type4=""/>
+    <Proper k1="10.0416" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-N2" type4=""/>
+    <Proper k1="6.276" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-NA" type4=""/>
+    <Proper k1="3.7656" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CA" type3="protein-OH" type4=""/>
+    <Proper k1="22.8028" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-CB" type4=""/>
+    <Proper k1="12.552" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-CN" type4=""/>
+    <Proper k1="10.6692" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CB" type3="protein-NB" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-CC" type3="protein-CT" type4=""/>
+    <Proper k1="21.547600000000003" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CC" type3="protein-CV" type4=""/>
+    <Proper k1="22.489" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CC" type3="protein-CW" type4=""/>
+    <Proper k1="5.8576" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CC" type3="protein-NA" type4=""/>
+    <Proper k1="10.0416" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CC" type3="protein-NB" type4=""/>
+    <Proper k1="6.3806" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CN" type3="protein-NA" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-CT" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-CX" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-CT" type3="protein-N" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-CX" type3="protein-N" type4=""/>
+    <Proper k1="0.0" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-N2" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-N3" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-N3" type4=""/>
+    <Proper k1="0.6973333333333334" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-OH" type4=""/>
+    <Proper k1="1.3946666666666667" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-S" type4=""/>
+    <Proper k1="1.046" periodicity1="3" phase1="0.0" type1="" type2="protein-CT" type3="protein-SH" type4=""/>
+    <Proper k1="7.0082" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C*" type3="protein-CB" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-C*" type3="protein-CT" type4=""/>
+    <Proper k1="27.300600000000003" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-C*" type3="protein-CW" type4=""/>
+    <Proper k1="9.727800000000002" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CR" type3="protein-NA" type4=""/>
+    <Proper k1="20.92" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CR" type3="protein-NB" type4=""/>
+    <Proper k1="10.0416" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CV" type3="protein-NB" type4=""/>
+    <Proper k1="6.276" periodicity1="2" phase1="3.141592653589793" type1="" type2="protein-CW" type3="protein-NA" type4=""/>
+    <Proper k1="0.0" k2="1.75728" k3="1.12968" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C" type2="protein-N" type3="protein-CX" type4="protein-C"/>
+    <Proper k1="0.0" k2="2.3012" k3="6.610720000000001" k4="1.8828" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="8.368" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="3.3472000000000004" k3="7.5312" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CT" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CT" type2="protein-CX" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-CT" type3="protein-C" type4="protein-N"/>
+    <Proper k1="10.46" k2="8.368" periodicity1="2" periodicity2="1" phase1="3.141592653589793" phase2="0.0" type1="protein-H" type2="protein-N" type3="protein-C" type4="protein-O"/>
+    <Proper k1="14.644" k2="2.5104" periodicity1="2" periodicity2="3" phase1="0.0" phase2="0.0" type1="protein-CT" type2="protein-S" type3="protein-S" type4="protein-CT"/>
+    <Proper k1="3.3472000000000004" k2="0.0" k3="0.33472" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0" phase2="0.0" phase3="3.141592653589793" type1="protein-H1" type2="protein-CT" type3="protein-C" type4="protein-O"/>
+    <Proper k1="3.3472000000000004" k2="0.0" k3="0.33472" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0" phase2="0.0" phase3="3.141592653589793" type1="protein-H1" type2="protein-CX" type3="protein-C" type4="protein-O"/>
+    <Proper k1="3.3472000000000004" k2="0.0" k3="0.33472" periodicity1="1" periodicity2="2" periodicity3="3" phase1="0.0" phase2="0.0" phase3="3.141592653589793" type1="protein-HC" type2="protein-CT" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-CX"/>
+    <Proper k1="0.66944" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HO" type2="protein-OH" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.66944" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HO" type2="protein-OH" type3="protein-CT" type4="protein-CX"/>
+    <Proper k1="9.623199999999999" k2="7.9496" periodicity1="2" periodicity2="1" phase1="3.141592653589793" phase2="0.0" type1="protein-HO" type2="protein-OH" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.75312" k2="1.046" k3="0.8368000000000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" type1="protein-CT" type2="protein-CT" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.75312" k2="1.046" k3="0.8368000000000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" type1="protein-CX" type2="protein-CT" type3="protein-CT" type4="protein-CT"/>
+    <Proper k1="0.602496" k2="4.916200000000001" periodicity1="3" periodicity2="2" phase1="0.0" phase2="0.0" type1="protein-OH" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CX" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HC" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="6.23416" k3="0.6527040000000001" k4="0.0" periodicity1="1" periodicity2="2" periodicity3="3" periodicity4="4" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CT" type3="protein-CT" type4="protein-OH"/>
+    <Proper k1="0.0" k2="3.3472000000000004" k3="7.5312" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-C8" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="3.3472000000000004" k3="7.5312" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="3.3472000000000004" k3="7.5312" k4="8.368" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-3C" type2="protein-CX" type3="protein-N" type4="protein-C"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-C8"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-2C"/>
+    <Proper k1="0.0" k2="1.6736000000000002" k3="0.8368000000000001" k4="0.8368000000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-3C"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-N" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.33472" k2="0.0" k3="3.3472000000000004" periodicity1="3" periodicity2="2" periodicity3="1" phase1="3.141592653589793" phase2="0.0" phase3="0.0" type1="protein-O" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-OH" type2="protein-C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-CB" type2="protein-C*" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-CW" type2="protein-C*" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-C8" type4=""/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-CX" type2="protein-C8" type3="protein-C8" type4="protein-HC"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-C8" type3="protein-C8" type4="protein-HC"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-CX" type4=""/>
+    <Proper k1="0.0" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-N2" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-C8" type3="protein-N3" type4=""/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="" type2="protein-CA" type3="protein-2C" type4=""/>
+    <Proper k1="21.547600000000003" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-CV" type4="protein-H4"/>
+    <Proper k1="21.547600000000003" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-CV" type4="protein-NB"/>
+    <Proper k1="22.489" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-CW" type4="protein-H4"/>
+    <Proper k1="22.489" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-CW" type4="protein-NA"/>
+    <Proper k1="5.8576" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-NA" type4="protein-CR"/>
+    <Proper k1="5.8576" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-NA" type4="protein-H"/>
+    <Proper k1="10.0416" periodicity1="2" phase1="3.141592653589793" type1="protein-2C" type2="protein-CC" type3="protein-NB" type4="protein-CR"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-CV" type2="protein-CC" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-CW" type2="protein-CC" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-NA" type2="protein-CC" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-NB" type2="protein-CC" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.0" periodicity1="2" phase1="0.0" type1="protein-O2" type2="protein-CO" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="1.3946666666666667" periodicity1="3" phase1="0.0" type1="protein-H1" type2="protein-CT" type3="protein-S" type4="protein-2C"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-CX"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-H1"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-HC"/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-OH"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-CT" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-2C" type4=""/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CX" type3="protein-2C" type4="protein-OH"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-CX" type3="protein-3C" type4=""/>
+    <Proper k1="0.0" k2="1.046" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-H1" type2="protein-CX" type3="protein-3C" type4="protein-OH"/>
+    <Proper k1="0.6973333333333334" periodicity1="3" phase1="0.0" type1="protein-HO" type2="protein-OH" type3="protein-2C" type4="protein-H1"/>
+    <Proper k1="0.6973333333333334" periodicity1="3" phase1="0.0" type1="protein-HO" type2="protein-OH" type3="protein-3C" type4="protein-H1"/>
+    <Proper k1="1.3946666666666667" periodicity1="3" phase1="0.0" type1="" type2="protein-S" type3="protein-2C" type4=""/>
+    <Proper k1="1.046" periodicity1="3" phase1="0.0" type1="" type2="protein-SH" type3="protein-2C" type4=""/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="" type2="protein-2C" type3="protein-2C" type4=""/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-2C" type3="protein-2C" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-CT" type2="protein-2C" type3="protein-3C" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-CX" type2="protein-2C" type3="protein-3C" type4="protein-HC"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-2C" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.66944" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-2C" type3="protein-3C" type4="protein-CX"/>
+    <Proper k1="0.6276" periodicity1="3" phase1="0.0" type1="protein-HC" type2="protein-2C" type3="protein-3C" type4="protein-HC"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-C" type2="protein-CX" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-N" type2="protein-CX" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-N3" type2="protein-CX" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.75312" k2="1.046" k3="0.8368000000000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" type1="protein-CX" type2="protein-C8" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-N2"/>
+    <Proper k1="0.0" k2="0.0" periodicity1="3" periodicity2="1" phase1="0.0" phase2="0.0" type1="protein-C8" type2="protein-C8" type3="protein-N2" type4="protein-CA"/>
+    <Proper k1="0.75312" k2="1.046" k3="0.8368000000000001" periodicity1="3" periodicity2="2" periodicity3="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-C8"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-C8" type2="protein-C8" type3="protein-C8" type4="protein-N3"/>
+    <Proper k1="0.0" k2="10.0416" periodicity1="4" periodicity2="2" phase1="0.0" phase2="3.141592653589793" type1="protein-C8" type2="protein-N2" type3="protein-CA" type4="protein-N2"/>
+    <Proper k1="0.0" k2="10.0416" periodicity1="4" periodicity2="2" phase1="0.0" phase2="3.141592653589793" type1="protein-H" type2="protein-N2" type3="protein-CA" type4="protein-N2"/>
+    <Proper k1="0.6508444444444444" periodicity1="3" phase1="0.0" type1="protein-C8" type2="protein-C8" type3="protein-N3" type4="protein-H"/>
+    <Proper k1="0.3138" k2="1.050184" k3="1.4100080000000002" k4="1.125496" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.138072" k2="1.050184" k3="2.033424" k4="0.644336" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.138072" k2="1.050184" k3="2.033424" k4="0.644336" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-SH"/>
+    <Proper k1="0.12552" k2="1.054368" k3="2.560608" k4="0.384928" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-SH" type4="protein-HS"/>
+    <Proper k1="0.644336" k2="0.24267200000000003" k3="1.9204560000000002" k4="1.774016" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.372376" k2="0.24267200000000003" k3="2.7070480000000003" k4="9.012336" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.372376" k2="0.24267200000000003" k3="2.7070480000000003" k4="9.012336" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.129704" k2="0.0" k3="3.217496" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-CO" type4="protein-O2"/>
+    <Proper k1="0.44768800000000003" k2="0.138072" k3="1.267752" k4="4.376464" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.246856" k2="0.138072" k3="1.242648" k4="2.878592" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.246856" k2="0.138072" k3="1.242648" k4="2.878592" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.0" periodicity1="1" phase1="0.0" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.832616" k2="0.033472" k3="2.4057999999999997" k4="5.016616000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-OH"/>
+    <Proper k1="0.47279200000000005" k2="2.004136" k3="11.321904" k4="1.874432" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-2C" type2="protein-C" type3="protein-OH" type4="protein-HO"/>
+    <Proper k1="0.033472" k2="1.259384" k3="2.02924" k4="3.464352" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-CX" type2="protein-2C" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.10460000000000001" k2="0.916296" k3="1.020896" k4="0.598312" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-CT" type4="protein-CC"/>
+    <Proper k1="0.372376" k2="0.916296" k3="0.924664" k4="1.280304" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-CT" type4="protein-CC"/>
+    <Proper k1="0.372376" k2="0.916296" k3="0.924664" k4="1.280304" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N3" type2="protein-CX" type3="protein-CT" type4="protein-CC"/>
+    <Proper k1="0.154808" k2="2.8702240000000003" k3="1.640128" k4="0.66944" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-CX" type2="protein-CT" type3="protein-CC" type4="protein-NA"/>
+    <Proper k1="0.04184" k2="0.510448" k3="3.138" k4="2.8200160000000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" type1="protein-CX" type2="protein-CT" type3="protein-CC" type4="protein-CV"/>
+    <Proper k1="0.19664800000000002" k2="3.0961600000000002" k3="0.853536" k4="2.8869599999999997" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-CT" type3="protein-CC" type4="protein-NB"/>
+    <Proper k1="0.468608" k2="0.619232" k3="1.209176" k4="1.6987040000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.48116000000000003" k2="0.47279200000000005" k3="3.07524" k4="0.6778080000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.004184" k2="0.619232" k3="0.903744" k4="1.4100080000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.40584800000000004" k2="0.47279200000000005" k3="0.602496" k4="1.29704" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.004184" k2="0.619232" k3="0.903744" k4="1.4100080000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.40584800000000004" k2="0.47279200000000005" k3="0.602496" k4="1.29704" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-3C" type4="protein-2C"/>
+    <Proper k1="0.9623200000000001" k2="0.44768800000000003" k3="0.221752" k4="1.8702480000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-3C" type3="protein-2C" type4="protein-CT"/>
+    <Proper k1="0.937216" k2="0.44768800000000003" k3="0.322168" k4="0.8451680000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CT" type2="protein-3C" type3="protein-2C" type4="protein-CT"/>
+    <Proper k1="0.6527040000000001" k2="1.31796" k3="0.497896" k4="2.916248" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-3C" type4="protein-OH"/>
+    <Proper k1="0.39748" k2="1.31796" k3="0.025104" k4="2.8200160000000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-3C" type4="protein-OH"/>
+    <Proper k1="0.39748" k2="1.31796" k3="0.025104" k4="2.8200160000000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-3C" type4="protein-OH"/>
+    <Proper k1="0.054392" k2="0.987424" k3="1.050184" k4="0.025104" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" type1="protein-CX" type2="protein-3C" type3="protein-OH" type4="protein-HO"/>
+    <Proper k1="0.200832" k2="0.987424" k3="0.330536" k4="2.690312" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CT" type2="protein-3C" type3="protein-OH" type4="protein-HO"/>
+    <Proper k1="0.79496" k2="0.602496" k3="2.59408" k4="2.953904" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.305432" k2="0.602496" k3="1.0836560000000002" k4="0.410032" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.305432" k2="0.602496" k3="1.0836560000000002" k4="0.410032" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-3C"/>
+    <Proper k1="0.748936" k2="0.594128" k3="0.112968" k4="1.585736" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-3C" type4="protein-CT"/>
+    <Proper k1="0.539736" k2="1.6777840000000002" k3="0.912112" k4="2.7656240000000003" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-OH"/>
+    <Proper k1="0.66944" k2="1.6777840000000002" k3="1.029264" k4="2.786544" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-OH"/>
+    <Proper k1="0.66944" k2="1.6777840000000002" k3="1.029264" k4="2.786544" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-OH"/>
+    <Proper k1="0.029288" k2="1.1171280000000001" k3="1.857696" k4="0.882824" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-OH" type4="protein-HO"/>
+    <Proper k1="0.309616" k2="0.9790560000000001" k3="1.476952" k4="0.07112800000000001" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-CT" type4="protein-C*"/>
+    <Proper k1="0.129704" k2="0.9790560000000001" k3="1.309592" k4="0.330536" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-CT" type4="protein-C*"/>
+    <Proper k1="0.129704" k2="0.9790560000000001" k3="1.309592" k4="0.330536" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-CT" type4="protein-C*"/>
+    <Proper k1="0.39748" k2="3.4266959999999997" k3="1.707072" k4="1.52716" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-CT" type3="protein-C*" type4="protein-CB"/>
+    <Proper k1="0.0" k2="0.0" k3="0.0" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-CT" type3="protein-C*" type4="protein-CW"/>
+    <Proper k1="0.050208" k2="0.803328" k3="1.962296" k4="0.23012000000000002" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-CT" type4="protein-CA"/>
+    <Proper k1="0.029288" k2="0.803328" k3="1.21336" k4="0.050208" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-CT" type4="protein-CA"/>
+    <Proper k1="0.029288" k2="0.803328" k3="1.21336" k4="0.050208" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N3" type2="protein-CX" type3="protein-CT" type4="protein-CA"/>
+    <Proper k1="0.200832" k2="0.0" k3="0.288696" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CX" type2="protein-CT" type3="protein-CA" type4="protein-CA"/>
+    <Proper k1="0.27196000000000004" k2="0.0" k3="3.694472" k4="0.0" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-CA" type2="protein-C" type3="protein-OH" type4="protein-HO"/>
+    <Proper k1="0.60668" k2="0.602496" k3="1.6443120000000002" k4="1.761464" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.32635200000000003" k2="0.602496" k3="0.769856" k4="0.41840000000000005" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.32635200000000003" k2="0.602496" k3="0.769856" k4="0.41840000000000005" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-2C"/>
+    <Proper k1="0.577392" k2="1.723808" k3="0.347272" k4="0.820064" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="3.141592653589793" phase3="0.0" phase4="3.141592653589793" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-C"/>
+    <Proper k1="0.0" periodicity1="1" phase1="0.0" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-O"/>
+    <Proper k1="0.276144" k2="0.10460000000000001" k3="4.619136" k4="3.447616" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="3.141592653589793" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-OH"/>
+    <Proper k1="0.17572800000000002" k2="0.35564000000000007" k3="3.53548" k4="2.548056" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="3.141592653589793" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-2C" type2="protein-2C" type3="protein-C" type4="protein-N"/>
+    <Proper k1="0.234304" k2="2.543872" k3="0.928848" k4="5.719528" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="3.141592653589793" phase3="3.141592653589793" phase4="3.141592653589793" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-CO"/>
+    <Proper k1="0.267776" k2="1.63176" periodicity1="4" periodicity2="2" phase1="0.0" phase2="3.141592653589793" type1="protein-2C" type2="protein-2C" type3="protein-CO" type4="protein-O2"/>
+    <Proper k1="0.117152" k2="0.066944" k3="1.02508" k4="1.744728" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.238488" k2="1.732176" k3="1.849328" k4="1.033448" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="3.141592653589793" type1="protein-2C" type2="protein-2C" type3="protein-S" type4="protein-CT"/>
+    <Proper k1="1.1631520000000002" k2="1.3514320000000002" k3="1.6484960000000002" k4="2.518768" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-C" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.267776" k2="1.3514320000000002" k3="0.08786400000000001" k4="1.962296" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.267776" k2="1.3514320000000002" k3="0.08786400000000001" k4="1.962296" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="3.141592653589793" phase4="0.0" type1="protein-N3" type2="protein-CX" type3="protein-2C" type4="protein-S"/>
+    <Proper k1="0.56484" k2="1.263568" k3="2.786544" k4="0.234304" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="3.141592653589793" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-CX" type2="protein-2C" type3="protein-S" type4="protein-S"/>
+    <Proper k1="1.585736" k2="2.8534880000000005" k3="18.744320000000002" k4="1.75728" periodicity1="4" periodicity2="3" periodicity3="2" periodicity4="1" phase1="0.0" phase2="0.0" phase3="0.0" phase4="0.0" type1="protein-2C" type2="protein-S" type3="protein-S" type4="protein-2C"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="" type3="" type4="protein-O"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="" type3="protein-O2" type4="protein-O2"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N2" type2="" type3="" type4="protein-H"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-NA" type2="" type3="" type4="protein-H"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="protein-N2" type4="protein-N2"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-CT" type4="protein-CT"/>
+    <Improper k1="4.184" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="" type3="protein-CX" type4="protein-CT"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-HA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CW" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CR" type2="" type3="" type4="protein-H5"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CV" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-H4"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="" type3="" type4="protein-H5"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CT" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CV" type4="protein-NA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NB"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CC" type2="protein-CT" type3="protein-CW" type4="protein-NA"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C*" type2="protein-CB" type3="protein-CT" type4="protein-CW"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-CT"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-CA" type3="protein-CA" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-CA" type3="protein-CA" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-H5" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CX" type4="protein-H"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-N" type2="protein-C" type3="protein-CT" type4="protein-O"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-CO" type2="" type3="protein-O2" type4="protein-O2"/>
+    <Improper k1="43.932" periodicity1="2" phase1="3.141592653589793" type1="protein-C" type2="protein-2C" type3="protein-O" type4="protein-OH"/>
+    <Improper k1="4.6024" periodicity1="2" phase1="3.141592653589793" type1="protein-CA" type2="protein-2C" type3="protein-CA" type4="protein-CA"/>
+  </PeriodicTorsionForce>
+  <NonbondedForce coulomb14scale="0.8333333333333334" lj14scale="0.5">
+    <UseAttributeFromResidue name="charge"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-C"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CA"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CB"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CC"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CN"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CR"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-CT"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CV"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CW"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-C*"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-CX"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.10690784617684071" type="protein-H"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.2649532787749369" type="protein-HC"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.2471353044121301" type="protein-H1"/>
+    <Atom epsilon="0.06276" sigma="0.25996424595335105" type="protein-HA"/>
+    <Atom epsilon="0.06276" sigma="0.2510552587719476" type="protein-H4"/>
+    <Atom epsilon="0.06276" sigma="0.24214627159054422" type="protein-H5"/>
+    <Atom epsilon="0.0" sigma="1.0" type="protein-HO"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.10690784617684071" type="protein-HS"/>
+    <Atom epsilon="0.06568879999999999" sigma="0.19599771799087468" type="protein-HP"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-NA"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-NB"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N2"/>
+    <Atom epsilon="0.7112800000000001" sigma="0.3249998523775958" type="protein-N3"/>
+    <Atom epsilon="0.87864" sigma="0.2959921901149463" type="protein-O"/>
+    <Atom epsilon="0.87864" sigma="0.2959921901149463" type="protein-O2"/>
+    <Atom epsilon="0.8803136" sigma="0.3066473387839048" type="protein-OH"/>
+    <Atom epsilon="1.046" sigma="0.35635948725613575" type="protein-S"/>
+    <Atom epsilon="1.046" sigma="0.35635948725613575" type="protein-SH"/>
+    <Atom epsilon="0.359824" sigma="0.3399669508423535" type="protein-CO"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-2C"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-3C"/>
+    <Atom epsilon="0.4577296" sigma="0.3399669508423535" type="protein-C8"/>
+  </NonbondedForce>
+</ForceField>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,4 @@
+# Utility scripts for perses
+
+* `setup_relative_calculation.py` - ???
+* `generate-protonated-termini.py` - generate C-terminal protonated terminal residue templates from new-style OpenMM ffxml forcefield

--- a/scripts/generate-protonated-termini.py
+++ b/scripts/generate-protonated-termini.py
@@ -1,0 +1,39 @@
+#!/bin/env python
+
+"""
+Parse an AMBER OpenMM ffxml file to generate variants of amino acid residue templates with protonated termini
+"""
+
+import xml.etree.ElementTree as etree
+from xml.etree.ElementTree import Element, ElementTree, SubElement
+
+input_filename = 'protein.ff14SB.xml' # input ffxml filename
+output_filename = 'protein.ff14SB.protonated-termini.xml' # output ffxml filename
+
+# Create new tree
+new_root = Element('ForceField')
+new_residues = SubElement(new_root, 'Residues')
+new_tree = ElementTree(new_root)
+
+# Parse old tree
+tree = etree.parse(input_filename)
+residues = tree.getroot().find('Residues').findall('Residue')
+for residue in residues:
+    name = residue.attrib['name']
+    atom_names = set([atom.attrib['name'] for atom in residue.findall('Atom')])
+    if set(['N', 'CA', 'C']).issubset(atom_names):
+        residue.attrib['name'] += '-CTER-PROT'
+        # Append HXT to carbonyl carbon
+        atom = Element('Atom', name='HXT', type='protein-HA', charge="0.0000")
+        residue.append(atom)
+        bond = Element('Bond', atomName1='C', atomName2='HXT')
+        residue.append(bond)
+        # Remove C-terminal external bond
+        for bond in residue.findall('ExternalBond'):
+            if bond.attrib['atomName'] == 'C':
+                residue.remove(bond)
+
+        new_residues.append(residue)
+
+# Write new file
+new_tree.write(output_filename)


### PR DESCRIPTION
Maestro files were previously difficult to deal with if the C-terminal carbon was protonated with `HXT`.
This PR adds a script in `scripts/` to generate new ffxml file derivatives for amino acids with protonated C-termini. I've added the converted file for `protein.ff14SB.xml` to `perses/data/protein.ff14SB.protonated-termini.xml`.

Example usage:
```python
from simtk.openmm import app
filename = 'Inputs_for_FEP/MCL1_protein.pdb'
print('Reading {}...'.format(filename))
pdb = app.PDBFile(filename)
print('Reading forcefield...')
forcefield = app.ForceField('protein.ff14SB.xml', 'protein.ff14SB.protonated-termini.xml')
print('Creating system...')
system = forcefield.createSystem(pdb.topology)
print('Done.')
```