### PR TITLE
Change default temp in protein mutation setup pipeline

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -17,7 +17,7 @@ from openff.toolkit.topology import Molecule
 from openmmforcefields.generators import SystemGenerator
 
 ENERGY_THRESHOLD = 1e-2
-temperature = 300 * unit.kelvin
+temperature = 298 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT
 ring_amino_acids = ['TYR', 'PHE', 'TRP', 'PRO', 'HIS']


### PR DESCRIPTION
Currently, the `temperature` is defaulted at 300 K, but it should be 298 K (as the default temperature for integrators in `openmmtools` is set to 298 K and 298 K is closer to 25 celsius). 