### PR TITLE
Store new and old positions and maps

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2100,6 +2100,9 @@ class HybridTopologyFactory(object):
             The positions of the old system
         """
         n_atoms_old = self._topology_proposal.n_atoms_old
+        # making sure hybrid positions are simtk.unit.Quantity objects
+        if not isinstance(hybrid_positions, unit.Quantity):
+            hybrid_positions = unit.Quantity(hybrid_positions, unit=unit.nanometer)
         old_positions = unit.Quantity(np.zeros([n_atoms_old, 3]), unit=unit.nanometer)
         for idx in range(n_atoms_old):
             old_positions[idx, :] = hybrid_positions[idx, :]
@@ -2120,6 +2123,9 @@ class HybridTopologyFactory(object):
             The positions of the new system
         """
         n_atoms_new = self._topology_proposal.n_atoms_new
+        # making sure hybrid positions are simtk.unit.Quantity objects
+        if not isinstance(hybrid_positions, unit.Quantity):
+            hybrid_positions = unit.Quantity(hybrid_positions, unit=unit.nanometer)
         new_positions = unit.Quantity(np.zeros([n_atoms_new, 3]), unit=unit.nanometer)
         for idx in range(n_atoms_new):
             new_positions[idx, :] = hybrid_positions[self._new_to_hybrid_map[idx], :]

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2091,7 +2091,7 @@ class HybridTopologyFactory(object):
 
         Parameters
         ----------
-        hybrid_positions : [n, 3] np.ndarray with unit
+        hybrid_positions : [n, 3] np.ndarray or simtk.unit.Quantity
             The positions of the hybrid system
 
         Returns
@@ -2114,7 +2114,7 @@ class HybridTopologyFactory(object):
 
         Parameters
         ----------
-        hybrid_positions : [n, 3] np.ndarray with unit
+        hybrid_positions : [n, 3] np.ndarray or simtk.unit.Quantity
             The positions of the hybrid system
 
         Returns

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -135,7 +135,7 @@ def relax_structure(temperature,
                     positions,
                     nequil=1000,
                     n_steps_per_iteration=250,
-                    platform_name='CPU',
+                    platform_name='OpenCL',
                     timestep=4.*unit.femtosecond,
                     collision_rate=90./unit.picosecond,
                     **kwargs):
@@ -416,12 +416,12 @@ def run_neq_fah_setup(ligand_file,
         pos = np.asarray(pos)
 
         import mdtraj as md
-        # Save old trajectory
+        # Store initial configuration/topology for old system sliced form hybrid system as PDB file
         old_traj = md.Trajectory(htfs[phase].old_positions(pos),
                                  md.Topology.from_openmm(htfs[phase]._topology_proposal.old_topology))
         old_traj.remove_solvent(exclude=['CL', 'NA'], inplace=True)
         old_traj.save(f'{dir}/old_{phase}.pdb')
-        # Save new trajectory
+        # Store initial configuration/topology for new system sliced form hybrid system as PDB file
         new_traj = md.Trajectory(htfs[phase].new_positions(pos),
                                  md.Topology.from_openmm(htfs[phase]._topology_proposal.new_topology))
         new_traj.remove_solvent(exclude=['CL', 'NA'], inplace=True)

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -409,6 +409,7 @@ def run_neq_fah_setup(ligand_file,
         else:
             passed = True
 
+        # TODO: state variable can indeed be undefined
         pos = state.getPositions(asNumpy=True)
         pos = np.asarray(pos)
 


### PR DESCRIPTION
## Description
This allow the serialization of new and old positions in pdb files as well as atom mappings in numpy object file, when creating hybrid topologies. 
<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #752 
## How has this been tested?
Tested using [minimal-neq-sprint.tar.gz](https://github.com/choderalab/perses/files/6948343/minimal-neq-sprint.tar.gz) by running `python 05-prepare-single-transformation.py 0`

<!--- Please describe in detail how you tested your changes. -->

## Change log
Addresses (issue #752 ) by storing positions and maps for new and old molecules when creating a hybrid topology.
<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
