### PR TITLE
Changing Hybrid{sams|repex}Sampler to accept variable number of sampler states

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -85,6 +85,8 @@ def getSetupOptions(filename):
         if 'beta_factor' not in setup_options:
             setup_options['beta_factor'] = 0.8
             _logger.info(f"\t\t\tbeta_factor not specified: default to 0.8.")
+        if 'n_replicas' not in setup_options:
+            setup_options['n_replicas'] = 1
     elif setup_options['fe_type'] == 'repex':
         _logger.info(f"\t\tfe_type: repex")
         if 'offline-freq' not in setup_options:
@@ -516,7 +518,7 @@ def run_setup(setup_options):
                                                hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                                                online_analysis_minimum_iterations=10,flatness_criteria=setup_options['flatness-criteria'],
                                                gamma0=setup_options['gamma0'])
-                hss[phase].setup(n_states=n_states, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
+                hss[phase].setup(n_states=n_states, n_replicas=n_replicas, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
             elif setup_options['fe_type'] == 'repex':
                 hss[phase] = HybridRepexSampler(mcmc_moves=mcmc.LangevinSplittingDynamicsMove(timestep=timestep,
                                                                                              collision_rate=5.0 / unit.picosecond,

--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -29,7 +29,7 @@ class HybridCompatibilityMixin(object):
         self._hybrid_factory = hybrid_factory
         super(HybridCompatibilityMixin, self).__init__(*args, **kwargs)
 
-    def setup(self, n_states, temperature, storage_file, minimisation_steps=100,lambda_schedule=None,lambda_protocol=LambdaProtocol(),endstates=True):
+    def setup(self, n_states, temperature, storage_file, minimisation_steps=100, n_samplers=None, lambda_schedule=None, lambda_protocol=LambdaProtocol(), endstates=True):
 
         from perses.dispersed import feptasks
 
@@ -46,6 +46,14 @@ class HybridCompatibilityMixin(object):
 
         context_cache = cache.ContextCache()
 
+        if n_samplers is None:
+            logger.info(f'n_samplers not defined, setting to match n_states, {n_states}') 
+            n_samplers = n_states
+        elif n_samplers > n_states:
+            logger.warning(f'More sampler states: {n_samplers} requested greater than number of states: {n_states}. Setting n_samplers to n_states: {n_states}')
+            n_samplers = n_states
+
+        # TODO this feels like it should be somewhere else... just not sure where. Maybe into lambda_protocol
         if lambda_schedule is None:
             lambda_schedule = np.linspace(0.,1.,n_states)
         else:
@@ -68,6 +76,17 @@ class HybridCompatibilityMixin(object):
             sampler_state_list.append(copy.deepcopy(sampler_state))
 
         reporter = storage_file
+
+        # making sure number of sampler states equals n_samplers
+        if len(sampler_state_list) == n_samplers:
+            continue
+        else:
+            # picking roughly evenly spaced sampler states
+            # if n_samplers == 1, then it will pick the first in the list
+            idx = np.round(np.linspace(0, len(sampler_state_list) - 1, n_samplers)).astype(int)
+            sampler_state_list = [state for i,state in enumerate(sampler_state_list) if i in idx]
+
+        assert len(sampler_state_list) == n_samplers 
 
         if endstates:
             # generating unsampled endstates

--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -29,7 +29,10 @@ class HybridCompatibilityMixin(object):
         self._hybrid_factory = hybrid_factory
         super(HybridCompatibilityMixin, self).__init__(*args, **kwargs)
 
-    def setup(self, n_states, temperature, storage_file, minimisation_steps=100, n_replicas=None, lambda_schedule=None, lambda_protocol=LambdaProtocol(), endstates=True):
+    def setup(self, n_states, temperature, storage_file, minimisation_steps=100,
+              n_replicas=None, lambda_schedule=None,
+              lambda_protocol=LambdaProtocol(), endstates=True):
+
 
         from perses.dispersed import feptasks
 
@@ -78,9 +81,7 @@ class HybridCompatibilityMixin(object):
         reporter = storage_file
 
         # making sure number of sampler states equals n_replicas
-        if len(sampler_state_list) == n_replicas:
-            continue
-        else:
+        if len(sampler_state_list) != n_replicas:
             # picking roughly evenly spaced sampler states
             # if n_replicas == 1, then it will pick the first in the list
             idx = np.round(np.linspace(0, len(sampler_state_list) - 1, n_replicas)).astype(int)

--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -29,7 +29,7 @@ class HybridCompatibilityMixin(object):
         self._hybrid_factory = hybrid_factory
         super(HybridCompatibilityMixin, self).__init__(*args, **kwargs)
 
-    def setup(self, n_states, temperature, storage_file, minimisation_steps=100, n_samplers=None, lambda_schedule=None, lambda_protocol=LambdaProtocol(), endstates=True):
+    def setup(self, n_states, temperature, storage_file, minimisation_steps=100, n_replicas=None, lambda_schedule=None, lambda_protocol=LambdaProtocol(), endstates=True):
 
         from perses.dispersed import feptasks
 
@@ -46,12 +46,12 @@ class HybridCompatibilityMixin(object):
 
         context_cache = cache.ContextCache()
 
-        if n_samplers is None:
-            logger.info(f'n_samplers not defined, setting to match n_states, {n_states}') 
-            n_samplers = n_states
-        elif n_samplers > n_states:
-            logger.warning(f'More sampler states: {n_samplers} requested greater than number of states: {n_states}. Setting n_samplers to n_states: {n_states}')
-            n_samplers = n_states
+        if n_replicas is None:
+            logger.info(f'n_replicas not defined, setting to match n_states, {n_states}')
+            n_replicas = n_states
+        elif n_replicas > n_states:
+            logger.warning(f'More sampler states: {n_replicas} requested greater than number of states: {n_states}. Setting n_replicas to n_states: {n_states}')
+            n_replicas = n_states
 
         # TODO this feels like it should be somewhere else... just not sure where. Maybe into lambda_protocol
         if lambda_schedule is None:
@@ -77,16 +77,16 @@ class HybridCompatibilityMixin(object):
 
         reporter = storage_file
 
-        # making sure number of sampler states equals n_samplers
-        if len(sampler_state_list) == n_samplers:
+        # making sure number of sampler states equals n_replicas
+        if len(sampler_state_list) == n_replicas:
             continue
         else:
             # picking roughly evenly spaced sampler states
-            # if n_samplers == 1, then it will pick the first in the list
-            idx = np.round(np.linspace(0, len(sampler_state_list) - 1, n_samplers)).astype(int)
+            # if n_replicas == 1, then it will pick the first in the list
+            idx = np.round(np.linspace(0, len(sampler_state_list) - 1, n_replicas)).astype(int)
             sampler_state_list = [state for i,state in enumerate(sampler_state_list) if i in idx]
 
-        assert len(sampler_state_list) == n_samplers 
+        assert len(sampler_state_list) == n_replicas
 
         if endstates:
             # generating unsampled endstates

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1733,7 +1733,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # forcefield.loadFile(StringIO(ffxml))
 
         # Create molecule in vacuum.
-        smiles = d_smiles_to_oemol.keys()[0] # getting the first smiles that works 
+        smiles = list(d_smiles_to_oemol.keys())[0] # getting the first smiles that works 
         print("smiles: ", smiles)
         molecule = smiles_to_oemol(smiles)
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1718,10 +1718,15 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # skipping molecules with undefined stereocenters
         d_smiles_to_oemol = {}
         for i, smiles in enumerate(molecules):
-            try:
-                d_smiles_to_oemol[smiles] = smiles_to_oemol(smiles, "MOL_%d" % i)
-            except Warning:
-                print(f'Molecle {i}, failed due to unspecified stereochemistry: {smiles}')
+            errfs = oechem.oeosstream()
+            oechem.OEThrow.SetOutputStream(errfs)
+            oechem.OEThrow.Clear()
+            mol = smiles_to_oemol(smiles, "MOL_%d" % i)
+            if 'Failed due to unspecified stereochemistry' in (errfs.str().decode("UTF-8")):
+                # can't handle strings with undefined stereochemistry so throwing them out of test
+                molecules.remove(smiles)
+            else:
+               d_smiles_to_oemol[smiles] = mol 
         # ffxml, failed_molecule_list = generateForceFieldFromMolecules(list(d_smiles_to_oemol.values()), ignoreFailures=True)
         #
         # f = open('clinical-kinase-inhibitors.xml', 'w')

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1722,11 +1722,12 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
             oechem.OEThrow.SetOutputStream(errfs)
             oechem.OEThrow.Clear()
             mol = smiles_to_oemol(smiles, "MOL_%d" % i)
-            if 'Failed due to unspecified stereochemistry' in (errfs.str().decode("UTF-8")):
+            if 'Failed due to unspecified stereochemistry' not in (errfs.str().decode("UTF-8")):
                 # can't handle strings with undefined stereochemistry so throwing them out of test
-                molecules.remove(smiles)
-            else:
-               d_smiles_to_oemol[smiles] = mol 
+                d_smiles_to_oemol[smiles] = mol 
+               
+        print(f'{len(molecules) - len(list(d_smiles_to_oemol.keys()))} molecules removed from test due to unspecified stereochemistry')
+        molecules = list(d_smiles_to_oemol.keys())
         # ffxml, failed_molecule_list = generateForceFieldFromMolecules(list(d_smiles_to_oemol.values()), ignoreFailures=True)
         #
         # f = open('clinical-kinase-inhibitors.xml', 'w')
@@ -1738,7 +1739,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # forcefield.loadFile(StringIO(ffxml))
 
         # Create molecule in vacuum.
-        smiles = list(d_smiles_to_oemol.keys())[0] # getting the first smiles that works 
+        smiles = molecules[0] # getting the first smiles that works 
         print("smiles: ", smiles)
         molecule = smiles_to_oemol(smiles)
 

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1722,7 +1722,7 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
             oechem.OEThrow.SetOutputStream(errfs)
             oechem.OEThrow.Clear()
             mol = smiles_to_oemol(smiles, "MOL_%d" % i)
-            if 'Failed due to unspecified stereochemistry' not in (errfs.str().decode("UTF-8")):
+            if 'Failed due to unspecified stereochemistry' not in (errfs.str().decode("ISO-8859-1")):
                 # can't handle strings with undefined stereochemistry so throwing them out of test
                 d_smiles_to_oemol[smiles] = mol 
                

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -1714,7 +1714,14 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # forcefield = app.ForceField(gaff_xml_filename, 'tip3p.xml', clinical-kinase-inhibitors_filename)
         from openmoltools import forcefield_generators ## IVY
         forcefield.registerTemplateGenerator(gaffTemplateGenerator) ## IVY
-        d_smiles_to_oemol = {smiles : smiles_to_oemol(smiles, "MOL_%d" % i)for i, smiles in enumerate(molecules)}
+
+        # skipping molecules with undefined stereocenters
+        d_smiles_to_oemol = {}
+        for i, smiles in enumerate(molecules):
+            try:
+                d_smiles_to_oemol[smiles] = smiles_to_oemol(smiles, "MOL_%d" % i)
+            except Warning:
+                print(f'Molecle {i}, failed due to unspecified stereochemistry: {smiles}')
         # ffxml, failed_molecule_list = generateForceFieldFromMolecules(list(d_smiles_to_oemol.values()), ignoreFailures=True)
         #
         # f = open('clinical-kinase-inhibitors.xml', 'w')
@@ -1726,17 +1733,8 @@ class SmallMoleculeLibraryTestSystem(PersesTestSystem):
         # forcefield.loadFile(StringIO(ffxml))
 
         # Create molecule in vacuum.
-        smiles = molecules[0]  # current sampler state ## IVY add this back in
-        # smiles = 'C5=C(C1=CN=CC=C1)N=C(NC2=C(C=CC(=C2)NC(C3=CC=C(C=C3)CN4CCN(CC4)C)=O)C)N=C5'  ## IVY delete this Imatinib
-        # smiles = 'Cc1ccc(cc1C#Cc2cnc3n2nccc3)C(=O)Nc4ccc(c(c4)C(F)(F)F)CN5CCN(CC5)C'
-        # smiles = 'Cc1c2cnc(nc2n(c(=O)c1C(=O)C)C3CCCC3)Nc4ccc(cn4)N5CCNCC5' # palbociclib
-        # smiles = 'Cc1c2cnc(nc2n(c(=O)c1C(=O)C)C3CCCC3)Nc4ccc(cn4)N5CCNCC5'
-        # smiles = 'C[C@@H]1CCN(C[C@@H]1[N@](C)c2c3cc[nH]c3ncn2)C(=O)CC#N'
-        # smiles = 'CC1=C(C=C(C=C1)NC2=NC=CC(=N2)N(C)C3=CC4=NN(C(=C4C=C3)C)C)S(=O)(=O)N' # Pazopanib
+        smiles = d_smiles_to_oemol.keys()[0] # getting the first smiles that works 
         print("smiles: ", smiles)
-        # smiles = sanitizeSMILES([smiles])[0]
-        # print("sanitized: ", smiles)
-        # molecule = smiles_to_oemol(smiles, title=d_smiles_to_oemol[smiles].GetTitle())
         molecule = smiles_to_oemol(smiles)
 
         topologies['vacuum'] = generateTopologyFromOEMol(molecule)

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -46,6 +46,7 @@ def smiles_to_oemol(smiles, title='MOL',max_confs=1):
     oechem.OEAssignAromaticFlags(molecule, oechem.OEAroModelOpenEye)
     oechem.OEAssignHybridization(molecule)
     oechem.OEAddExplicitHydrogens(molecule)
+    oechem.OEPerceiveChiral(molecule)
 
     # Create atom names.
     oechem.OETriposAtomNames(molecule)
@@ -251,6 +252,7 @@ def createOEMolFromSDF(sdf_filename, index=0):
         oechem.OEAssignAromaticFlags(molecule, oechem.OEAroModelOpenEye)
         oechem.OEAssignHybridization(molecule)
         oechem.OEAddExplicitHydrogens(molecule)
+        oechem.OEPerceiveChiral(molecule)
 
     mol_to_return = mol_list[index]
     return mol_to_return
@@ -271,7 +273,6 @@ def calculate_mol_similarity(molA, molB):
     return oegraphsim.OETanimoto(fpA, fpB)
 
 def createSMILESfromOEMol(molecule):
-    smiles = oechem.OECreateSmiString(molecule,
                              oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_Hydrogens)
     return smiles
 

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -273,6 +273,7 @@ def calculate_mol_similarity(molA, molB):
     return oegraphsim.OETanimoto(fpA, fpB)
 
 def createSMILESfromOEMol(molecule):
+    smiles = oechem.OECreateSmiString(molecule,
                              oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_Hydrogens)
     return smiles
 

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -280,17 +280,17 @@ def createSMILESfromOEMol(molecule):
 
 def generate_unique_atom_names(molecule):
     """
-    Check if an oemol has unique atom names, and if not, then assigns them 
+    Check if an oemol has unique atom names, and if not, then assigns them
 
     Parameters
     ----------
     molecule : openeye.oechem.OEMol object
-        oemol object to check 
+        oemol object to check
 
     Returns
     -------
     molecule : openeye.oechem.OEMol object
-        oemol, either unchanged if atom names are already unique, or newly generated atom names 
+        oemol, either unchanged if atom names are already unique, or newly generated atom names
     """
     atom_names = []
 
@@ -302,7 +302,7 @@ def generate_unique_atom_names(molecule):
     if len(set(atom_names)) == atom_count:
         # one name per atom therefore unique
         _logger.info(f'molecule {molecule.GetTitle()} has unique atom names already')
-        return molecule 
+        return molecule
     else:
         # generating new atom names
         from collections import defaultdict
@@ -315,3 +315,30 @@ def generate_unique_atom_names(molecule):
             name = element._symbol + str(element_counts[element._symbol])
             atom.SetName(name)
         return molecule
+
+
+def has_undefined_stereocenters(mol):
+    """
+    Check that _if_ a molecule has a stereocenter, the stereochemistry is defined
+    if no stereocenter then will return False too
+
+    Parameters
+    ----------
+    molecule : openeye.oechem.OEMol object
+        oemol object to check
+
+    Returns
+    -------
+    bool : True if undefined Stereochemistry
+           False if no stereochemistry or all stereocenter's are labelled
+    """
+    oechem.OEPerceiveChiral(mol)
+    for atom in mol.GetAtoms():
+        if atom.IsChiral():
+            if not atom.HasStereoSpecified():
+                return True # we have a stereocenter with no stereochemistry!
+    for bond in mol.GetBonds():
+        if bond.IsChiral():
+            if not bond.HasStereoSpecified():
+                return True #we have a geometric isomer that isn't specified!
+    return False # nothing bad found


### PR DESCRIPTION
This adds an optional argument called `n_samplers` which defines the number of sampler states to run with. If `n_samplers != n_states` it will pick approximately equally spaced sampler states from the list.

The default for n_samplers is to equal n_states, but possibly we would want the defaults to be:

REPEX n_samplers = n_states
SAMS n_samplers = 1

?