### PR TITLE
Feat/lazy load imports

### DIFF
--- a/perses/analysis/analysis.py
+++ b/perses/analysis/analysis.py
@@ -14,7 +14,6 @@ __author__ = 'John D. Chodera'
 ################################################################################
 
 import numpy as np
-from openeye import oeiupac, oechem
 import itertools
 import pymbar
 from perses import storage
@@ -85,6 +84,8 @@ class Analysis(object):
         state_transition_iupac : [str, str]
             The pair of molecules in IUPAC names
         """
+        from openeye import oeiupac, oechem
+
         state_transition_iupac = []
         for state in state_transition:
             mol = oechem.OEMol()

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from perses.utils.openeye import createOEMolFromSDF, extractPositionsFromOEMol, oechem
+from perses.utils.openeye import createOEMolFromSDF, extractPositionsFromOEMol
 from perses.annihilation.relative import HybridTopologyFactory, RepartitionedHybridTopologyFactory
 from perses.rjmc.topology_proposal import PointMutationEngine
 from perses.rjmc.geometry import FFAllAngleGeometryEngine
@@ -158,6 +158,7 @@ class PointMutationExecutor(object):
         TODO : allow argument for spectator ligands besides the 'ligand_file'
 
         """
+        from openeye import oechem
 
         # First thing to do is load the apo protein to mutate...
         protein_pdbfile = open(protein_filename, 'r')

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from perses.dispersed import feptasks
-from perses.utils.openeye import createOEMolFromSDF, createSystemFromSMILES, extractPositionsFromOEMol, generate_unique_atom_names, oechem
+from perses.utils.openeye import createOEMolFromSDF, createSystemFromSMILES, extractPositionsFromOEMol, generate_unique_atom_names
 from perses.utils.data import load_smi
 from perses.annihilation.lambda_protocol import RelativeAlchemicalState, LambdaProtocol
 from perses.rjmc.topology_proposal import TopologyProposal, SmallMoleculeSetProposalEngine
@@ -142,6 +142,8 @@ class RelativeFEPSetup(object):
             whether to extract the positions of ligand B and set the unique_new atom positions deterministically;
             if True, `complex` must be in `phases` and .sdf or .mol2 file of ligand must be provided
         """
+        from openeye import oechem
+
         self._pressure = pressure
         self._temperature = temperature
         self._barostat_period = 50

--- a/perses/bias/bias_engine.py
+++ b/perses/bias/bias_engine.py
@@ -2,10 +2,7 @@
 This is the base class for generating a biasing potential
 for expanded ensemble simulation
 """
-import openeye.oechem as oechem
-import openeye.oeomega as oeomega
 import openmoltools
-import openeye.oeiupac as oeiupac
 import simtk.openmm as openmm
 import simtk.openmm.app as app
 import simtk.unit as units
@@ -78,6 +75,9 @@ class MinimizedPotentialBias(BiasEngine):
         oemol_list : dict of smiles : oemol
             smile : oemols for the simulation
         """
+        import openeye.oechem as oechem
+        import openeye.oeomega as oeomega
+
         oemol_dict ={}
         omega = oeomega.OEOmega()
         omega.SetMaxConfs(1)
@@ -106,6 +106,8 @@ class MinimizedPotentialBias(BiasEngine):
         positions : np.array, Quantity nm
            array of atomic positions
         """
+        import openeye.oeiupac as oeiupac
+
         molecule_name = oeiupac.OECreateIUPACName(mol)
         openmoltools.openeye.enter_temp_directory()
         _ , tripos_mol2_filename = openmoltools.openeye.molecule_to_mol2(mol, tripos_mol2_filename=molecule_name + '.tripos.mol2', conformer=0, residue_name='MOL')

--- a/perses/data/constant-pH/imidazole/generate-protomers-from-smiles.py
+++ b/perses/data/constant-pH/imidazole/generate-protomers-from-smiles.py
@@ -10,7 +10,6 @@ import re
 import traceback
 import numpy as np
 
-from openeye import oechem
 from openmoltools import schrodinger
 from perses.utils.openeye import smiles_to_oemol
 
@@ -31,6 +30,7 @@ def read_molecules(filename):
         If no molecules are read, None is returned.
 
     """
+    from openeye import oechem
 
     ifs = oechem.oemolistream(filename)
     molecules = list()
@@ -47,6 +47,8 @@ def read_molecules(filename):
         return molecules
 
 def DumpSDData(mol):
+    from openeye import oechem
+
     print("SD data of", mol.GetTitle())
     #loop over SD data
     for dp in oechem.OEGetSDDataPairs(mol):
@@ -63,6 +65,8 @@ def retrieve_url(url, filename):
     outfile.close()
 
 def read_molecule(filename):
+    from openeye import oechem
+
     ifs = oechem.oemolistream()
     ifs.open(filename)
     molecule = oechem.OEMol()
@@ -81,6 +85,8 @@ def fix_mol2_resname(filename, residue_name):
     outfile.close()
 
 def write_mol2_preserving_atomnames(filename, molecules, residue_name):
+    from openeye import oechem
+
     ofs = oechem.oemolostream()
     ofs.open(filename)
     ofs.SetFlavor(oechem.OEFormat_MOL2, oechem.OEOFlavor_MOL2_GeneralFFFormat)
@@ -104,6 +110,8 @@ def enumerate_conformations(name, smiles=None, pdbname=None):
     pdbname : str
        Three-letter PDB code (e.g. 'DB8')
     """
+    from openeye import oechem
+
     # Create output subfolder
     output_basepath = os.path.join(output_dir, name)
     if not os.path.isdir(output_basepath):

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -8,7 +8,6 @@ import numpy as np
 import networkx as nx
 
 from perses.storage import NetCDFStorageView
-from openeye import oechem, oeomega
 
 ################################################################################
 # Initialize logging
@@ -2179,6 +2178,8 @@ class GeometrySystemGenerator(object):
 
         """
         from perses.rjmc import coordinate_numba
+        from openeye import oechem
+
         # Do nothing if there are no atoms to grow.
         if len(growth_indices) == 0:
             return torsion_force
@@ -2407,6 +2408,8 @@ class GeometrySystemGenerator(object):
         """
         from simtk import openmm
         import itertools
+        from openeye import oechem, oeomega
+
         if len(growth_indices)==0:
             return
         angle_force_constant = 400.0*unit.kilojoules_per_mole/unit.radians**2
@@ -2421,6 +2424,7 @@ class GeometrySystemGenerator(object):
             print(e)
 
         #get the omega geometry of the molecule:
+
         omega = oeomega.OEOmega()
         omega.SetMaxConfs(1)
         omega.SetStrictStereo(False) #TODO: fix stereochem

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -8,7 +8,6 @@ import copy
 import logging
 import itertools
 import os
-import openeye.oechem as oechem
 import numpy as np
 import networkx as nx
 import openmoltools.forcefield_generators as forcefield_generators
@@ -24,32 +23,36 @@ except ImportError:
 # CONSTANTS
 ################################################################################
 
-OESMILES_OPTIONS = oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_ISOMERIC | oechem.OESMILESFlag_Hydrogens
+try:
+    import openeye.oechem as oechem
+    OESMILES_OPTIONS = oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_ISOMERIC | oechem.OESMILESFlag_Hydrogens
 
-# TODO write a mapping-protocol class to handle these options
+    # TODO write a mapping-protocol class to handle these options
 
-# weak requirements for mapping atoms == more atoms mapped, more in core
-# atoms need to match in aromaticity. Same with bonds.
-# maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
-WEAK_ATOM_EXPRESSION = oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic #| oechem.OEExprOpts_IntType
-WEAK_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+    # weak requirements for mapping atoms == more atoms mapped, more in core
+    # atoms need to match in aromaticity. Same with bonds.
+    # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
+    WEAK_ATOM_EXPRESSION = oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic #| oechem.OEExprOpts_IntType
+    WEAK_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
 
-# default atom expression, requires same aromaticitiy and hybridization
-# bonds need to match in bond order
-# ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
-DEFAULT_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization #| oechem.OEExprOpts_IntType
-DEFAULT_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+    # default atom expression, requires same aromaticitiy and hybridization
+    # bonds need to match in bond order
+    # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
+    DEFAULT_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization #| oechem.OEExprOpts_IntType
+    DEFAULT_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
 
-# strong requires same hybridization AND the same atom type
-# bonds are same as default, require them to match in bond order
-STRONG_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms
-STRONG_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+    # strong requires same hybridization AND the same atom type
+    # bonds are same as default, require them to match in bond order
+    STRONG_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms
+    STRONG_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
 
-# specific to proteins
-# PROTEIN_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_EqAromatic
-# PROTEIN_BOND_EXPRESSION = oechem.OEExprOpts_Aromaticity
-PROTEIN_ATOM_EXPRESSION = DEFAULT_ATOM_EXPRESSION
-PROTEIN_BOND_EXPRESSION = DEFAULT_BOND_EXPRESSION
+    # specific to proteins
+    # PROTEIN_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_EqAromatic
+    # PROTEIN_BOND_EXPRESSION = oechem.OEExprOpts_Aromaticity
+    PROTEIN_ATOM_EXPRESSION = DEFAULT_ATOM_EXPRESSION
+    PROTEIN_BOND_EXPRESSION = DEFAULT_BOND_EXPRESSION
+except(ImportError):
+    print("Openeye is required to use this module")
 
 
 ################################################################################

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -20,42 +20,6 @@ except ImportError:
     from commands import getoutput  # If python 2
 
 ################################################################################
-# CONSTANTS
-################################################################################
-
-try:
-    import openeye.oechem as oechem
-    OESMILES_OPTIONS = oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_ISOMERIC | oechem.OESMILESFlag_Hydrogens
-
-    # TODO write a mapping-protocol class to handle these options
-
-    # weak requirements for mapping atoms == more atoms mapped, more in core
-    # atoms need to match in aromaticity. Same with bonds.
-    # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
-    WEAK_ATOM_EXPRESSION = oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic #| oechem.OEExprOpts_IntType
-    WEAK_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
-
-    # default atom expression, requires same aromaticitiy and hybridization
-    # bonds need to match in bond order
-    # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
-    DEFAULT_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization #| oechem.OEExprOpts_IntType
-    DEFAULT_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
-
-    # strong requires same hybridization AND the same atom type
-    # bonds are same as default, require them to match in bond order
-    STRONG_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms
-    STRONG_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
-
-    # specific to proteins
-    # PROTEIN_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_EqAromatic
-    # PROTEIN_BOND_EXPRESSION = oechem.OEExprOpts_Aromaticity
-    PROTEIN_ATOM_EXPRESSION = DEFAULT_ATOM_EXPRESSION
-    PROTEIN_BOND_EXPRESSION = DEFAULT_BOND_EXPRESSION
-except(ImportError):
-    print("Openeye is required to use this module")
-
-
-################################################################################
 # LOGGER
 ################################################################################
 
@@ -115,6 +79,7 @@ def _get_networkx_molecule(self):
     graph : NetworkX.Graph
         networkx representation of the residue
     """
+    import openeye.oechem as oechem
     graph = nx.Graph()
 
     oemol_atom_dict = {atom.GetIdx() : atom for atom in self.residue_oemol.GetAtoms()}
@@ -239,7 +204,14 @@ def deepcopy_topology(source_topology):
     append_topology(topology, source_topology)
     return topology
 
-def has_h_mapped(atommap, mola: oechem.OEMol, molb: oechem.OEMol):
+def has_h_mapped(atommap, mola, molb):
+    """
+    Parameters
+    mola : oechem.OEMol
+    molb : oechem.OEMol
+    """
+
+    import openeye.oechem as oechem
     for a_atom, b_atom in atommap.items():
         if mola.GetAtom(oechem.OEHasAtomIdx(a_atom)).GetAtomicNum() == 1 or molb.GetAtom(oechem.OEHasAtomIdx(b_atom)).GetAtomicNum() == 1:
             return True
@@ -410,6 +382,25 @@ class AtomMapper(object):
             dictionary of scores (keys) and maps (dict)
 
         """
+        import openeye.oechem as oechem
+
+        # weak requirements for mapping atoms == more atoms mapped, more in core
+        # atoms need to match in aromaticity. Same with bonds.
+        # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
+        WEAK_ATOM_EXPRESSION = oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic #| oechem.OEExprOpts_IntType
+        WEAK_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
+        # default atom expression, requires same aromaticitiy and hybridization
+        # bonds need to match in bond order
+        # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
+        DEFAULT_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization #| oechem.OEExprOpts_IntType
+        DEFAULT_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
+        # strong requires same hybridization AND the same atom type
+        # bonds are same as default, require them to match in bond order
+        STRONG_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms
+        STRONG_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
         allowed_map_strategy = ['core','geometry', 'matching_criterion', 'random', 'weighted-random', 'return-all']
         assert map_strategy in allowed_map_strategy, f'map_strategy cannot be {map_strategy}, it must be one of the allowed options {allowed_map_strategy}.'
         _logger.info(f'Using {map_strategy} to chose best atom map')
@@ -650,6 +641,25 @@ class AtomMapper(object):
             dictionary of scores (keys) and maps (dict)
 
         """
+        import openeye.oechem as oechem
+
+        # weak requirements for mapping atoms == more atoms mapped, more in core
+        # atoms need to match in aromaticity. Same with bonds.
+        # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
+        WEAK_ATOM_EXPRESSION = oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic #| oechem.OEExprOpts_IntType
+        WEAK_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
+        # default atom expression, requires same aromaticitiy and hybridization
+        # bonds need to match in bond order
+        # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
+        DEFAULT_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization #| oechem.OEExprOpts_IntType
+        DEFAULT_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
+        # strong requires same hybridization AND the same atom type
+        # bonds are same as default, require them to match in bond order
+        STRONG_ATOM_EXPRESSION = oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms
+        STRONG_BOND_EXPRESSION = oechem.OEExprOpts_DefaultBonds
+
         map_strength_dict = {'default': [DEFAULT_ATOM_EXPRESSION, DEFAULT_BOND_EXPRESSION],
                              'weak': [WEAK_ATOM_EXPRESSION, WEAK_BOND_EXPRESSION],
                              'strong': [STRONG_ATOM_EXPRESSION, STRONG_BOND_EXPRESSION]}
@@ -837,6 +847,7 @@ class AtomMapper(object):
         new_to_old_atom_map : dict
             map of new to old atom indices
         """
+        import openeye.oechem as oechem
         new_to_old_atom_map = {}
         pattern_to_target_map = AtomMapper._create_pattern_to_target_map(old_mol, new_mol, match, matching_criterion)
         for pattern_atom, target_atom in pattern_to_target_map.items():
@@ -868,6 +879,7 @@ class AtomMapper(object):
         ring_as_base_two : int
             binary integer corresponding to the atoms ring membership
         """
+        import openeye.oechem as oechem
         rings = ''
         for i in range(3, max_ring_size+1): #  smallest feasible ring size is 3
             rings += str(int(oechem.OEAtomIsInRingSize(atom, i)))
@@ -876,6 +888,7 @@ class AtomMapper(object):
 
     @staticmethod
     def _assign_bond_ring_id(bond, max_ring_size=10):
+        import openeye.oechem as oechem
         """ Returns the int type based on the ring occupancy
         of the bond
 
@@ -983,6 +996,7 @@ class AtomMapper(object):
                     if True, flip two
                     else: do nothing
         """
+        import openeye.oechem as oechem
         pattern_atoms = { atom.GetIdx() : atom for atom in current_mol.GetAtoms() }
         target_atoms = { atom.GetIdx() : atom for atom in proposed_mol.GetAtoms() }
         # _logger.warning(f"\t\t\told oemols: {pattern_atoms}")
@@ -1132,6 +1146,7 @@ class AtomMapper(object):
         """
         """
         """
+        import openeye.oechem as oechem
         score_list = {}
         for idx, match in enumerate(matches):
             counter_arom, counter_aliph = 0, 0
@@ -2257,6 +2272,7 @@ class PolymerProposalEngine(ProposalEngine):
         -------
         new_to_old_atom_map : dict, key : index of atom in new residue, value : index of atom in old residue
         """
+        import openeye.oechem as oechem
         # Load current and proposed residues as OEGraphMol objects
         oegraphmol_current = oechem.OEGraphMol(current_molecule)
         oegraphmol_proposed = oechem.OEGraphMol(proposed_molecule)
@@ -3209,6 +3225,9 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             OpenEye isomeric canonical smiles corresponding to the input
         """
         # TODO can this go in perses/utils/openeye?
+        import openeye.oechem as oechem
+        OESMILES_OPTIONS = oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_ISOMERIC | oechem.OESMILESFlag_Hydrogens
+
         mol = oechem.OEMol()
         oechem.OESmilesToMol(mol, smiles)
         oechem.OEAddExplicitHydrogens(mol)
@@ -3233,6 +3252,9 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
             molecule
         """
         # TODO can this go in perses/utils/openeye?
+        import openeye.oechem as oechem
+        OESMILES_OPTIONS = oechem.OESMILESFlag_DEFAULT | oechem.OESMILESFlag_ISOMERIC | oechem.OESMILESFlag_Hydrogens
+
         molecule_name = self._residue_name
         _logger.info(f"\tmolecule name specified from residue: {self._residue_name}.")
 

--- a/perses/tests/test_geometry_engine.py
+++ b/perses/tests/test_geometry_engine.py
@@ -1,7 +1,6 @@
 __author__ = 'Patrick B. Grinaway'
 
 import simtk.openmm as openmm
-import openeye.oechem as oechem
 import openmoltools
 import simtk.openmm.app as app
 import simtk.unit as unit
@@ -887,6 +886,8 @@ def align_molecules(mol1, mol2):
     """
     MCSS two OEmols. Return the mapping of new : old atoms
     """
+    import openeye.oechem as oechem
+
     mcs = oechem.OEMCSSearch(oechem.OEMCSType_Exhaustive)
     atomexpr = oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_AtomicNumber | oechem.OEExprOpts_HvyDegree
     bondexpr = oechem.OEExprOpts_Aromaticity
@@ -1914,6 +1915,7 @@ def test_logp_forward_check_for_vacuum_topology_proposal(current_mol_name = 'pro
     from perses.utils.smallmolecules import render_atom_mapping
     import tqdm
     from openff.toolkit.topology import Molecule
+    import openeye.oechem as oechem
 
     current_mol, unsolv_old_system, pos_old, top_old = createSystemFromIUPAC(current_mol_name,title=current_mol_name[0:4])
     proposed_mol = iupac_to_oemol(proposed_mol_name)

--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -407,12 +407,13 @@ def compare_energies(mol_name="naphthalene", ref_mol_name="benzene",atom_express
     """
     Make an atom map where the molecule at either lambda endpoint is identical, and check that the energies are also the same.
     """
+    from openmoltools.openeye import generate_conformers
     from openmmtools.constants import kB
     from perses.rjmc.topology_proposal import SmallMoleculeSetProposalEngine
     from perses.annihilation.relative import HybridTopologyFactory
     from perses.rjmc.geometry import FFAllAngleGeometryEngine
     import simtk.openmm as openmm
-    from perses.utils.openeye import iupac_to_oemol, extractPositionsFromOEMol, generate_conformers
+    from perses.utils.openeye import iupac_to_oemol, extractPositionsFromOEMol
     from perses.utils.openeye import generate_expression
     from openmmforcefields.generators import SystemGenerator
     from openmoltools.forcefield_generators import generateTopologyFromOEMol

--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -18,7 +18,6 @@ from perses.utils.smallmolecules import render_atom_mapping
 from perses.rjmc.topology_proposal import SmallMoleculeSetProposalEngine
 from perses.rjmc import topology_proposal
 from collections import defaultdict
-import openeye.oechem as oechem
 from openmmforcefields.generators import SystemGenerator
 from openff.toolkit.topology import Molecule
 from openmoltools.forcefield_generators import generateOEMolFromTopologyResidue
@@ -43,6 +42,8 @@ def test_small_molecule_proposals():
     """
     Make sure the small molecule proposal engine generates molecules
     """
+    import openeye.oechem as oechem
+
     list_of_smiles = ['CCCC','CCCCC','CCCCCC']
     list_of_mols = []
     for smi in list_of_smiles:
@@ -330,12 +331,12 @@ def generate_dipeptide_top_pos_sys(topology,
             else:
                 subtracted_valence_energy = geometry_engine.reverse_final_context_reduced_potential - geometry_engine.reverse_atoms_with_positions_reduced_potential
 
-            zero_state_error, one_state_error = validate_endstate_energies(forward_htf._topology_proposal, 
-                                                                           forward_htf, 
-                                                                           added_valence_energy, 
-                                                                           subtracted_valence_energy, 
-                                                                           beta = 1.0/(kB*temperature), 
-                                                                           ENERGY_THRESHOLD = ENERGY_THRESHOLD, 
+            zero_state_error, one_state_error = validate_endstate_energies(forward_htf._topology_proposal,
+                                                                           forward_htf,
+                                                                           added_valence_energy,
+                                                                           subtracted_valence_energy,
+                                                                           beta = 1.0/(kB*temperature),
+                                                                           ENERGY_THRESHOLD = ENERGY_THRESHOLD,
                                                                            platform = openmm.Platform.getPlatformByName('Reference'),
                                                                            repartitioned_endstate=endstate)
             print(f"zero state error : {zero_state_error}")

--- a/perses/tests/testsystems.py
+++ b/perses/tests/testsystems.py
@@ -32,7 +32,6 @@ import os
 import os.path
 import numpy as np
 from functools import partial
-from openeye import oechem
 from openmmtools import states
 from openmmtools.mcmc import MCMCSampler, LangevinSplittingDynamicsMove
 from perses.utils.smallmolecules import sanitizeSMILES, canonicalize_SMILES
@@ -1231,6 +1230,8 @@ class AblImatinibProtonationStateTestSystem(PersesTestSystem):
     """
     def __init__(self, **kwargs):
         super(AblImatinibProtonationStateTestSystem, self).__init__(**kwargs)
+        from openeye import oechem
+
         solvents = ['vacuum', 'explicit'] # TODO: Add 'implicit' once GBSA parameterization for small molecules is working
         components = ['inhibitor', 'complex'] # TODO: Add 'ATP:kinase' complex to enable resistance design
         #solvents = ['vacuum'] # DEBUG: Just try vacuum for now
@@ -1454,6 +1455,8 @@ class ImidazoleProtonationStateTestSystem(PersesTestSystem):
     """
     def __init__(self, **kwargs):
         super(ImidazoleProtonationStateTestSystem, self).__init__(**kwargs)
+        from openeye import oechem
+
         solvents = ['vacuum', 'explicit'] # TODO: Add 'implicit' once GBSA parameterization for small molecules is working
         components = ['imidazole']
         padding = 9.0*unit.angstrom
@@ -1871,6 +1874,8 @@ class T4LysozymeInhibitorsTestSystem(SmallMoleculeLibraryTestSystem):
     def __init__(self, **kwargs):
         # Read SMILES from CSV file of clinical kinase inhibitors.
         from pkg_resources import resource_filename
+        from openeye import oechem
+
         molecules = list()
         molecules += self.read_smiles(resource_filename('perses', 'data/L99A-binders.txt'))
         molecules += self.read_smiles(resource_filename('perses', 'data/L99A-non-binders.txt'))
@@ -2051,6 +2056,8 @@ class ValenceSmallMoleculeLibraryTestSystem(PersesTestSystem):
         list_of_canonicalized_smiles : list of str
             canonical isomeric smiles
         """
+        from openeye import oechem
+
         list_of_canonicalized_smiles = []
         ofs = oechem.oemolostream('current.mol2') # DEBUG
         for smiles in list_of_smiles:

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -15,7 +15,6 @@ import sys
 import numpy as np
 from perses.rjmc import geometry
 from perses.rjmc.topology_proposal import SmallMoleculeSetProposalEngine
-from openeye import oechem
 from openmmtools.constants import kB
 from openmmtools import states
 import contextlib

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -7,8 +7,6 @@ Utility functions for simulations using openeye toolkits
 __author__ = 'John D. Chodera'
 
 
-from openeye import oechem, oegraphsim
-from openmoltools.openeye import generate_conformers
 from simtk import unit
 from simtk.openmm import app
 import simtk.unit as unit
@@ -51,6 +49,8 @@ def system_generator_wrapper(oemols,
     """
     from openff.toolkit.topology import Molecule
     from openmmforcefields.generators import SystemGenerator
+    from openeye import oechem
+
     system_generator = SystemGenerator(forcefields = forcefield_files, barostat=barostat, forcefield_kwargs=forcefield_kwargs,nonperiodic_forcefield_kwargs=nonperiodic_forcefield_kwargs,
                                          small_molecule_forcefield = small_molecule_forcefield, molecules=[Molecule.from_openeye(oemol) for oemol in oemols], cache=None)
     return system_generator
@@ -72,7 +72,7 @@ def smiles_to_oemol(smiles, title='MOL', max_confs=1):
     molecule : openeye.oechem.OEMol
         OEMol object of the molecule
     """
-    from openeye import oeomega
+    from openeye import oeomega, oechem
 
     # Create molecule
     molecule = oechem.OEMol()
@@ -127,7 +127,7 @@ def iupac_to_oemol(iupac, title='MOL', max_confs=1):
     molecule : openeye.oechem.OEMol
         OEMol object of the molecule
     """
-    from openeye import oeiupac, oeomega
+    from openeye import oeiupac, oeomega, oechem
 
     # Create molecule
     molecule = oechem.OEMol()
@@ -243,6 +243,8 @@ def createSystemFromIUPAC(iupac_name, title="MOL", **system_generator_kwargs):
     topology : openmm.app.Topology object
         Topology
     """
+    from openeye import oechem
+    from openmoltools.openeye import generate_conformers
 
     # Create OEMol
     # TODO write our own of this function so we can be
@@ -339,6 +341,8 @@ def createOEMolFromSDF(sdf_filename, index=0, add_hydrogens=True, allow_undefine
     mol : openeye.oechem.OEMol object
         The loaded oemol object
     """
+    from openeye import oechem
+
     # TODO this needs a test
     ifs = oechem.oemolistream()
     ifs.open(sdf_filename)
@@ -376,6 +380,8 @@ def calculate_mol_similarity(molA, molB):
     :param molB: oemol object of molecule B
     :return: float, tanimoto score of the two molecules, between 0 and 1
     """
+    from openeye import oegraphsim
+
     fpA = oegraphsim.OEFingerPrint()
     fpB = oegraphsim.OEFingerPrint()
     oegraphsim.OEMakeFP(fpA, molA, oegraphsim.OEFPType_MACCS166)
@@ -385,6 +391,8 @@ def calculate_mol_similarity(molA, molB):
 
 
 def createSMILESfromOEMol(molecule):
+    from openeye import oechem
+
     smiles = oechem.OECreateSmiString(molecule,
                                       oechem.OESMILESFlag_DEFAULT |
                                       oechem.OESMILESFlag_Hydrogens)
@@ -405,6 +413,8 @@ def generate_unique_atom_names(molecule):
         oemol, either unchanged if atom names are
         already unique, or newly generated atom names
     """
+    from openeye import oechem
+
     atom_names = []
 
     atom_count = 0
@@ -451,6 +461,7 @@ def has_undefined_stereocenters(mol):
     bool : True if undefined Stereochemistry
            False if no stereochemistry or all stereocenter's are labelled
     """
+    from openeye import oechem
 
     assert oechem.OEPerceiveChiral(mol), f"chirality perception failed"
 
@@ -483,6 +494,8 @@ def generate_expression(list):
         Integer that openeye magically understands for matching expressions
 
     """
+    from openeye import oechem
+
     total_expr = 0
 
     for string in list:
@@ -522,6 +535,8 @@ def get_scaffold(molecule, adjustHcount=False):
     openeye.oechem.oemol
         scaffold oemol of the input mol. New oemol.
     """
+    from openeye import oechem
+
     def TraverseForRing(visited, atom):
         visited.add(atom.GetIdx())
 


### PR DESCRIPTION
Moving all of our `openeye` imports inside the methods/functions that need them. I didn't do this to the examples folder but everything else has been moved except for `perses/rjmc/topology_proposal.py` which uses `openeye` extensively for some global constants. I will have to think about the best way to edit that file, thoughts @jaimergp @jchodera for that one? 
