### PR TITLE
use a local context cache instead of a global one

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -77,7 +77,9 @@ class PointMutationExecutor(object):
                                                                                   n_restart_attempts=20,
                                                                                   splitting="V R R R O R R R V",
                                                                                   constraint_tolerance=1e-06),
-                                                                                  hybrid_factory=htf, online_analysis_interval=10)
+                                                                                  hybrid_factory=htf,
+                                                                                  online_analysis_interval=10,
+                                                                                  context_cache=cache.ContextCache(capacity=None, time_to_live=None))
             hss.setup(n_states=n_states, temperature=300*unit.kelvin, storage_file=reporter, lambda_protocol=lambda_protocol, endstates=False)
             hss.extend(n_cycles)
 
@@ -361,7 +363,7 @@ class PointMutationExecutor(object):
         '''
         Get the charge, sigma, and epsilon for the positive and negative ions. Also get the charge of the water atoms. Set
         these parameters as class variables.
-          
+
         Parameters
         ----------
         system : simtk.openmm.System
@@ -374,9 +376,9 @@ class PointMutationExecutor(object):
             the residue name of each negative ion
         water_name : str, "HOH"
             the residue name of each water
-        
+
         '''
-    
+
         # Get the indices
         pos_index = None
         neg_index = None
@@ -395,8 +397,8 @@ class PointMutationExecutor(object):
         assert pos_index is not None, f"Error occurred when trying to turn a water into an ion: No positive ions with residue name {positive_ion_name} found"
         assert neg_index is not None, f"Error occurred when trying to turn a water into an ion: No negative ions with residue name {negative_ion_name} found"
         assert O_index is not None, f"Error occurred when trying to turn a water into an ion: No O atoms with residue name {water_name} and atom name O found"
-        assert H_index is not None, f"Error occurred when trying to turn a water into an ion: No water atoms with residue name {water_name} and atom name H1 found" 
-    
+        assert H_index is not None, f"Error occurred when trying to turn a water into an ion: No water atoms with residue name {water_name} and atom name H1 found"
+
         # Get parameters from nonbonded force
         force_dict = {i.__class__.__name__: i for i in system.getForces()}
         if 'NonbondedForce' in [i for i in force_dict.keys()]:
@@ -405,7 +407,7 @@ class PointMutationExecutor(object):
             neg_charge, neg_sigma, neg_epsilon = nbf.getParticleParameters(neg_index)
             O_charge, _, _ = nbf.getParticleParameters(O_index)
             H_charge, _, _ = nbf.getParticleParameters(H_index)
-    
+
         self._pos_charge = pos_charge
         self._pos_sigma = pos_sigma
         self._pos_epsilon = pos_epsilon

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -640,7 +640,8 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                                                                                         collision_rate=1.0 / unit.picosecond,
                                                                                         n_steps=n_steps_per_move_application,
                                                                                         reassign_velocities=False,
-                                                                                        n_restart_attempts=20,constraint_tolerance=1e-06),
+                                                                                        n_restart_attempts=20,constraint_tolerance=1e-06,
+                                                                                        context_cache=cache.ContextCache(capacity=None, time_to_live=None)),
                                                    hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                                                    online_analysis_minimum_iterations=10,flatness_criteria=setup_options['flatness-criteria'],
                                                    gamma0=setup_options['gamma0'])
@@ -651,7 +652,8 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                                                                                          n_steps=n_steps_per_move_application,
                                                                                          reassign_velocities=False,
                                                                                          n_restart_attempts=20,constraint_tolerance=1e-06),
-                                                                                         hybrid_factory=htf[phase],online_analysis_interval=setup_options['offline-freq'])
+                                                                                         hybrid_factory=htf[phase],online_analysis_interval=setup_options['offline-freq'],
+                                                                                         context_cache = cache.ContextCache(capacity=None, time_to_live=None))
                     hss[phase].setup(n_states=n_states, temperature=temperature,storage_file=reporter,lambda_protocol=lambda_protocol,endstates=endstates)
             else:
                 _logger.info(f"omitting sampler construction")

--- a/perses/dispersed/feptasks.py
+++ b/perses/dispersed/feptasks.py
@@ -4,6 +4,7 @@ import os
 import copy
 
 import openmmtools.mcmc as mcmc
+from openmmtools import cache
 import openmmtools.integrators as integrators
 import openmmtools.states as states
 import numpy as np
@@ -884,7 +885,8 @@ def run_equilibrium(task):
     n_atoms = subset_topology.n_atoms
 
     #construct the MCMove:
-    mc_move = mcmc.LangevinSplittingDynamicsMove(n_steps=inputs['nsteps_equil'], splitting=inputs['splitting'], timestep = inputs['timestep'])
+    mc_move = mcmc.LangevinSplittingDynamicsMove(n_steps=inputs['nsteps_equil'],
+            splitting=inputs['splitting'], timestep = inputs['timestep'], context_cache=cache.ContextCache(capacity=None, time_to_live=None))
     mc_move.n_restart_attempts = 10
 
     #create a numpy array for the trajectory

--- a/perses/dispersed/utils.py
+++ b/perses/dispersed/utils.py
@@ -2,6 +2,7 @@ import simtk.openmm as openmm
 import os
 import copy
 
+from openmmtools import cache
 import openmmtools.mcmc as mcmc
 import openmmtools.integrators as integrators
 import openmmtools.states as states
@@ -307,7 +308,8 @@ def run_equilibrium(task):
     n_atoms = subset_topology.n_atoms
 
     #construct the MCMove:
-    mc_move = mcmc.LangevinSplittingDynamicsMove(n_steps=inputs['nsteps_equil'], splitting=inputs['splitting'], timestep = inputs['timestep'])
+    mc_move = mcmc.LangevinSplittingDynamicsMove(n_steps=inputs['nsteps_equil'],
+            splitting=inputs['splitting'], timestep = inputs['timestep'], context_cache = cache.ContextCache(capacity=None, time_to_live=None))
     mc_move.n_restart_attempts = 10
 
     #create a numpy array for the trajectory


### PR DESCRIPTION
## Description

Instead of using the global context cache (which is the default) create a instance of the context cache and use that for all the mcmc move types. I also updated an example code snippet as well.

## Motivation and context

See this issue https://github.com/choderalab/perses/issues/613#issuecomment-899746348


## How has this been tested?

Tested on CI, issue linked above also shows that this fix works for large systems.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Use an instance of ContextCache instead of the default global instance.
```
