### PR TITLE
Fix endstate validation handling in PointMutationExecutor

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -330,9 +330,9 @@ class PointMutationExecutor(object):
             else:
                 subtracted_valence_energy = geometry_engine.reverse_final_context_reduced_potential - geometry_engine.reverse_atoms_with_positions_reduced_potential
 
-
-            if conduct_endstate_validation and repartitioned_endstate is None:
-                zero_state_error, one_state_error = validate_endstate_energies(forward_htf._topology_proposal, forward_htf, added_valence_energy, subtracted_valence_energy, beta=beta, ENERGY_THRESHOLD=ENERGY_THRESHOLD)
+            if conduct_endstate_validation and generate_unmodified_hybrid_topology_factory:
+                htf = self.get_complex_htf() if is_complex else self.get_apo_htf()
+                zero_state_error, one_state_error = validate_endstate_energies(htf._topology_proposal, htf, added_valence_energy, subtracted_valence_energy, beta=beta, ENERGY_THRESHOLD=ENERGY_THRESHOLD)
                 if zero_state_error > ENERGY_THRESHOLD:
                     _logger.warning(f"Reduced potential difference of the nonalchemical and alchemical Lambda = 0 state is above the threshold ({ENERGY_THRESHOLD}): {zero_state_error}")
                 if one_state_error > ENERGY_THRESHOLD:

--- a/perses/tests/test_relative_point_mutation_setup.py
+++ b/perses/tests/test_relative_point_mutation_setup.py
@@ -1,14 +1,36 @@
 def test_PointMutationExecutor():
     from pkg_resources import resource_filename
-    from perses.app.relative_point_mutation_setup import PointMutationExecutor
     from simtk import unit
-    pdb_filename = resource_filename('perses', 'data/ala_vacuum.pdb')
-    solvent_delivery = PointMutationExecutor(pdb_filename,
-                            '1',
-                            '2',
-                            'ASP',
-                            ionic_strength=0.15*unit.molar,
-                            flatten_torsions=True,
-                            flatten_exceptions=True,
-                            conduct_endstate_validation=False
-                           )
+
+    from perses.app.relative_point_mutation_setup import PointMutationExecutor
+
+    pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
+    PointMutationExecutor(
+        pdb_filename,
+        "1",
+        "2",
+        "ASP",
+        ionic_strength=0.15 * unit.molar,
+        flatten_torsions=True,
+        flatten_exceptions=True,
+        conduct_endstate_validation=False,
+    )
+
+
+def test_PointMutationExecutor_endstate_validation():
+    from pkg_resources import resource_filename
+    from simtk import unit
+
+    from perses.app.relative_point_mutation_setup import PointMutationExecutor
+
+    pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
+    PointMutationExecutor(
+        pdb_filename,
+        "1",
+        "2",
+        "ASP",
+        ionic_strength=0.15 * unit.molar,
+        flatten_torsions=False,
+        flatten_exceptions=False,
+        conduct_endstate_validation=True,
+    )


### PR DESCRIPTION
## Description

The default behavior of `PointMutationExecutor` in Perses 0.9.2 leads to a `NameError` since `forward_htf` is not defined. This PR aims to fix the endstate validation handling.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
The defaults in `PointMutationExecutor` lead to a `NameError`.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #865 

## How has this been tested?

I tested the changes with an ABL1:dasatinib system ([protein](https://github.com/openkinome/study-abl-resistance/blob/update_modeling/data/tki_complexes/kinoml_OEKLIFSKinaseHybridDockingFeaturizer_ABL1_2gqg_chainA_altlocA_dasatinib_protein.pdb), [ligand](https://github.com/openkinome/study-abl-resistance/blob/update_modeling/data/tki_complexes/kinoml_OEKLIFSKinaseHybridDockingFeaturizer_ABL1_2gqg_chainA_altlocA_dasatinib_ligand.sdf)):

```
solvent_delivery = PointMutationExecutor(
    protein_path, 
    '1', # First and only protein chain 
    str(resid), 
    mutate_to,
    ligand_input=ligand_path,
    ionic_strength=0.15*unit.molar,
)
```

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Adapt endstate validation handling in PointMutationExecuter to be only done for the vanilla HybridTopologyFactory. 
```
