### PR TITLE
Use mamba instead of conda

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -46,11 +46,12 @@ jobs:
           python-version: ${{ matrix.python-version }}
           mamba-version: "*"
           environment-file: devtools/conda-envs/test_env.yaml
-          channels: conda-forge,defaults,omnia-dev,openeye
+          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,defaults,omnia-dev,openeye
           activate-environment: test
           auto-update-conda: true
           auto-activate-base: false
           show-channel-urls: true
+          channel-priority: true
 
       - name: Refine test environment
         shell: bash -l {0}

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -1,5 +1,6 @@
 name: test
 channels:
+  - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
   - defaults
   - omnia-dev


### PR DESCRIPTION
## Description

`mamba` tends to be faster than `conda` this PR changes our CI to use `mamba`

## Motivation and context

I'm working on using a selt-hosted runner on AWS, to save $ we need our CI to take less time. Instead of adding a GPU runner + switching to using `mamba`, I wanted to split the change into two PRs.



## How has this been tested?

Testing with CI right now :)

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Switch to mamba instead of conda
```
