### PR TITLE
[MRG] Fix minimizers

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -135,8 +135,15 @@ class HybridTopologyFactory(object):
         self._interpolate_14s = interpolate_old_and_new_14s
 
         #new attributes from the modified geometry engine
-        self.neglected_new_angle_terms = neglected_new_angle_terms
-        self.neglected_old_angle_terms = neglected_old_angle_terms
+        if neglected_old_angle_terms:
+            self.neglected_old_angle_terms = neglected_old_angle_terms
+        else:
+            self.neglected_old_angle_terms = []
+
+        if neglected_new_angle_terms:
+            self.neglected_new_angle_terms = neglected_new_angle_terms
+        else:
+            self.neglected_new_angle_terms = []
 
         if bond_softening_constant != 1.0:
             self._bond_softening_constant = bond_softening_constant

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -323,7 +323,7 @@ def run_setup(setup_options):
         atom_selection = setup_options['atom_selection']
         _logger.info(f"\tatom selection detected: {atom_selection}")
     else:
-        _logger.info(f"\tno atom selection detected: default to None.")
+        _logger.info(f"\tno atom selection detected: default to all.")
         atom_selection = 'all' 
 
     if setup_options['fe_type'] == 'neq':

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -156,10 +156,6 @@ def run_setup(setup_options):
         - 'topology_proposals':
     """
     phases = setup_options['phases']
-    if len(phases) > 2:
-        _logger.info(f"\tnumber of phases is greater than 2...complex and solvent will be provided...")
-        phases = ['complex', 'solvent']
-
     known_phases = ['complex','solvent','vacuum']
     for phase in phases:
         assert (phase in known_phases), f"Unknown phase, {phase} provided. run_setup() can be used with {known_phases}"
@@ -328,7 +324,7 @@ def run_setup(setup_options):
         _logger.info(f"\tatom selection detected: {atom_selection}")
     else:
         _logger.info(f"\tno atom selection detected: default to None.")
-        atom_selection = None
+        atom_selection = 'all' 
 
     if setup_options['fe_type'] == 'neq':
         _logger.info(f"\tInstantiating nonequilibrium switching FEP")
@@ -538,10 +534,6 @@ if __name__ == "__main__":
             _logger.info(f'\tRunning {phase} phase...')
             hss_run = hss[phase]
 
-            _logger.info(f"\t\tminimizing...\n\n")
-            hss_run.minimize()
-            _logger.info(f"\n\n")
-
             _logger.info(f"\t\tequilibrating...\n\n")
             hss_run.equilibrate(n_equilibration_iterations)
             _logger.info(f"\n\n")
@@ -569,10 +561,6 @@ if __name__ == "__main__":
         for phase in setup_options['phases']:
             print(f'Running {phase} phase')
             hss_run = hss[phase]
-
-            _logger.info(f"\t\tminimizing...\n\n")
-            hss_run.minimize()
-            _logger.info(f"\n\n")
 
             _logger.info(f"\t\tequilibrating...\n\n")
             hss_run.equilibrate(n_equilibration_iterations)


### PR DESCRIPTION
This PR removes any use of the FIREMinimizationIntegrator, and instead uses functions that rely on openmm.LocalEnergyMinimizer instead, which has been more robust - particularly with hybrid systems.