### PR TITLE
Fixing CI run

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - "master"
   pull_request:
     branches:
       - "master"


### PR DESCRIPTION
remove redundancy in CI.yaml caused by merging


-push
....


was accidentally int the CI.yaml file twice, presumably due to a merge issue. This simply removes the duplicate