### PR TITLE
Add library functions for bootstrapping

### DIFF
--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -127,7 +127,7 @@ def free_energies(
 
     details = {}
     for path in details_file_path:
-        with open(path, 'r') as f:
+        with open(path, "r") as f:
             new = json.load(f)
             details = {**details, **new}
 
@@ -239,8 +239,7 @@ def free_energies(
                 continue
 
         fig.suptitle(
-            f"{RUN}: {d['protein'].split('_')[0]} {d['start']}-{d['end']}",
-            fontsize=16,
+            f"{RUN}: {d['protein'].split('_')[0]} {d['start']}-{d['end']}", fontsize=16,
         )
         fig.subplots_adjust(top=0.9, wspace=0.15)
         axes[0].legend()
@@ -258,7 +257,6 @@ def free_energies(
     ligand_result = {0: 0.0}
     ligand_result_uncertainty = {0: 0.0}
 
-
     # TODO -- this assumes that everything is star-shaped, linked to ligand 0. If it's not, the values in ligand_result and ligand_result_uncertainty won't be correct.
     for d in details.values():
         if "complex_fes" in d and "solvent_fes" in d:
@@ -271,8 +269,8 @@ def free_energies(
             ligand_result[d["end"]] = DDG
             ligand_result_uncertainty[d["end"]] = DDG
 
-
     _plot_relative_distribution(livand_result.values())
+
     def _plot_relative_distribution(relative_fes, bins=100):
         """ Plots the distribution of relative free energies
 

--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -235,7 +235,7 @@ def free_energies(
             try:
                 _process_phase(i, phase)
             except ValueError as e:
-                logging.warn(f"Can't calculate {RUN} {phase}: {e}")
+                logging.warning(f"Can't calculate {RUN} {phase}: {e}")
                 continue
 
         fig.suptitle(
@@ -251,7 +251,7 @@ def free_energies(
         try:
             _process_run(RUN)
         except ValueError as e:
-            logging.warn(f"Can't calculate {RUN}: {e}")
+            logging.warning(f"Can't calculate {RUN}: {e}")
             continue
 
     ligand_result = {0: 0.0}

--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -264,7 +264,7 @@ def free_energies(
                 unit.kilocalories_per_mole
             )
             dDDG = (
-                (d["solvent_fes"][1] ** 0.5 + d["complex_fes"][1] ** 0.5) ** 2 * kT
+                (d["solvent_fes"][1] ** 2 + d["complex_fes"][1] ** 2) ** 0.5 * kT
             ).value_in_unit(unit.kilocalories_per_mole)
             ligand_result[d["end"]] = DDG
             ligand_result_uncertainty[d["end"]] = DDG
@@ -299,10 +299,10 @@ def free_energies(
                     ).value_in_unit(unit.kilocalories_per_mole)
                     dDDG = (
                         (
-                            d[f"complex_dfe_GEN{i}"] ** 0.5
-                            + d[f"solvent_dfe_GEN{i}"] ** 0.5
+                            d[f"complex_dfe_GEN{i}"] ** 2
+                            + d[f"solvent_dfe_GEN{i}"] ** 2
                         )
-                        ** 2
+                        ** 0.5
                         * kT
                     ).value_in_unit(unit.kilocalories_per_mole)
                     plt.errorbar(i, DDG, yerr=dDDG)

--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -269,7 +269,7 @@ def free_energies(
             ligand_result[d["end"]] = DDG
             ligand_result_uncertainty[d["end"]] = DDG
 
-    _plot_relative_distribution(livand_result.values())
+    _plot_relative_distribution(ligand_result.values())
 
     def _plot_relative_distribution(relative_fes, bins=100):
         """ Plots the distribution of relative free energies

--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -154,9 +154,13 @@ def free_energies(
         r_works = _strip_outliers(r_works)
 
         if len(f_works) < min_num_work_values:
-            raise ValueError(f"less than {min_num_work_values} forward work values")
+            raise ValueError(
+                f"less than {min_num_work_values} forward work values (got {len(f_works)})"
+            )
         if len(r_works) < min_num_work_values:
-            raise ValueError(f"less than {min_num_work_values} reverse work values")
+            raise ValueError(
+                f"less than {min_num_work_values} reverse work values (got {len(r_works)})"
+            )
 
         fe, err = bootstrap_uncorrelated(BAR, n_iters=n_bootstrap)(
             f_works.values, r_works.values

--- a/perses/analysis/resample.py
+++ b/perses/analysis/resample.py
@@ -92,7 +92,7 @@ def bootstrap(f, n_iters=100, seed=None):
     return inner
 
 
-def bootstrap_uncorrelated(f, n_iters=100):
+def bootstrap_uncorrelated(f, n_iters=100, seed=None):
     """
     Transforms a function that computes a sample statistic to a
     function that estimates the corresponding population statistic and
@@ -135,7 +135,7 @@ def bootstrap_uncorrelated(f, n_iters=100):
                 for sample_args in islice(
                     zip(
                         *[
-                            [x for (x,) in samples_with_replacement([array])]
+                            [x for (x,) in samples_with_replacement([array], seed=seed)]
                             for array in arrays
                         ]
                     ),

--- a/perses/analysis/resample.py
+++ b/perses/analysis/resample.py
@@ -135,7 +135,7 @@ def bootstrap_uncorrelated(f, n_iters=100, seed=None):
                 for sample_args in islice(
                     zip(
                         *[
-                            [x for (x,) in samples_with_replacement([array], seed=seed)]
+                            (x for (x,) in samples_with_replacement([array], seed=seed))
                             for array in arrays
                         ]
                     ),

--- a/perses/analysis/resample.py
+++ b/perses/analysis/resample.py
@@ -144,7 +144,7 @@ def bootstrap_correlated(f, n_iters=100, seed=None):
     -------
     callable
         Function with the same input signature as `f`, returning a
-        pair of scalars: bootstrap estimate, uncertainty
+        pair of scalars: (estimate, error)
 
     """
 
@@ -181,7 +181,7 @@ def bootstrap_uncorrelated(f, n_iters=100, seed=None):
     -------
     callable
         Function with the same input signature as `f`, returning a
-        pair of (bootstrap estimate, uncertainty)
+        pair of scalars: (estimate, error)
 
     """
 

--- a/perses/analysis/resample.py
+++ b/perses/analysis/resample.py
@@ -1,0 +1,149 @@
+import numpy as np
+from functools import wraps
+from itertools import islice
+
+
+def samples_with_replacement(arrays, seed=None):
+    """
+    Resample from a dataset with replacement.
+
+    Parameters
+    ----------
+    arrays : list of array
+        1-d arrays with consistent length
+
+    Returns
+    -------
+    iterator of tuple of array
+        Resampled arrays, each with same length as the input
+    """
+
+    random_state = (
+        np.random.mtrand._rand if seed is None else np.random.RandomState(seed)
+    )
+
+    n_samples = len(arrays[0])
+
+    for i, array in enumerate(arrays):
+        if array.ndim > 1:
+            raise ValueError(
+                f"Arguments must have dimension 1, but argument {i} has "
+                f"dimension {array.ndim}."
+            )
+        if len(array) != n_samples:
+            raise ValueError(
+                f"Arguments must have consistent lengths, but the lengths "
+                f"of arguments 0 and {i} are inconsistent: "
+                f"{n_samples}, {len(array)}."
+            )
+
+    while True:
+        indices = random_state.randint(0, n_samples, size=(n_samples,))
+        yield tuple(array[indices] for array in arrays)
+
+
+def bootstrap(f, n_iters=100, seed=None):
+    """
+    Transforms a function that computes a sample statistic to a
+    function that estimates the corresponding population statistic and
+    uncertainty estimate via bootstrap resampling.
+
+    In this version, the positional arguments to the function are
+    assumed to be equal-length arrays, with the ith index of the jth
+    array representing quantity j measured at observation i; the data
+    are assumed to be correlated across quantities at a fixed
+    observation, and uncorrelated across observations at a fixed
+    quantity.
+
+    Parameters
+    ----------
+    f : callable
+        Function of one or more arrays returning a scalar. The
+        positional arguments are assumed to be 1-d arrays to be
+        resampled at each iteration. Keyword arguments are passed
+        through but are not resampled.
+
+    n_iter : int
+        Number of bootstrap iterations
+
+    seed : int
+        Random seed
+
+    Returns
+    -------
+    callable
+        Function with the same input signature as `f`, returning a
+        pair of (bootstrap estimate, uncertainty)
+
+    """
+
+    @wraps(f)
+    def inner(*arrays, **kwargs):
+
+        samples = np.array(
+            [
+                f(*sample_args, **kwargs)
+                for sample_args in islice(
+                    samples_with_replacement(arrays, seed=seed), n_iters
+                )
+            ]
+        )
+        return samples.mean(), samples.std()
+
+    return inner
+
+
+def bootstrap_uncorrelated(f, n_iters=100):
+    """
+    Transforms a function that computes a sample statistic to a
+    function that estimates the corresponding population statistic and
+    uncertainty estimate via bootstrap resampling.
+
+    In this version, the positional arguments to the function are
+    arrays of arbitrary length (not necessarily consistent), with
+    the ith index of the jth array representing the ith observation
+    in the jth experiment; the data are assumed to be uncorrelated
+    across both observations and experiements.
+
+    Parameters
+    ----------
+    f : callable
+        Function of one or more arrays returning a scalar. The
+        positional arguments are assumed to be 1-d arrays to be
+        resampled at each iteration. Keyword arguments are passed
+        through but are not resampled.
+
+    n_iter : int
+        Number of bootstrap iterations
+
+    seed : int
+        Random seed
+
+    Returns
+    -------
+    callable
+        Function with the same input signature as `f`, returning a
+        pair of (bootstrap estimate, uncertainty)
+
+    """
+
+    @wraps(f)
+    def inner(*arrays, **kwargs):
+
+        samples = np.array(
+            [
+                f(*sample_args, **kwargs)
+                for sample_args in islice(
+                    zip(
+                        *[
+                            [x for (x,) in samples_with_replacement([array])]
+                            for array in arrays
+                        ]
+                    ),
+                    n_iters,
+                )
+            ]
+        )
+        return samples.mean(), samples.std()
+
+    return inner

--- a/perses/analysis/resample.py
+++ b/perses/analysis/resample.py
@@ -46,22 +46,21 @@ def bootstrap(f, n_iters=100, seed=None):
     """
     Transforms a function that computes a sample statistic to a
     function that estimates the corresponding population statistic and
-    uncertainty estimate via bootstrap resampling.
+    uncertainty via bootstrap.
 
     In this version, the positional arguments to the function are
     assumed to be equal-length arrays, with the ith index of the jth
     array representing quantity j measured at observation i; the data
-    are assumed to be correlated across quantities at a fixed
-    observation, and uncorrelated across observations at a fixed
-    quantity.
+    are assumed correlated across quantities at a fixed observation,
+    and uncorrelated across observations of a fixed quantity.
 
     Parameters
     ----------
     f : callable
         Function of one or more arrays returning a scalar. The
-        positional arguments are assumed to be 1-d arrays to be
-        resampled at each iteration. Keyword arguments are passed
-        through but are not resampled.
+        positional arguments are assumed to be 1-d arrays of
+        consistent length to be resampled at each iteration. Keyword
+        arguments are passed through but are not resampled.
 
     n_iter : int
         Number of bootstrap iterations
@@ -73,7 +72,7 @@ def bootstrap(f, n_iters=100, seed=None):
     -------
     callable
         Function with the same input signature as `f`, returning a
-        pair of (bootstrap estimate, uncertainty)
+        pair of scalars: bootstrap estimate, uncertainty
 
     """
 
@@ -97,13 +96,13 @@ def bootstrap_uncorrelated(f, n_iters=100):
     """
     Transforms a function that computes a sample statistic to a
     function that estimates the corresponding population statistic and
-    uncertainty estimate via bootstrap resampling.
+    uncertainty via bootstrap.
 
     In this version, the positional arguments to the function are
-    arrays of arbitrary length (not necessarily consistent), with
-    the ith index of the jth array representing the ith observation
-    in the jth experiment; the data are assumed to be uncorrelated
-    across both observations and experiements.
+    arrays of arbitrary length (not necessarily consistent), with the
+    ith index of the jth array representing the ith observation of the
+    jth independent experiment; the data are assumed to be
+    uncorrelated across both observations and experiements.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR pulls out some of the common bootstrapping code into a new submodule, `perses.anaylsis.resample`.

Also includes various fixes:

- Typo in standard error of sum formula: 0860cd5