### PR TITLE
CLI - Making sure input ligand file exists

### DIFF
--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -202,6 +202,9 @@ class RelativeFEPSetup(object):
         self._new_ligand_index = new_ligand_index
         _logger.info(f"Handling files for ligands and indices...")
         if type(self._ligand_input) is not list: # the ligand has been provided as a single file
+            # Make sure the input file exists
+            if not os.path.isfile(self._ligand_input):
+                raise FileNotFoundError(f"Input file at {self._ligand_input} does not exist.")
             if self._ligand_input[-3:] == 'smi': #
                 _logger.info(f"Detected .smi format.  Proceeding...")
                 _logger.info('  Note that SMILES does not contain geometry information for use in mapping')


### PR DESCRIPTION
## Description

This change makes sure input ligand file exists when running simulations with the CLI. Avoiding freezing.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #836 

## How has this been tested?

Tested manually so far.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Avoid freeze if ligand file is not found or does not exist when using CLI.
```
