### PR TITLE
Switch to pytest runner

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,8 +21,8 @@ jobs:
         cfg:
           - { os: ubuntu-latest, python-version: 3.7, openmm: latest }
           - { os: ubuntu-latest, python-version: 3.8, openmm: latest }
-          - { os: ubuntu-latest, python-version: 3.7, openmm: nightly }
-          - { os: ubuntu-latest, python-version: 3.8, openmm: nightly }
+          - { os: ubuntu-latest, python-version: 3.7, openmm: nightly, experimental: true }
+          - { os: ubuntu-latest, python-version: 3.8, openmm: nightly, experimental: true }
           - { os: ubuntu-latest, python-version: 3.7, openmm: conda-forge }
           - { os: ubuntu-latest, python-version: 3.8, openmm: conda-forge }
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,7 +91,7 @@ jobs:
           export OE_LICENSE="$HOME/oe_license.txt"
           export TRAVIS=true
           pushd .
-          nosetests perses --with-coverage --cover-package=perses --verbosity=3 --with-timer -a '!advanced' --cover-xml --cover-xml-file=./coverage.xml
+          pytest -v --cov-report xml --cov=perses --durations=0
           popd
 
       - name: Codecov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,7 +91,7 @@ jobs:
           export OE_LICENSE="$HOME/oe_license.txt"
           export TRAVIS=true
           pushd .
-          pytest -v --cov-report xml --cov=perses --durations=0 -a '!advanced'
+          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced"
           popd
 
       - name: Codecov

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -21,8 +21,8 @@ jobs:
         cfg:
           - { os: ubuntu-latest, python-version: 3.7, openmm: latest }
           - { os: ubuntu-latest, python-version: 3.8, openmm: latest }
-          - { os: ubuntu-latest, python-version: 3.7, openmm: nightly, experimental: true }
-          - { os: ubuntu-latest, python-version: 3.8, openmm: nightly, experimental: true }
+          - { os: ubuntu-latest, python-version: 3.7, openmm: nightly }
+          - { os: ubuntu-latest, python-version: 3.8, openmm: nightly }
           - { os: ubuntu-latest, python-version: 3.7, openmm: conda-forge }
           - { os: ubuntu-latest, python-version: 3.8, openmm: conda-forge }
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,7 +91,7 @@ jobs:
           export OE_LICENSE="$HOME/oe_license.txt"
           export TRAVIS=true
           pushd .
-          pytest -v --cov-report xml --cov=perses --durations=0
+          pytest -v --cov-report xml --cov=perses --durations=0 -a '!advanced'
           popd
 
       - name: Codecov

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -35,6 +35,7 @@ dependencies:
   - tqdm
   - pytest
   - pytest-cov
+  - pytest-attrib
   - coverage
   - openff-toolkit
   - sphinx

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -33,8 +33,8 @@ dependencies:
   - progressbar2
   - parmed # may need to sort out ambermini/ambertools/parmed dependencies
   - tqdm
-  - nose
-  - nose-timer
+  - pytest
+  - pytest-cov
   - coverage
   - openff-toolkit
   - sphinx

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -7,6 +7,7 @@ channels:
   - openeye
 dependencies:
   - python >=3.6
+  - pip
   - setuptools
   - fire
   - joblib
@@ -35,7 +36,6 @@ dependencies:
   - tqdm
   - pytest
   - pytest-cov
-  - pytest-attrib
   - coverage
   - openff-toolkit
   - sphinx
@@ -43,3 +43,5 @@ dependencies:
   - openmmforcefields >=0.9.0
   - dicttoxml
   - tinydb
+  - pip:
+    - pytest-attrib

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -1722,7 +1722,7 @@ class NonequilibriumSwitchingFEP(DaskClient):
 
     @staticmethod
     def multinomial_resample(cumulative_works, sampler_states, num_resamples, previous_labels):
-        """
+        r"""
         from a list of cumulative works and sampler states, resample the sampler states N times with replacement
         from a multinomial distribution conditioned on the weights w_i \propto e^{-cumulative_works_i}
 

--- a/perses/dispersed/utils.py
+++ b/perses/dispersed/utils.py
@@ -147,7 +147,7 @@ def minimize(thermodynamic_state,
     sampler_state.update_from_context(context)
 
 def multinomial_resample(total_works, num_resamples):
-    """
+    r"""
     from a numpy array of total works and particle_labels, resample the particle indices N times with replacement
     from a multinomial distribution conditioned on the weights w_i \propto e^{-cumulative_works_i}
     Parameters

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -1176,7 +1176,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return xyz, detJ
 
     def _bond_log_pmf(self, bond, beta, n_divisions):
-        """
+        r"""
         Calculate the log probability mass function (PMF) of drawing a bond.
 
         .. math ::
@@ -1242,7 +1242,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return r_i, log_p_i, bin_width
 
     def _bond_logp(self, r, bond, beta, n_divisions):
-        """
+        r"""
         Calculate the log-probability of a given bond at a given inverse temperature
 
         Propose dimensionless bond length r from distribution
@@ -1286,7 +1286,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return logp
 
     def _propose_bond(self, bond, beta, n_divisions):
-        """
+        r"""
         Propose dimensionless bond length r from distribution
 
         .. math ::
@@ -1330,7 +1330,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return r
 
     def _angle_log_pmf(self, angle, beta, n_divisions):
-        """
+        r"""
         Calculate the log probability mass function (PMF) of drawing a angle.
 
         .. math ::
@@ -1398,7 +1398,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return theta_i, log_p_i, bin_width
 
     def _angle_logp(self, theta, angle, beta, n_divisions):
-        """
+        r"""
         Calculate the log-probability of a given angle at a given inverse temperature
 
         Propose dimensionless bond length r from distribution
@@ -1442,7 +1442,7 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         return logp
 
     def _propose_angle(self, angle, beta, n_divisions):
-        """
+        r"""
         Propose dimensionless angle from distribution
 
         .. math ::

--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -134,7 +134,7 @@ class ExpandedEnsembleSampler(object):
 
     """
     def __init__(self, sampler, topology, state_key, proposal_engine, geometry_engine, log_weights=None, options=None, platform=None, envname=None, storage=None, ncmc_write_interval=1):
-        """
+        r"""
         Create an expanded ensemble sampler.
 
         p(x,k) \propto \exp[-u_k(x) + g_k]
@@ -830,7 +830,7 @@ class MultiTargetDesign(object):
 
     """
     def __init__(self, target_samplers, storage=None, verbose=False):
-        """
+        r"""
         Initialize a multi-objective design sampler with the specified target sampler powers.
 
         Parameters


### PR DESCRIPTION
As a first pass in improving our testing, we are going to switch to using [`pytest`](https://docs.pytest.org/en/stable/) to run tests. Because of the [compatibility between `pytest` and `nose`](https://docs.pytest.org/en/stable/nose.html) we shouldn't need to do anything to the old tests, but we should start writing new tests using `pytest` features.