### PR TITLE
Update CI.yaml

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -63,10 +63,10 @@ jobs:
              #conda install --quiet -c conda-forge/label/openmm_rc openmm;;
             nightly)
               echo "Using OpenMM nightly dev build."
-              # need this until we cut a new openmoltools release/merge in PR
-              pip install git+https://github.com/choderalab/openmoltools.git@feat/fix_openmm_nightly
-              # need this until parmed updates to a new release
-              pip install git+https://github.com/mikemhenry/ParmEd.git@fix/openmm_namespace_change_1
+              # need this until we cut a new openmoltools release
+              pip install git+https://github.com/choderalab/openmoltools.git
+              # need to install from master until parmed updates to a new release
+              pip install git+https://github.com/ParmEd/ParmEd.git
               conda install --quiet -c omnia-dev openmm;;
           esac
 


### PR DESCRIPTION
Now that we merged in the openmoltools pr 
https://github.com/choderalab/openmoltools/pull/304
and parmed merged in my pr to fix the namespace issue
https://github.com/ParmEd/ParmEd/pull/1176

We can install from master instead of my forks. Once a new release gets cut we can just install from conda.