### PR TITLE
Use LJPME for endstate corrections instead of expanded cutoff

### DIFF
--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -77,8 +77,12 @@ class HybridCompatibilityMixin(object):
             logger.info('Generating unsampled endstates.')
             unsampled_endstates = [thermodynamic_state_list[0],thermodynamic_state_list[-1]] # taking the first and last states of the alchemical protocol
 
-             # changing the non-bonded method for the unsampled endstates
-            unsampled_dispersion_endstates = []
+            # For the unsampled endstates:
+            # - move all alchemical atom LJ parameters from CustomNonbondedForce back to NonbondedForce
+            # - delete CustomNonbondedForce (since it is no longer needed)
+            # - set PME tolerance to 1e-5 of better
+            # - enable LJPME to handle long-range dispersion correction in physically reasonable manner
+            unsampled_dispersion_endstates = list()
             for master_lambda, endstate in zip([0.,1.],unsampled_endstates):
                 # Get a copy of the system
                 dispersion_system = endstate.get_system()


### PR DESCRIPTION
Instead of expanding cutoffs, it seems simpler to just use LJPME and a tighter PME tolerance.

In this implementation, we
- move all alchemical atom LJ parameters from CustomNonbondedForce back to NonbondedForce
- delete CustomNonbondedForce (since it is no longer needed)
- set PME tolerance to 1e-5
- enable LJPME to handle long-range dispersion correction in physically reasonable manner

I'm not sure which test(s) to run, so this is implemented as best I can without running any tests, and may still need some debugging.

See the warning that the platform precision may not actually be set to `mixed` using the scheme you had been using:
```python
        # WARNING: THIS DOES NOT ACTUALLY DO ANYTHING because we can't set the precision after context creation
        # TODO: FIX THIS BY MOVING IT TO THE INITIAL SETUP
        # SEE https://github.com/choderalab/yank/blob/3ac34a66883941492825450aeddf2e5be8bc848e/Yank/experiment.py#L2218-L2304
        context, _ = context_cache.get_context(compound_thermodynamic_state)
        platform = context.getPlatform()
        logger.info('Setting the platform precision to mixed')
        platform.setPropertyDefaultValue('Precision','mixed')
```
I think this needs to be set _before_ you create any `Context`s with the `Platform`. You'll want to see [how YANK does this](https://github.com/choderalab/yank/blob/3ac34a66883941492825450aeddf2e5be8bc848e/Yank/experiment.py#L2218-L2304) and consult with @andrrizzi.