### PR TITLE
Updating small molecule pipeline to fit into the new protein-mutation stuff

### DIFF
--- a/perses/analysis/load_simulations.py
+++ b/perses/analysis/load_simulations.py
@@ -185,6 +185,7 @@ class Simulation(object):
         from pymbar import timeseries
         from pymbar import MBAR
         from perses.analysis import utils
+        from simtk import unit
         import os
         from openmmtools.multistate import MultiStateReporter, MultiStateSamplerAnalyzer
 
@@ -199,8 +200,10 @@ class Simulation(object):
                 for step in range(stepsize, n_iterations, stepsize):
                     vacuum_analyzer = MultiStateSamplerAnalyzer(vacuum_reporter,max_n_iterations=step)
                     f_ij, df_ij = vacuum_analyzer.get_free_energy()
-                    self._vacdg_history.append(_kt_to_kcal(f_ij[0, -1]))
-                    self._vacddg_history.append(_kt_to_kcal(df_ij[0,-1]))
+                    f = f_ij[0,-1] * vacuum_analyzer.kT
+                    self._vacdg_history.append(f.in_units_of(unit.kilocalories_per_mole))
+                    df = df_ij[0, -1] * vacuum_analyzer.kT
+                    self._vacddg_history.append(df.in_units_of(unit.kilocalories_per_mole))
             if 'solvent' in out:
                 solvent_reporter = MultiStateReporter(f'{self.directory}/{out}')
                 ncfile = utils.open_netcdf(f'{self.directory}/{out}')
@@ -208,8 +211,10 @@ class Simulation(object):
                 for step in range(stepsize, n_iterations, stepsize):
                     solvent_analyzer = MultiStateSamplerAnalyzer(solvent_reporter,max_n_iterations=step)
                     f_ij, df_ij = solvent_analyzer.get_free_energy()
-                    self._soldg_history.append(_kt_to_kcal(f_ij[0, -1]))
-                    self._solddg_history.append(_kt_to_kcal(df_ij[0,-1]))
+                    f = f_ij[0,-1] * solvent_analyzer.kT
+                    self._soldg_history.append(f.in_units_of(unit.kilocalories_per_mole))
+                    df = df_ij[0, -1] * solvent_analyzer.kT
+                    self._solddg_history.append(df.in_units_of(unit.kilocalories_per_mole))
             if 'complex' in out:
                 complex_reporter = MultiStateReporter(f'{self.directory}/{out}')
                 ncfile = utils.open_netcdf(f'{self.directory}/{out}')
@@ -217,8 +222,10 @@ class Simulation(object):
                 for step in range(stepsize, n_iterations, stepsize):
                     complex_analyzer = MultiStateSamplerAnalyzer(complex_reporter,max_n_iterations=step)
                     f_ij, df_ij = complex_analyzer.get_free_energy()
-                    self._comdg_history.append(_kt_to_kcal(f_ij[0, -1]))
-                    self._comddg_history.append(_kt_to_kcal(df_ij[0,-1]))
+                    f = f_ij[0,-1] * complex_analyzer.kT
+                    self._comdg_history.append(f.in_units_of(unit.kilocalories_per_mole))
+                    df = df_ij[0, -1] * complex_analyzer.kT
+                    self._comddg_history.append(df.in_units_of(unit.kilocalories_per_mole))
         return
 
     def sample_history(self, method='binding'):

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -114,6 +114,7 @@ class RelativeFEPSetup(object):
 
         try:
             self._nonbonded_method = getattr(app,nonbonded_method)
+            _logger.info(f'Setting non bonded method to {nonbonded_method}')
         except AttributeError:
             _logger.warning(f'Nonbonded method {nonbonded_method} not recognised')
             if 'complex' in phases or 'solvent' in phases:
@@ -268,7 +269,7 @@ class RelativeFEPSetup(object):
         _logger.info("successfully created SystemGenerator to create ligand systems")
 
         _logger.info(f"executing SmallMoleculeSetProposalEngine...")
-        self._proposal_engine = SmallMoleculeSetProposalEngine([self._ligand_oemol_old, self._ligand_oemol_new], self._system_generator, map_strength=self._map_strength, atom_expr=self._atom_expr, bond_expr=self._bond_expr, residue_name='MOL')
+        self._proposal_engine = SmallMoleculeSetProposalEngine([self._ligand_oemol_old, self._ligand_oemol_new], self._system_generator, residue_name='MOL')
 
         _logger.info(f"instantiating FFAllAngleGeometryEngine...")
         # NOTE: we are conducting the geometry proposal without any neglected angles
@@ -289,7 +290,7 @@ class RelativeFEPSetup(object):
             _logger.info(f"creating TopologyProposal...")
             self._complex_topology_proposal = self._proposal_engine.propose(self._complex_system_old_solvated,
                                           self._complex_topology_old_solvated,
-                                          current_mol_id=0, proposed_mol_id=1)
+                                          current_mol_id=0, proposed_mol_id=1, map_strength=self._map_strength, atom_expr=self._atom_expr, bond_expr=self._bond_expr)
 
             self.non_offset_new_to_old_atom_map = self._proposal_engine.non_offset_new_to_old_atom_map
 
@@ -323,7 +324,6 @@ class RelativeFEPSetup(object):
             _logger.info(f"Detected solvent...")
             if self._proposal_phase is None:
                 _logger.info(f"no complex detected in phases...generating unique topology/geometry proposals...")
-                self._nonbonded_method = app.PME
                 _logger.info(f"solvating ligand...")
                 self._ligand_topology_old_solvated, self._ligand_positions_old_solvated, self._ligand_system_old_solvated = self._solvate_system(
                 self._ligand_topology_old, self._ligand_positions_old,phase='solvent')
@@ -332,7 +332,7 @@ class RelativeFEPSetup(object):
                 _logger.info(f"creating TopologyProposal")
                 self._solvent_topology_proposal = self._proposal_engine.propose(self._ligand_system_old_solvated,
                                                                                 self._ligand_topology_old_solvated,
-                                                                                current_mol_id=0, proposed_mol_id=1)
+                                          current_mol_id=0, proposed_mol_id=1, map_strength=self._map_strength, atom_expr=self._atom_expr, bond_expr=self._bond_expr)
 
                 self.non_offset_new_to_old_atom_map = self._proposal_engine.non_offset_new_to_old_atom_map
                 self._proposal_phase = 'solvent'
@@ -382,7 +382,7 @@ class RelativeFEPSetup(object):
                                                                                                          self._ligand_positions_old,phase='vacuum')
                 self._vacuum_topology_proposal = self._proposal_engine.propose(self._vacuum_system_old,
                                                                                self._vacuum_topology_old,
-                                                                               current_mol_id=0, proposed_mol_id=1)
+                                          current_mol_id=0, proposed_mol_id=1, map_strength=self._map_strength, atom_expr=self._atom_expr, bond_expr=self._bond_expr)
 
                 self.non_offset_new_to_old_atom_map = self._proposal_engine.non_offset_new_to_old_atom_map
                 self._proposal_phase = 'vacuum'

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -520,7 +520,7 @@ def run_setup(setup_options):
             #TODO expose more of these options in input
             if setup_options['fe_type'] == 'sams':
                 hss[phase] = HybridSAMSSampler(mcmc_moves=mcmc.LangevinDynamicsMove(timestep=timestep,
-                                                                                    collision_rate=5.0 / unit.picosecond,
+                                                                                    collision_rate=1.0 / unit.picosecond,
                                                                                     n_steps=n_steps_per_move_application,
                                                                                     reassign_velocities=False,
                                                                                     n_restart_attempts=20),
@@ -530,7 +530,7 @@ def run_setup(setup_options):
                 hss[phase].setup(n_states=n_states, n_replicas=n_replicas, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
             elif setup_options['fe_type'] == 'repex':
                 hss[phase] = HybridRepexSampler(mcmc_moves=mcmc.LangevinDynamicsMove(timestep=timestep,
-                                                                                     collision_rate=5.0 / unit.picosecond,
+                                                                                     collision_rate=1.0 / unit.picosecond,
                                                                                      n_steps=n_steps_per_move_application,
                                                                                      reassign_velocities=False,
                                                                                      n_restart_attempts=20),

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -521,9 +521,7 @@ def run_setup(setup_options):
                                                                                     collision_rate=5.0 / unit.picosecond,
                                                                                     n_steps=n_steps_per_move_application,
                                                                                     reassign_velocities=False,
-                                                                                    n_restart_attempts=20,
-                                                                                    splitting="V R O R V",
-                                                                                    constraint_tolerance=1e-06),
+                                                                                    n_restart_attempts=20),
                                                hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                                                online_analysis_minimum_iterations=10,flatness_criteria=setup_options['flatness-criteria'],
                                                gamma0=setup_options['gamma0'])
@@ -533,9 +531,7 @@ def run_setup(setup_options):
                                                                                      collision_rate=5.0 / unit.picosecond,
                                                                                      n_steps=n_steps_per_move_application,
                                                                                      reassign_velocities=False,
-                                                                                     n_restart_attempts=20,
-                                                                                     splitting="V R O R V",
-                                                                                     constraint_tolerance=1e-06),
+                                                                                     n_restart_attempts=20),
                                                                                      hybrid_factory=htf[phase],online_analysis_interval=setup_options['offline-freq'])
                 hss[phase].setup(n_states=n_states, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
 

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -59,7 +59,7 @@ def getSetupOptions(filename):
         phases to simulate, can be 'complex', 'solvent' or 'vacuum'
     """
     yaml_file = open(filename, 'r')
-    setup_options = yaml.load(yaml_file)
+    setup_options = yaml.load(yaml_file, Loader=yaml.FullLoader)
     yaml_file.close()
 
     _logger.info("\tDetecting phases...")
@@ -238,17 +238,19 @@ def getSetupOptions(filename):
     else:
         _logger.info(f"\t'neglect_angles' detected: {setup_options['neglect_angles']}.")
 
-    setup_options['atom_expr'] = None
     if 'atom_expression' in setup_options:
         # need to convert the list to Integer
         from perses.utils.openeye import generate_expression
         setup_options['atom_expr'] = generate_expression(setup_options['atom_expression'])
+    else:
+        setup_options['atom_expr'] = None
 
-    setup_options['bond_expr'] = None
     if 'bond_expression' in setup_options:
         # need to convert the list to Integer
         from perses.utils.openeye import generate_expression
         setup_options['bond_expr'] = generate_expression(setup_options['bond_expression'])
+    else:
+        setup_options['bond_expr'] = None
 
     if 'map_strength' not in setup_options:
         setup_options['map_strength'] = None 

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -491,7 +491,7 @@ def run_setup(setup_options):
             _forward_added_valence_energy = top_prop['%s_added_valence_energy' % phase]
             _reverse_subtracted_valence_energy = top_prop['%s_subtracted_valence_energy' % phase]
 
-            zero_state_error, one_state_error = validate_endstate_energies(_top_prop, _htf, _forward_added_valence_energy, _reverse_subtracted_valence_energy, beta = 1.0/(kB*temperature), ENERGY_THRESHOLD = ENERGY_THRESHOLD)
+            zero_state_error, one_state_error = validate_endstate_energies(_top_prop, _htf, _forward_added_valence_energy, _reverse_subtracted_valence_energy, beta = 1.0/(kB*temperature), ENERGY_THRESHOLD = ENERGY_THRESHOLD, platform=openmm.Platform.getPlatformByName("Reference"))
             _logger.info(f"\t\terror in zero state: {zero_state_error}")
             _logger.info(f"\t\terror in one state: {one_state_error}")
 

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -517,26 +517,26 @@ def run_setup(setup_options):
                 endstates = True
             #TODO expose more of these options in input
             if setup_options['fe_type'] == 'sams':
-                hss[phase] = HybridSAMSSampler(mcmc_moves=mcmc.LangevinSplittingDynamicsMove(timestep=timestep,
-                                                                                             collision_rate=5.0 / unit.picosecond,
-                                                                                             n_steps=n_steps_per_move_application,
-                                                                                             reassign_velocities=False,
-                                                                                             n_restart_attempts=20,
-                                                                                             splitting="V R O R V",
-                                                                                             constraint_tolerance=1e-06),
+                hss[phase] = HybridSAMSSampler(mcmc_moves=mcmc.LangevinDynamicsMove(timestep=timestep,
+                                                                                    collision_rate=5.0 / unit.picosecond,
+                                                                                    n_steps=n_steps_per_move_application,
+                                                                                    reassign_velocities=False,
+                                                                                    n_restart_attempts=20,
+                                                                                    splitting="V R O R V",
+                                                                                    constraint_tolerance=1e-06),
                                                hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                                                online_analysis_minimum_iterations=10,flatness_criteria=setup_options['flatness-criteria'],
                                                gamma0=setup_options['gamma0'])
                 hss[phase].setup(n_states=n_states, n_replicas=n_replicas, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
             elif setup_options['fe_type'] == 'repex':
-                hss[phase] = HybridRepexSampler(mcmc_moves=mcmc.LangevinSplittingDynamicsMove(timestep=timestep,
-                                                                                             collision_rate=5.0 / unit.picosecond,
-                                                                                             n_steps=n_steps_per_move_application,
-                                                                                             reassign_velocities=False,
-                                                                                             n_restart_attempts=20,
-                                                                                             splitting="V R O R V",
-                                                                                             constraint_tolerance=1e-06),
-                                                                                             hybrid_factory=htf[phase],online_analysis_interval=setup_options['offline-freq'])
+                hss[phase] = HybridRepexSampler(mcmc_moves=mcmc.LangevinDynamicsMove(timestep=timestep,
+                                                                                     collision_rate=5.0 / unit.picosecond,
+                                                                                     n_steps=n_steps_per_move_application,
+                                                                                     reassign_velocities=False,
+                                                                                     n_restart_attempts=20,
+                                                                                     splitting="V R O R V",
+                                                                                     constraint_tolerance=1e-06),
+                                                                                     hybrid_factory=htf[phase],online_analysis_interval=setup_options['offline-freq'])
                 hss[phase].setup(n_states=n_states, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
 
         return {'topology_proposals': top_prop, 'hybrid_topology_factories': htf, 'hybrid_samplers': hss}

--- a/perses/dispersed/utils.py
+++ b/perses/dispersed/utils.py
@@ -56,7 +56,7 @@ def check_platform(platform):
         raise Exception(e)
 
 
-def configure_platform(platform_name='Reference', fallback_platform_name='CPU'):
+def configure_platform(platform_name='Reference', fallback_platform_name='CPU', precision='mixed'):
     """
     Retrieve the requested platform with platform-appropriate precision settings.
     platform_name : str, optional, default='Reference'
@@ -79,10 +79,10 @@ def configure_platform(platform_name='Reference', fallback_platform_name='CPU'):
             platform = openmm.Platform.getPlatformByName("CPU")
         elif platform_name.upper() == 'OpenCL'.upper():
             platform = openmm.Platform.getPlatformByName('OpenCL')
-            platform.setPropertyDefaultValue('OpenCLPrecision', 'mixed')
+            platform.setPropertyDefaultValue('OpenCLPrecision', precision)
         elif platform_name.upper() == 'CUDA'.upper():
             platform = openmm.Platform.getPlatformByName('CUDA')
-            platform.setPropertyDefaultValue('CudaPrecision', 'mixed')
+            platform.setPropertyDefaultValue('CudaPrecision', precision)
             platform.setPropertyDefaultValue('DeterministicForces', 'true')
         else:
             raise (ValueError("Invalid platform name"))

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -648,15 +648,15 @@ class FFAllAngleGeometryEngine(GeometryEngine):
 
         state = final_context.getState(getEnergy=True)
         final_context_reduced_potential = beta*state.getPotentialEnergy()
-        final_context_components = [(force, energy*beta) for force, energy in compute_potential_components(final_context)]
-        atoms_with_positions_reduced_potential_components = [(force, energy*beta) for force, energy in compute_potential_components(atoms_with_positions_context)]
+        final_context_components = [(force, energy*beta) for force, energy in compute_potential_components(final_context, platform=openmm.Platform.getPlatformByName("Reference"))]
+        atoms_with_positions_reduced_potential_components = [(force, energy*beta) for force, energy in compute_potential_components(atoms_with_positions_context, platform=openmm.Platform.getPlatformByName("Reference"))]
         _logger.debug(f"reduced potential components before atom placement:")
         for item in atoms_with_positions_reduced_potential_components:
             _logger.debug(f"\t\t{item[0]}: {item[1]}")
         _logger.info(f"total reduced potential before atom placement: {atoms_with_positions_reduced_potential}")
 
         _logger.debug(f"potential components added from growth system:")
-        added_energy_components = [(force, energy*beta) for force, energy in compute_potential_components(context)]
+        added_energy_components = [(force, energy*beta) for force, energy in compute_potential_components(context, platform=openmm.Platform.getPlatformByName("Reference"))]
         for item in added_energy_components:
             _logger.debug(f"\t\t{item[0]}: {item[1]}")
 
@@ -725,7 +725,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         mod_state = mod_context.getState(getEnergy=True)
         modified_reduced_potential_energy = beta * mod_state.getPotentialEnergy()
 
-        added_energy_components = [(force, energy) for force, energy in compute_potential_components(mod_context)]
+        added_energy_components = [(force, energy) for force, energy in compute_potential_components(mod_context, platform=openmm.Platform.getPlatformByName("Reference"))]
         print(f"added energy components: {added_energy_components}")
 
         return modified_reduced_potential_energy

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -489,9 +489,13 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         #Print the energy of the system before unique_new/old atoms are placed...
         state = atoms_with_positions_context.getState(getEnergy=True)
         atoms_with_positions_reduced_potential = beta*state.getPotentialEnergy()
-        atoms_with_positions_reduced_potential_components = [(force, energy) for force, energy in compute_potential_components(atoms_with_positions_context)]
+        atoms_with_positions_reduced_potential_components = [(force, energy) for force, energy in compute_potential_components(atoms_with_positions_context, platform=openmm.Platform.getPlatformByName("Reference"))]
+        _logger.debug(f'atoms_with_positions_reduced_potential_components:')
+        for f, e in atoms_with_positions_reduced_potential_components:
+            _logger.debug(f'\t{f} : {e}')
         atoms_with_positions_methods_differences = abs(atoms_with_positions_reduced_potential - sum([i[1] for i in atoms_with_positions_reduced_potential_components]))
-        assert atoms_with_positions_methods_differences < ENERGY_THRESHOLD, f"the difference between the atoms_with_positions_reduced_potential and the sum of atoms_with_positions_reduced_potential_components is {abs(atoms_with_positions_reduced_potential - sum([i[1] for i in atoms_with_positions_reduced_potential_components]))}"
+        _logger.debug(f'Diffence in energy on adding unique atoms: {atoms_with_positions_methods_differences}')
+        assert atoms_with_positions_methods_differences < ENERGY_THRESHOLD, f"the difference between the atoms_with_positions_reduced_potential and the sum of atoms_with_positions_reduced_potential_components is {atoms_with_positions_methods_differences}"
 
         # Place each atom in predetermined order
         _logger.info("There are {} new atoms".format(len(atom_proposal_order)))

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -302,17 +302,6 @@ class AtomMapper(object):
     allow_ring_breaking
 
     """
-    # def __init__(self, list_of_oemols, atom_expr=DEFAULT_ATOM_EXPRESSION, bond_expr=DEFAULT_BOND_EXPRESSION,
-    #              map_strength='default', allow_ring_breaking=False, **kwargs):
-    #     self.list_of_oemols = list_of_oemols
-    #     assert len(self.list_of_oemols) >= 2 , 'At least two molecules are required'
-    #     self.map_strength = map_strength
-    #     self.atom_expr = atom_expr
-    #     self.bond_expr = bond_expr
-    #     self.allow_ring_breaking = allow_ring_breaking
-    #
-    #     #self.atom_map = AtomMapper._get_mol_atom_map(self.list_of_oemols[0],self.list_of_oemols[1])
-    #     super(AtomMapper, self).__init__(**kwargs)
 
     @staticmethod
     def _get_mol_atom_map(current_oemol,
@@ -356,23 +345,28 @@ class AtomMapper(object):
             list of the matches between the molecules, or None if no matches possible
 
         """
-        map_strength_dict = {'default': (DEFAULT_ATOM_EXPRESSION, DEFAULT_BOND_EXPRESSION),
-                             'weak': (WEAK_ATOM_EXPRESSION, WEAK_BOND_EXPRESSION),
-                             'strong': (STRONG_ATOM_EXPRESSION, STRONG_BOND_EXPRESSION)}
-        if (atom_expr, bond_expr) == (None, None):
-            #then choose the appropriate mapping criteria
-            _logger.debug(f"\t\t\tfound map strength: {map_strength}")
-            atom_expr, bond_expr = map_strength_dict[map_strength]
+        map_strength_dict = {'default': [DEFAULT_ATOM_EXPRESSION, DEFAULT_BOND_EXPRESSION],
+                             'weak': [WEAK_ATOM_EXPRESSION, WEAK_BOND_EXPRESSION],
+                             'strong': [STRONG_ATOM_EXPRESSION, STRONG_BOND_EXPRESSION]}
+        if map_strength is None:
+            map_strength = 'default'
+    
+        if atom_expr is None:
+            _logger.debug(f'No atom expression defined, using map strength : {map_strength}')
+            atom_expr = map_strength_dict[map_strength][0]
+        if bond_expr is None:
+            _logger.debug(f'No bond expression defined, using map strength : {map_strength}')
+            bond_expr = map_strength_dict[map_strength][1]
 
         # this ensures that the hybridization of the oemols is done for correct atom mapping
         oechem.OEAssignHybridization(current_oemol)
         oechem.OEAssignHybridization(proposed_oemol)
         oegraphmol_current = oechem.OEGraphMol(current_oemol)  # pattern molecule
         oegraphmol_proposed = oechem.OEGraphMol(proposed_oemol)  # target molecule
-        if not allow_ring_breaking:
-            # assigning ring membership to prevent ring breaking
-            oegraphmol_current = AtomMapper._assign_ring_ids(oegraphmol_current)
-            oegraphmol_proposed = AtomMapper._assign_ring_ids(oegraphmol_proposed)
+
+        # assigning ring membership to prevent ring breaking
+        oegraphmol_current = AtomMapper._assign_ring_ids(oegraphmol_current)
+        oegraphmol_proposed = AtomMapper._assign_ring_ids(oegraphmol_proposed)
         mcs = oechem.OEMCSSearch(oechem.OEMCSType_Approximate)
         mcs.Init(oegraphmol_current, atom_expr, bond_expr)
         mcs.SetMCSFunc(oechem.OEMCSMaxBondsCompleteCycles())
@@ -2604,9 +2598,11 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         self._storage = storage
         if self._storage is not None:
             self._storage = NetCDFStorageView(storage, modname=self.__class__.__name__)
-
-        _logger.info(f"creating probability matrix...")
-        self._probability_matrix = self._calculate_probability_matrix()
+   
+        # no point in doing this if there are only two molecules
+        if self._n_molecules != 2:
+            _logger.info(f"creating probability matrix...")
+            self._probability_matrix = self._calculate_probability_matrix()
 
 
     def propose(self,
@@ -2980,8 +2976,6 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         """
         # Compute contribution from the chemical proposal to the log probability of acceptance (Eq. 36 for hybrid; Eq. 53 for two-stage)
         # log [P(Mold | Mnew) / P(Mnew | Mold)]
-
-        # Retrieve the current molecule index
 
         # Propose a new molecule
         molecule_probabilities = self._probability_matrix[current_mol_id, :]

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -74,7 +74,7 @@ PROTEIN_BOND_EXPRESSION = DEFAULT_BOND_EXPRESSION
 import logging
 logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("proposal_generator")
-_logger.setLevel(logging.DEBUG)
+_logger.setLevel(logging.INFO)
 
 ################################################################################
 # UTILITIES

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -408,8 +408,6 @@ class AtomMapper(object):
         _logger.debug(f"\tthe max number of atom matches is: {max_num_atoms}; there are {len([m for m in top_matches if m.NumAtoms() == max_num_atoms])} matches herein")
         new_top_matches = [m for m in top_matches if m.NumAtoms() == max_num_atoms]
         new_to_old_atom_maps = [AtomMapper.hydrogen_mapping_exceptions(current_oemol, proposed_oemol, match, matching_criterion) for match in new_top_matches]
-        _logger.debug(f"\tthe hydrogen ")
-        #_logger.debug(f"\tnew to old atom maps with most atom hits: {new_to_old_atom_maps}")
 
         #now all else is equal; we will choose the map with the highest overlap of atom indices
         index_overlap_numbers = []
@@ -2669,7 +2667,7 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
         _logger.info(f"small molecule has {len_old_mol} atoms.")
 
         # Determine atom indices of the small molecule in the current topology
-        old_alchemical_atoms = range(old_mol_start_index, len_old_mol)
+        old_alchemical_atoms = range(old_mol_start_index, old_mol_start_index+len_old_mol)
         _logger.info(f"old alchemical atom indices: {old_alchemical_atoms}")
 
         # Select the next molecule SMILES given proposal probabilities

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -341,33 +341,26 @@ def createOEMolFromSDF(sdf_filename, index=0, add_hydrogens=True):
     mol_list = [oechem.OEMol(mol) for mol in ifs.GetOEMols()]
     # we'll always take the first for now
 
-    # check molecule unique names
-    renamed_mol_list = []
-    for mol_index, molecule in enumerate(mol_list):
-        # create unique atom names
-        if len([atom.GetName() for atom in molecule.GetAtoms()]) > len(set([atom.GetName() for atom in molecule.GetAtoms()])):
-            # the atom names are not unique
-            molecule_fixed = generate_unique_atom_names(molecule)
-        else:
-            molecule_fixed = molecule
+    # pick out molecule of interest
+    molecule = mol_list[index]
 
-        renamed_mol_list.append(molecule_fixed)
+    # Generate unique atom names
+    if len([atom.GetName() for atom in molecule.GetAtoms()]) > len(set([atom.GetName() for atom in molecule.GetAtoms()])):
+        molecule = generate_unique_atom_names(molecule)
 
     # Assign aromaticity and hydrogens.
-    for molecule in renamed_mol_list:
-        oechem.OEAssignAromaticFlags(molecule, oechem.OEAroModelOpenEye)
-        oechem.OEAssignHybridization(molecule)
-        if add_hydrogens:
-            oechem.OEAddExplicitHydrogens(molecule)
+    oechem.OEAssignAromaticFlags(molecule, oechem.OEAroModelOpenEye)
+    oechem.OEAssignHybridization(molecule)
+    if add_hydrogens:
         oechem.OEAddExplicitHydrogens(molecule)
-        oechem.OEPerceiveChiral(molecule)
+    oechem.OEAddExplicitHydrogens(molecule)
+    oechem.OEPerceiveChiral(molecule)
 
-        # perceive chirality
-        assert oechem.OE3DToInternalStereo(molecule), f"the stereochemistry perception from 3D coordinates failed"
-        assert not has_undefined_stereocenters(molecule), f"there is an atom with an undefined stereochemistry"
+    # perceive chirality
+    assert oechem.OE3DToInternalStereo(molecule), f"the stereochemistry perception from 3D coordinates failed"
+    assert not has_undefined_stereocenters(molecule), f"there is an atom with an undefined stereochemistry"
 
-    mol_to_return = renamed_mol_list[index]
-    return mol_to_return
+    return molecule
 
 
 def calculate_mol_similarity(molA, molB):


### PR DESCRIPTION
This PR

- [x] passes mapping criteria into `propose` function, rather than init statement of `SmallMoleculeSetProposalEngine `
- [x] turns off `validate_energy_bookkeeping` in the pipeline, so that passes for the JACS set, where sometimes entire rings are deleted**
- [x] removing bug where solvent phase was ignoring user defined nonbonded method
- [x] calling `augment_openmm_topology` for 'secondary' phases - i.e. if topology_proposal has already been called for a different phase
- [x] updating yaml loader line to get rid of the depreciated warning
- [x] replacing LangevinSplittingDynamicsMove with LangevinDynamicsMove***
- [x] running `compute_potential_components` and `validate_endstate_energies` on Reference, as it's more precise than CUDA, even though it's slower****
- [x] calling `_assign_ring_ids` irrespective of ring breaking or not* . If IntType isn't in the atom expression then this has no effect anyway
- [x] avoiding calling `SmallMoleculeSetProposalEngine._calculate_probability_matrix` if only two molecules are there
- [x] fixing small indexing bug


** I am opening Issue #656 to try understand what types of things count as ring breaking, and how we can juggle all different sorts of things simultaneously
*** This means that `constraint_tolerance=1e-06` has been taken out
**** I can just try run this on one of complex/solvent to get a speed up