### PR TITLE
Remove hacks now that upstream has updated packages

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -63,10 +63,6 @@ jobs:
              #conda install --quiet -c conda-forge/label/openmm_rc openmm;;
             nightly)
               echo "Using OpenMM nightly dev build."
-              # need this until we cut a new openmoltools release
-              pip install git+https://github.com/choderalab/openmoltools.git
-              # need to install from master until parmed updates to a new release
-              pip install git+https://github.com/ParmEd/ParmEd.git
               conda install --quiet -c omnia-dev openmm;;
           esac
 

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -22,7 +22,7 @@ requirements:
     - numpy >=1.14
     - scipy
     - pymbar
-    - openmm >=7.5.0 # constraint slowdown has fixed https://github.com/openmm/openmm/pull/2818
+    - openmm >=7.6.0 # constraint slowdown has fixed https://github.com/openmm/openmm/pull/2818
     - parmed
     - openmoltools >=0.8.4
     - openmmtools


### PR DESCRIPTION
## Description

Removed forks when installing openmm nightly 

## Motivation and context

Now that parmed has made a new release to support the openmm name change + we just cut (will be on conda-forge soon) a new openmoltools release, these CI hacks are no longer needed.

Resolves #798 

## How has this been tested?

Tested on CI

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
CI no longer requires forks for openmm namespace changes.  
```
