### PR TITLE
Fix #811: Restore default timesteps to 4 fs, constrained bonds to hydrogen

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy >=1.14
     - scipy
     - pymbar
-    - openmm >=7.4.2
+    - openmm >=7.5.0 # constraint slowdown has fixed https://github.com/openmm/openmm/pull/2818
     - parmed
     - openmoltools >=0.8.4
     - openmmtools

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -134,7 +134,7 @@ def relax_structure(temperature,
                     nequil=1000,
                     n_steps_per_iteration=250,
                     platform_name='OpenCL',
-                    timestep=2.*unit.femtosecond,
+                    timestep=4.*unit.femtosecond,
                     collision_rate=90./unit.picosecond,
                     **kwargs):
     """
@@ -151,7 +151,7 @@ def relax_structure(temperature,
             numper of steps per nequil
         platform name : str default='OpenCL'
             platform to run openmm on. OpenCL is best as this is what is used on FAH
-        timestep : simtk.unit.Quantity, default = 2*unit.femtosecond
+        timestep : simtk.unit.Quantity, default = 4*unit.femtosecond
             timestep for equilibration NOT for production
         collision_rate : simtk.unit.Quantity, default=90./unit.picosecond
 
@@ -197,7 +197,7 @@ def run_neq_fah_setup(ligand_file,
                       trajectory_directory,
                       complex_box_dimensions=(9.8, 9.8, 9.8),
                       solvent_box_dimensions=(3.5, 3.5, 3.5),
-                      timestep=4.0,
+                      timestep=4.0, # femtoseconds (implicit)
                       eq_splitting='V R O R V',
                       neq_splitting='V R H O R V',
                       measure_shadow_work=False,
@@ -234,7 +234,7 @@ def run_neq_fah_setup(ligand_file,
                       setup='small_molecule',
                       protein_kwargs=None,
                       ionic_strength=0.15*unit.molar,
-                      remove_constraints='not water',
+                      remove_constraints=False,
                       rmsd_restraint=True,
                       **kwargs):
     """
@@ -486,7 +486,7 @@ def run(yaml_filename=None):
         if not os.path.exists(f"{setup_options['apo_projid']}"):
             #os.makedirs(f"{setup_options['apo_projid']}/RUNS/")
             dst = f"{setup_options['apo_projid']}/RUNS/{setup_options['trajectory_directory']}"
-            os.makedirs(dst)        
+            os.makedirs(dst)
             copyfile(yaml_filename, dst)
     if 'vacuum_projid' in setup_options:
         if not os.path.exists(f"{setup_options['vacuum_projid']}"):

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -1011,7 +1011,7 @@ class NonequilibriumSwitchingFEP(DaskClient):
                  eq_splitting_string="V R O R V",
                  neq_splitting_string = "V R O R V",
                  measure_shadow_work=False,
-                 timestep=1.0*unit.femtoseconds,
+                 timestep=4.0*unit.femtoseconds,
                  ncmc_save_interval = None,
                  write_ncmc_configuration = False,
                  relative_transform = True):


### PR DESCRIPTION
Fixes #811: Restores default timesteps to 4 fs, constrained bonds to hydrogen

Note that the pathological constraint issue was fixed in openMM 7.5.0