### PR TITLE
Fix Fah generator to only generate yaml-specified directories

### DIFF
--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -287,7 +287,7 @@ def run_neq_fah_setup(ligand_file,
         if phase == 'complex':
             phase_dir = f"{setup_options['complex_projid']}/RUNS"
         if phase == 'vacuum':
-            phase_dir = 'VACUUM/RUNS'
+             phase_dir = f"{setup_options['vacuum_projid']}/RUNS"
         if phase == 'apo':
             phase_dir = f"{setup_options['apo_projid']}/RUNS"
         dir = os.path.join(os.getcwd(), phase_dir, trajectory_directory)
@@ -384,19 +384,22 @@ def run(yaml_filename=None):
     yaml_file.close()
 
     import os
-    # make master directories
-    if not os.path.exists(f"{setup_options['complex_projid']}"):
-        os.makedirs(f"{setup_options['complex_projid']}/RUNS/")
-    if not os.path.exists(f"{setup_options['solvent_projid']}"):
-        os.makedirs(f"{setup_options['solvent_projid']}/RUNS/")
-    if not os.path.exists(f"{setup_options['apo_projid']}"):
-        os.makedirs(f"{setup_options['apo_projid']}/RUNS/")
-    if not os.path.exists('VACUUM'):
-        os.makedirs('VACUUM/RUNS/')
-
-    # make run directories
-    os.makedirs(f"{setup_options['complex_projid']}/RUNS/{setup_options['trajectory_directory']}")
-    os.makedirs(f"{setup_options['solvent_projid']}/RUNS/{setup_options['trajectory_directory']}")
-    os.makedirs(f"VACUUM/RUNS/{setup_options['trajectory_directory']}")
+    # make master and run directories
+    if 'complex_projid' in setup_options:
+        if not os.path.exists(f"{setup_options['complex_projid']}"):
+            os.makedirs(f"{setup_options['complex_projid']}/RUNS/")
+            os.makedirs(f"{setup_options['complex_projid']}/RUNS/{setup_options['trajectory_directory']}")
+    if 'solvent_projid' in setup_options:
+        if not os.path.exists(f"{setup_options['solvent_projid']}"):
+            os.makedirs(f"{setup_options['solvent_projid']}/RUNS/")
+            os.makedirs(f"{setup_options['solvent_projid']}/RUNS/{setup_options['trajectory_directory']}")
+    if 'apo_projid' in setup_options:
+        if not os.path.exists(f"{setup_options['apo_projid']}"):
+            os.makedirs(f"{setup_options['apo_projid']}/RUNS/")
+            os.makedirs(f"{setup_options['apo_projid']}/RUNS/{setup_options['trajectory_directory']}")
+    if 'vacuum_projid' in setup_options:
+        if not os.path.exists(f"{setup_options['vacuum_projid']}"):
+            os.makedirs(f"{setup_options['vacuum_projid']}/RUNS/")
+            os.makedirs(f"{setup_options['vacuum_projid']}/RUNS/{setup_options['trajectory_directory']}")
 
     run_neq_fah_setup(**setup_options)

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -250,12 +250,8 @@ def run_neq_fah_setup(ligand_file,
         setup_options.update(setup_options['kwargs'])
     if protein_kwargs is not None: #update the setup options w.r.t. the protein kwargs
         setup_options.update(setup_options['protein_kwargs'])
-        if 'apo_box_dimensions' not in setup_options:
+        if 'apo_box_dimensions' not in list(setup_options.keys()):
             setup_options['apo_box_dimensions'] = setup_options['complex_box_dimensions']
-        if 'hbond_constraints' in setup_options:
-            if setup_options['hbond_constraints'] == False:
-                setup_options['forcefield_kwargs'] = {'removeCMMotion': False, 'ewaldErrorTolerance': 0.00025, 'hydrogenMass' : 4 * unit.amus}
-                del setup_options['hbond_constraints']
 
     #setups_allowed
     setups_allowed = ['small_molecule', 'protein']

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -287,7 +287,7 @@ def run_neq_fah_setup(ligand_file,
         if phase == 'complex':
             phase_dir = f"{setup_options['complex_projid']}/RUNS"
         if phase == 'vacuum':
-             phase_dir = f"{setup_options['vacuum_projid']}/RUNS"
+            phase_dir = f"{setup_options['vacuum_projid']}/RUNS"
         if phase == 'apo':
             phase_dir = f"{setup_options['apo_projid']}/RUNS"
         dir = os.path.join(os.getcwd(), phase_dir, trajectory_directory)

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -250,8 +250,12 @@ def run_neq_fah_setup(ligand_file,
         setup_options.update(setup_options['kwargs'])
     if protein_kwargs is not None: #update the setup options w.r.t. the protein kwargs
         setup_options.update(setup_options['protein_kwargs'])
-        if 'apo_box_dimensions' not in list(setup_options.keys()):
+        if 'apo_box_dimensions' not in setup_options:
             setup_options['apo_box_dimensions'] = setup_options['complex_box_dimensions']
+        if 'hbond_constraints' in setup_options:
+            if setup_options['hbond_constraints'] == False:
+                setup_options['forcefield_kwargs'] = {'removeCMMotion': False, 'ewaldErrorTolerance': 0.00025, 'hydrogenMass' : 4 * unit.amus}
+                del setup_options['hbond_constraints']
 
     #setups_allowed
     setups_allowed = ['small_molecule', 'protein']


### PR DESCRIPTION
- Only generate necessary directories (complex, solvent, apo, vacuum) based on yaml file
- ~Allow removal of HBond constraints~