### PR TITLE
[WIP] fixing bug with no unique

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -371,7 +371,7 @@ class HybridTopologyFactory(object):
 
         #The union of the two will give the core atoms that can result from either new or old topology
         total_core_atoms = core_atoms_from_old.union(core_atoms_from_new)
-        assert sorted(core_atoms_from_old) == sorted(core_atoms_from_new), 'Core atoms must match between old and new systems'
+        assert set(core_atoms_from_old) == set(core_atoms_from_new), 'Core atoms must match between old and new systems'
 
         #as a side effect, we can now compute the environment atom indices too, by subtracting the core indices
         #from the mapped atom set (since any atom that is mapped but not core is environment)

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -370,13 +370,13 @@ class HybridTopologyFactory(object):
                                                                      self._new_to_hybrid_map, name_of_residue)
 
         #The union of the two will give the core atoms that can result from either new or old topology
-        # TODO: Shouldn't these sets be the same?
         total_core_atoms = core_atoms_from_old.union(core_atoms_from_new)
+        assert sorted(core_atoms_from_old) == sorted(core_atoms_from_new), 'Core atoms must match between old and new systems'
 
         #as a side effect, we can now compute the environment atom indices too, by subtracting the core indices
         #from the mapped atom set (since any atom that is mapped but not core is environment)
         environment_atoms = mapped_hybrid_atoms_set.difference(total_core_atoms)
-
+        
         return total_core_atoms, environment_atoms
 
     def _determine_core_atoms_in_topology(self, topology, unique_atoms, mapped_atoms, hybrid_map, residue_to_switch):
@@ -416,6 +416,8 @@ class HybridTopologyFactory(object):
                         #we specifically want to add the hybrid atom.
                         hybrid_index = hybrid_map[atom_index]
                         core_atoms.add(hybrid_index)
+
+        assert len(core_atoms) >= 3, 'Cannot run a simulation with fewer than 3 core atoms. System has {len(core_atoms)}'        
 
         return core_atoms
 

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -463,7 +463,7 @@ class RelativeFEPSetup(object):
                                                     new_system=new_solvated_system,
                                                     old_topology=old_solvated_topology, old_system=old_solvated_system,
                                                     new_to_old_atom_map=new_to_old_atom_map, old_chemical_state_key='A',
-                                                    new_chemical_state_key='B')
+                                                    new_chemical_state_key='B',old_residue_name='MOL',new_residue_name='MOL')
 
         return ligand_topology_proposal, old_solvated_positions
 
@@ -518,7 +518,7 @@ class RelativeFEPSetup(object):
                                                     new_system=new_ligand_system,
                                                     old_topology=old_ligand_topology, old_system=old_ligand_system,
                                                     new_to_old_atom_map=new_to_old_atom_map, old_chemical_state_key='A',
-                                                    new_chemical_state_key='B')
+                                                    new_chemical_state_key='B',old_residue_name='MOL',new_residue_name='MOL')
 
         return ligand_topology_proposal, old_ligand_positions
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -797,7 +797,7 @@ class TopologyProposal(object):
                  logp_proposal=None,
                  new_to_old_atom_map=None, old_alchemical_atoms=None,
                  old_chemical_state_key=None, new_chemical_state_key=None,
-                 old_residue_name=None, new_residue_name=None,
+                 old_residue_name='MOL', new_residue_name='MOL',
                  metadata=None):
 
         if new_chemical_state_key is None or old_chemical_state_key is None:


### PR DESCRIPTION
Addresses #592

Core atoms are being mistakenly labelled as environment when:
- there are no unique new or old atoms
- the topology proposal is being generated from a higher order phase in the setup.

The TopologyProposal is instantiated using parameters gleaned from setting up the higher order (i.e. complex > solvent > vacuum) and the new and old residue names aren't set, so default to `None`
i.e. this bug doesn't arise if you _just_ run a vacuum leg, only if a solvent leg is set up and we try 'extract' the vacuum leg from that.

The defaults in TopologyProposal could instead be changed to 'MOL'

Adding an assert that the number of cores must be at least 3