### PR TITLE
Use a list of oemols for PointMutationExecutor input instead of files

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -177,10 +177,9 @@ class PointMutationExecutor(object):
                         ligand_pdb.topology)
                     ligand_n_atoms = ligand_md_topology.n_atoms
 
-            elif isinstance(ligand_input, list): # list of oemol object(s)
-                ligand_mol = ligand_input[0] # assume only one molecule in the list
-                molecules.append(Molecule.from_openeye(ligand_mol, allow_undefined_stereo=False))
-                ligand_positions, ligand_topology = extractPositionsFromOEMol(ligand_mol),  forcefield_generators.generateTopologyFromOEMol(ligand_mol)
+            elif isinstance(ligand_input, oechem.OEMol): # oemol object
+                molecules.append(Molecule.from_openeye(ligand_input, allow_undefined_stereo=False))
+                ligand_positions, ligand_topology = extractPositionsFromOEMol(ligand_input),  forcefield_generators.generateTopologyFromOEMol(ligand_input)
                 ligand_md_topology = md.Topology.from_openmm(ligand_topology)
                 ligand_n_atoms = ligand_md_topology.n_atoms
 

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -163,7 +163,6 @@ class PointMutationExecutor(object):
             if isinstance(ligand_input, str):
                 if ligand_input.endswith('.sdf'): # small molecule
                         ligand_mol = createOEMolFromSDF(ligand_input, index=ligand_index)
-                        ligand_mol = generate_unique_atom_names(ligand_mol)
                         molecules.append(Molecule.from_openeye(ligand_mol, allow_undefined_stereo=False))
                         ligand_positions, ligand_topology = extractPositionsFromOEMol(ligand_mol),  forcefield_generators.generateTopologyFromOEMol(ligand_mol)
                         ligand_md_topology = md.Topology.from_openmm(ligand_topology)

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -117,7 +117,7 @@ class PointMutationExecutor(object):
             conduct_endstate_validation : bool, default True
                 whether to conduct an endstate validation of the hybrid topology factory
             ligand_input : str or list of oemol objects, default None
-                path to ligand of interest (i.e. small molecule or protein); .sdf or .pdb
+                path to ligand of interest: .pdb for protein and .sdf or oemol for small molecule
             ligand_index : int, default 0
                 which ligand to use
             water_model : str, default 'tip3p'

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -116,7 +116,7 @@ class PointMutationExecutor(object):
                 if phase == vacuum, then the complex will not be solvated with water; else, it will be solvated with tip3p
             conduct_endstate_validation : bool, default True
                 whether to conduct an endstate validation of the hybrid topology factory
-            ligand_input : str or list of oemol objects, default None
+            ligand_input : str or oemol, default None
                 path to ligand of interest: .pdb for protein and .sdf or oemol for small molecule
             ligand_index : int, default 0
                 which ligand to use


### PR DESCRIPTION
This PR adapts the input of `PointMutationExecutor` to allow for a list of oemol objects to be used instead. Both @schallerdavid and I were having difficulty parsing ligand `.sdf` [files](https://github.com/openkinome/study-ntrk-resistance/tree/perses_sims/notebooks/kinoml_modeling/data) containing a nitrogen that was perceived as needing to be tetrahedral at [this line](https://github.com/choderalab/perses/blob/master/perses/utils/openeye.py#L366) in `perses.utils.openeye`. This PR allows the user to bypass internal oemol preparation. 

Changed:
- `PointMutationExecutor` now takes inputs: `.sdf`, `.pdb`, `[oemol]`.
- `ligand_file` renamed to `ligand_input` to be more general.

An example script of how to prepare the `[oemol]` object is below, input names changed from my use case:

```python
from perses.app.relative_point_mutation_setup import PointMutationExecutor
from perses.utils.openeye import generate_unique_atom_names
import oechem
from simtk import unit

ifs = oechem.oemolistream()
ifs.open('./ligand.sdf')
mol_list = [oechem.OEMol(mol) for mol in ifs.GetOEMols()]
mol = mol_list[0]

if len([atom.GetName() for atom in mol.GetAtoms()]) > len(set([atom.GetName() for atom in mol.GetAtoms()])):
        mol = generate_unique_atom_names(mol)
oechem.OEAssignAromaticFlags(mol, oechem.OEAroModelOpenEye)
oechem.OEAssignHybridization(mol)
oechem.OEAddExplicitHydrogens(mol)
oechem.OEPerceiveChiral(mol)

mol_list = [mol]
protein_file = './protein.pdb'

x = PointMutationExecutor(
protein_file,
'1',
'510', # an example residue number
'VAL', # an example mutation
ligand_input=mol_list,
ionic_strength=0.15 * unit.molar,
small_molecule_forcefields='openff-1.2.0'
)
```