### PR TITLE
Setup miniconda v2 & use new CF OpenMM

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -72,7 +72,7 @@ jobs:
               conda install --quiet -c omnia-dev openmm;;
             conda-forge)
               echo "Using OpenMM conda-forge testing build."
-              conda install --quiet -c conda-forge/label/testing openmm;;
+              conda install --quiet -c conda-forge/label/test openmm;;
           esac
 
       - name: Install package

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,8 +40,8 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/goanpeca/setup-miniconda
-      - uses: goanpeca/setup-miniconda@v1
+      # More info on options: https://github.com/conda-incubator/setup-miniconda
+      - uses: conda-incubator/setup-miniconda@v2
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: devtools/conda-envs/test_env.yaml


### PR DESCRIPTION
Adressing two things:

* `add-path` and `set-env` commands are deprecated and will be disabled on November 16th. More information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* I merged the new conda forge packages for OpenMM so they use the `test` label (and not `testing`) following what CF is doing for `cudatoolkit`. This will allow us to test the latest builds!