### PR TITLE
Write out YAML file after parsing

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -299,6 +299,10 @@ def getSetupOptions(filename):
         _logger.info(f"\t'softcore_v2' not specified: default to 'False'")
 
     _logger.info(f"\tCreating '{trajectory_directory}'...")
+
+    if not 'rmsd_restraint' in setup_options:
+        setup_options['rmsd_restraint'] = False
+
     os.makedirs(trajectory_directory, exist_ok=True)
 
 
@@ -327,8 +331,6 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
     #   such as deferring to defaults for modules we call unless the user
     #   chooses to override them.
 
-    if not 'rmsd_restraint' in setup_options:
-        setup_options['rmsd_restraint'] = False
 
     if 'use_given_geometries' not in list(setup_options.keys()):
         use_given_geometries = False
@@ -680,7 +682,10 @@ def run(yaml_filename=None):
            _logger.critical(f"You must specify the setup yaml file as an argument to the script.")
 
     _logger.info(f"Getting setup options from {yaml_filename}")
-    setup_options = getSetupOptions(yaml_filename)
+    from types import MappingProxyType
+
+    setup_options_temp = getSetupOptions(yaml_filename)
+    setup_options = MappingProxyType(setup_options_temp)
 
     # The name of the reporter file includes the phase name, so we need to check each
     # one

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -5,6 +5,7 @@ import os
 import sys
 import simtk.unit as unit
 import logging
+from pathlib import Path
 
 from perses.samplers.multistate import HybridSAMSSampler, HybridRepexSampler
 from perses.annihilation.relative import HybridTopologyFactory
@@ -682,10 +683,17 @@ def run(yaml_filename=None):
            _logger.critical(f"You must specify the setup yaml file as an argument to the script.")
 
     _logger.info(f"Getting setup options from {yaml_filename}")
-    from types import MappingProxyType
 
-    setup_options_temp = getSetupOptions(yaml_filename)
-    setup_options = MappingProxyType(setup_options_temp)
+    setup_options = getSetupOptions(yaml_filename)
+
+    # We want to make sure that if the file is in a directory, we put the parsed file in
+    # the same directory
+    yaml_path = Path(yaml_filename)
+    yaml_name = yaml_path.name
+    time = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
+    yaml_parse_name = f"parsed-{time}-{yaml_name}"
+    with open(Path.joinpath(yaml_path.parents[0], yaml_parse_name), "w") as outfile:
+            yaml.dump(setup_options, outfile)
 
     # The name of the reporter file includes the phase name, so we need to check each
     # one

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -106,6 +106,9 @@ def getSetupOptions(filename):
 
     if 'complex_box_dimensions' not in setup_options:
         setup_options['complex_box_dimensions'] = None
+    # If complex_box_dimensions is None, nothing to do
+    elif setup_options['complex_box_dimensions'] is None:
+        pass
     else:
         setup_options['complex_box_dimensions'] = tuple([float(x) for x in setup_options['complex_box_dimensions']])
 


### PR DESCRIPTION
## Description

Write out YAML file after parsing.

## Motivation and context

In order to improve reproducibility and quickly see which options were used in the simulation, it would be nice to be able to inspect the YAML that has all the options set as parsed.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #817 

## How has this been tested?

Tested on GHA and locally manually.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Write out YAML file after all options are parsed and set. Saved as YAML original file name + date + time. 
```
