### PR TITLE
Add scaled water rest implementation (second attempt)

### DIFF
--- a/perses/annihilation/lambda_protocol.py
+++ b/perses/annihilation/lambda_protocol.py
@@ -219,6 +219,18 @@ class RESTProtocol(object):
     def __init__(self):
         self.functions = RESTProtocol.default_functions
 
+class RESTProtocolV3(object):
+    default_functions = {'lambda_rest_bonds': lambda beta0, beta :  np.sqrt(beta / beta0),
+                         'lambda_rest_angles' : lambda beta0, beta : np.sqrt(beta / beta0),
+                         'lambda_rest_torsions' : lambda beta0, beta :  np.sqrt(beta / beta0),
+                         'lambda_rest_electrostatics' : lambda beta0, beta : np.sqrt(beta / beta0),
+                         'lambda_rest_sterics': lambda beta0, beta : np.sqrt(beta / beta0),
+                         'lambda_rest_electrostatics_exceptions': lambda beta0, beta: np.sqrt(beta / beta0),
+                         'lambda_rest_sterics_exceptions': lambda beta0, beta: np.sqrt(beta / beta0)
+                         }
+    def __init__(self):
+        self.functions = RESTProtocolV3.default_functions
+
 
 class RelativeAlchemicalState(AlchemicalState):
     """
@@ -299,6 +311,48 @@ class RESTState(AlchemicalState):
            The new value for all defined parameters.
        """
        lambda_protocol = RESTProtocol()
+       for parameter_name in lambda_protocol.functions:
+           lambda_value = lambda_protocol.functions[parameter_name](beta0, beta)
+           setattr(self, parameter_name, lambda_value)
+
+class RESTStateV3(AlchemicalState):
+    """
+    REST State to handle all lambda parameters required for REST2 implementation.
+
+    Attributes
+    ----------
+    solute_scale : solute scaling parameter
+    inter_scale : inter-region scaling parameter
+    """
+
+    class _LambdaParameter(AlchemicalState._LambdaParameter):
+        @staticmethod
+        def lambda_validator(self, instance, parameter_value):
+            if parameter_value is None:
+                return parameter_value
+            return float(parameter_value)
+
+    lambda_rest_bonds = _LambdaParameter('lambda_rest_bonds')
+    lambda_rest_angles = _LambdaParameter('lambda_rest_angles')
+    lambda_rest_torsions = _LambdaParameter('lambda_rest_torsions')
+    lambda_rest_electrostatics = _LambdaParameter('lambda_rest_electrostatics')
+    lambda_rest_sterics = _LambdaParameter('lambda_rest_sterics')
+    lambda_rest_electrostatics_exceptions = _LambdaParameter('lambda_rest_electrostatics_exceptions')
+    lambda_rest_sterics_exceptions = _LambdaParameter('lambda_rest_sterics_exceptions')
+
+    def set_alchemical_parameters(self,
+                                  beta0,
+                                  beta):
+       """Set each lambda value according to the lambda_functions protocol.
+       The undefined parameters (i.e. those being set to None) remain
+       undefined.
+
+       Parameters
+       ----------
+       lambda_value : float
+           The new value for all defined parameters.
+       """
+       lambda_protocol = RESTProtocolV3()
        for parameter_name in lambda_protocol.functions:
            lambda_value = lambda_protocol.functions[parameter_name](beta0, beta)
            setattr(self, parameter_name, lambda_value)

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -281,3 +281,701 @@ class RESTTopologyFactory(HybridTopologyFactory):
     @property
     def REST_system(self):
         return self._out_system
+
+class RESTTopologyFactoryV3(HybridTopologyFactory):
+    """
+    This class takes a standard simtk.openmm.system equipped with
+        a. `HarmonicBondForce`
+        b. `HarmonicAngleForce`
+        c. `PeriodicTorsionForce`
+        d. `NonbondedForce`
+    and will convert to another system that allows for rest scaling and is equipped with
+        a. `CustomBondForce`: rewrite `HarmonicBondForce`
+        b. `CustomAngleForce`: rewrite `HarmonicAngleForce`
+        c. `CustomTorsionForce`: rewrite `PeriodicTorsionForce`
+        d. `CustomNonbondedForce`: handles direct space PME electrostatics interactions (with long range correction off)
+        e. `CustomNonbondedForce` handles direct space PME steric interactions (with long range correction on)
+        f. `CustomBondForce`: handles direct space PME electrostatics and steric exceptions
+        g. `NonbondedForce`: handles reciprocal space PME electrostatics
+    """
+
+    _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
+
+    from openmmtools.constants import ONE_4PI_EPS0
+    _default_electrostatics_expression_list = [
+
+        "U_electrostatics;",
+
+        # Define electrostatics functional form
+        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd  * erfc(alpha * r)/ r_eff_electrostatics;",
+
+        # Define chargeProd (with REST scaling)
+        "chargeProd = (charge1 * p1_electrostatics_rest_scale) * (charge2 * p2_electrostatics_rest_scale);",
+
+        # Define rest scale factors (normal rest)
+        # "p1_electrostatics_rest_scale = is_rest1 * lambda_rest_electrostatics + is_nonrest_solute1 + is_nonrest_solvent1;",
+        # "p2_electrostatics_rest_scale = is_rest2 * lambda_rest_electrostatics + is_nonrest_solute2 + is_nonrest_solvent2;",
+        # "p1_sterics_rest_scale = is_rest1 * lambda_rest_sterics + is_nonrest_solute1 + is_nonrest_solvent1;",
+        # "p2_sterics_rest_scale = is_rest2 * lambda_rest_sterics + is_nonrest_solute2 + is_nonrest_solvent2;",
+
+        # # Define rest scale factors (scaled water rest)
+        # "p1_electrostatics_rest_scale = select(1 - is_both_solvent, is_rest1 * lambda_electrostatics_rest + is_nonrest_solute1 + is_nonrest_solvent1 * lambda_electrostatics_rest, 1);",
+        # "p2_electrostatics_rest_scale = select(1 - is_both_solvent, is_rest2 * lambda_electrostatics_rest + is_nonrest_solute2 + is_nonrest_solvent2 * lambda_electrostatics_rest, 1);",
+        # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
+
+        # Define rest scale factors (scaled water rest)
+        "p1_electrostatics_rest_scale = lambda_electrostatics_rest * (is_rest1 + is_nonrest_solvent1 * is_rest2);",
+        "p2_electrostatics_rest_scale = lambda_electrostatics_rest * (is_rest2 + is_nonrest_solvent2 * is_rest1);",
+
+        # Define alpha
+        "alpha = sqrt(-log(2 * delta) / r_cutoff);",
+        "delta = {delta};",
+        "r_cutoff = {r_cutoff};",
+
+        # Define r_eff
+        "r_eff_electrostatics = sqrt(r^2);"
+    ]
+
+    _default_sterics_expression_list = [
+
+        "U_sterics;",
+
+        # Define sterics functional form
+        "U_sterics = 4 * epsilon * x * (x - 1.0);"
+        "x = (sigma / r_eff_sterics)^6;"
+
+        # Define sigma
+        "sigma = (sigma1 + sigma2) / 2;",
+
+        # Define epsilon (with rest scaling)
+        "epsilon = p1_sterics_rest_scale * p2_sterics_rest_scale * sqrt(epsilon1 * epsilon2);",
+
+        # # Define rest scale factors (normal rest)
+        # "p1_sterics_rest_scale = is_rest1 * lambda_rest_sterics + is_nonrest_solute1 + is_nonrest_solvent1;",
+        # "p2_sterics_rest_scale = is_rest2 * lambda_rest_sterics + is_nonrest_solute2 + is_nonrest_solvent2;",
+
+        # Define rest scale factors (scaled water rest)
+        # "p1_sterics_rest_scale = select(1 - is_both_solvent, is_rest1 * lambda_sterics_rest + is_nonrest_solute1 + is_nonrest_solvent1 * lambda_sterics_rest, 1);",
+        # "p2_sterics_rest_scale = select(1 - is_both_solvent, is_rest2 * lambda_sterics_rest_ + is_nonrest_solute2 + is_nonrest_solvent2 * lambda_sterics_rest, 1);",
+        # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
+
+        # Define rest scale factors (scaled water rest)
+        "p1_sterics_rest_scale = lambda_sterics_rest * (is_rest1 + is_nonrest_solvent1 * is_rest2);",
+        "p2_sterics_rest_scale = lambda_sterics_rest * (is_rest2 + is_nonrest_solvent2 * is_rest1);",
+
+        # Define r_eff
+        "r_eff_sterics = sqrt(r^2);"
+
+    ]
+
+    _default_exceptions_expression_list = [
+
+        "U_electrostatics * electrostatics_rest_scale + U_sterics * sterics_rest_scale;",
+
+        # Define rest scale
+        "electrostatics_rest_scale = is_rest * lambda_rest_electrostatics_exceptions * lambda_rest_electrostatics_exceptions + is_inter * lambda_rest_electrostatics_exceptions + is_nonrest;",
+        "sterics_rest_scale = is_rest * lambda_rest_sterics_exceptions * lambda_rest_sterics_exceptions + is_inter * lambda_rest_sterics_exceptions + is_nonrest;",
+
+        # Define electrostatics functional form
+        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd * erfc(alpha * r)/ r_eff_electrostatics;",
+
+        # Define sterics functional form
+        "U_sterics = 4 * epsilon * x * (x - 1.0);"
+        "x = (sigma / r_eff_sterics)^6;"
+
+        # Define alpha
+        "alpha = sqrt(-log(2 * delta) / r_cutoff);",
+        "delta = {delta};",
+        "r_cutoff = {r_cutoff};",
+
+        # Define r_eff
+        "r_eff_electrostatics = sqrt(r^2);",
+        "r_eff_sterics = sqrt(r^2);",
+
+    ]
+
+    _default_electrostatics_expression = ' '.join(_default_electrostatics_expression_list)
+    _default_sterics_expression = ' '.join(_default_sterics_expression_list)
+    _default_exceptions_expression = ' '.join(_default_exceptions_expression_list)
+
+    def __init__(self,
+                 system,
+                 topology,
+                 rest_region,
+                 use_dispersion_correction=False, # TODO: remove this?
+
+                 # PME parameters
+                 r_cutoff=None,
+                 delta=1e-4, # ewaldErrorTolerance
+                 **kwargs):
+        """
+        arguments
+            system : simtk.openmm.system
+                system that will be rewritten
+            topology : simtk.openmm.app.topology
+                topology of the system that will be rewritten
+            rest_region : list of ints
+                list of atom indices that will be define the rest region
+            use_dispersion_correction : bool, default False
+                whether to use a dispersion correction
+            r_cutoff : value in units of distance
+                cutoff distance (in nm) beyond which electrostatics are not calculated
+            delta : float
+                error tolerance for alpha in electrostatics
+
+        Properties
+        ----------
+            REST_system : simtk.openmm.system
+                the REST2-implemented system
+        """
+
+        _logger.info("*** Generating RESTTopologyFactoryV3 ***")
+
+        # Set variables related to original system
+        self._topology = topology
+        self._num_particles = system.getNumParticles()
+        self._og_system = system
+        self._og_system_forces = {type(force).__name__ : force for force in self._og_system.getForces()}
+
+        # Validate rest region
+        self._validate_rest_region(rest_region)
+        self._rest_region = rest_region
+        self._nonrest_region = list(set(range(self._num_particles)).difference(set(self._rest_region)))
+        _logger.debug(f"rest region: {self._rest_region}")
+        _logger.debug(f"nonrest region: {self._nonrest_region}")
+
+        # Check that there are no unknown forces in the original system
+        for system_name in ['og']:
+            force_names = getattr(self, '_{}_system_forces'.format(system_name)).keys()
+            unknown_forces = set(force_names) - set(self._known_forces)
+            if len(unknown_forces) > 0:
+                raise ValueError(f"Unknown forces {unknown_forces} encountered in {system_name} system")
+        _logger.info("No unknown forces.")
+
+        # Set nonbonded parameters
+        self._nonbonded_method = self._og_system_forces['NonbondedForce'].getNonbondedMethod()
+        if not r_cutoff:  # Set the cutoff based on the old system's cutoff
+            if self._nonbonded_method != openmm.NonbondedForce.NoCutoff:
+                self._r_cutoff = self._og_system_forces['NonbondedForce'].getCutoffDistance()
+            else:
+                self._r_cutoff = 100 * unit.nanometer
+                # If the nonbonded method is NoCutoff, set alpha to 0
+                self._default_electrostatics_expression_list[5] = "alpha = 0;"
+                self._default_exceptions_expression_list[6] = "alpha = 0;"
+                self._default_electrostatics_expression = ' '.join(self._default_electrostatics_expression_list)
+                self._default_exceptions_expression = ' '.join(self._default_exceptions_expression_list)
+        else:
+            self._r_cutoff = r_cutoff
+        self._w_scale = w_scale
+        self._delta = delta
+        self._use_dispersion_correction = use_dispersion_correction
+
+        # Create REST system and add particles to it
+        self._out_system = openmm.System()
+        self._out_system_forces = {}
+        for particle_idx in range(self._num_particles):
+            particle_mass = self._og_system.getParticleMass(particle_idx)
+            hybrid_idx = self._out_system.addParticle(particle_mass)
+
+        # Add barostat
+        if "MonteCarloBarostat" in self._og_system_forces.keys():
+            barostat = copy.deepcopy(self._og_system_forces["MonteCarloBarostat"])
+            self._out_system.addForce(barostat)
+            self._out_system_forces[barostat.__class__.__name__] = barostat
+            _logger.info("Added MonteCarloBarostat.")
+        else:
+            _logger.info("No MonteCarloBarostat added.")
+
+        # Copy over the box vectors:
+        box_vectors = self._og_system.getDefaultPeriodicBoxVectors()
+        self._out_system.setDefaultPeriodicBoxVectors(*box_vectors)
+        _logger.info(f"getDefaultPeriodicBoxVectors added to hybrid: {box_vectors}")
+
+        # Prep look up dict for determining if atom is solvent
+        if 'openmm' in self._topology.__module__:
+            atoms = self._topology.atoms()
+        elif 'mdtraj' in self._topology.__module__:
+            atoms = self._topology.atoms
+        else:
+            raise Exception("Topology object must be simtk.openmm.app.topology or mdtraj.core.topology")
+        self._atom_idx_to_object = {atom.index: atom for atom in atoms}
+
+        # Copy constraints, checking to make sure they are not changing
+        self._handle_constraints()
+
+        # Create custom bond force and add bonds to it
+        self._create_bond_force()
+        self._copy_bonds()
+
+        # Create custom angle force and add angles to it
+        self._create_angle_force()
+        self._copy_angles()
+
+        # Create custom torsion force and add torsions to it
+        self._create_torsion_force()
+        self._copy_torsions()
+
+        # Create custom nonbonded and custom bond forces and add particles/bonds to them
+        # self._add_nonbonded_force_terms()
+        # self._add_nonbondeds()
+        self._create_nonbonded_electrostatics_force()
+        self._create_nonbonded_sterics_force()
+        self._copy_nonbondeds()
+
+        self._create_nonbonded_exceptions_force()
+        self._copy_nonbondeds_exceptions()
+
+        self._create_nonbonded_reciprocal_space_force()
+        self._copy_nonbondeds_reciprocal_space()
+
+    def _validate_rest_region(self, rest_region):
+        """
+        Check that rest_region was defined correctly
+
+        Parameters
+        ----------
+        rest_region : lists of ints
+            contains the indices of atoms that should be scaled by rest
+        """
+
+        # Check that rest_region is a list
+        assert type(rest_region) == list
+
+        # Check that the list contains ints
+        assert all(type(element) == int for element in rest_region)
+
+        # Check that the rest region is a subset of the system particles
+        assert set(rest_region).issubset(
+            set(range(self._num_particles))), f"the rest region is not a subset of the system particles"
+
+        # Check that there are no duplicate particles in the rest region
+        assert len(rest_region) == len(set(rest_region)), "There are duplicate atom indices in the rest_region"
+
+
+    def _handle_constraints(self):
+        for constraint_idx in range(self._og_system.getNumConstraints()):
+            atom1, atom2, length = self._og_system.getConstraintParameters(constraint_idx)
+            self._out_system.addConstraint(atom1, atom2, length)
+
+    def get_rest_identifier(self, particles):
+        """
+        For a given particle or set of particles, get the rest_id which is a list of binary ints that defines which
+        region the particle(s) belong to.
+        If there is a single particle, the regions are: is_rest, is_nonrest_solute, is_nonrest_solvent
+        If there is a set of particles, the regions are: is_rest, is_inter, is_nonrest
+        Example: if there is a single particle that is in the nonrest_solute region, the rest_id is [0, 1, 0]
+        Arguments
+        ---------
+        particles : set or int
+            a set of hybrid particle indices or single particle
+        Returns
+        -------
+        rest_id : list
+            list of binaries indicating which region the particle(s) belong to
+        """
+
+        def _is_solvent(particle_index, positive_ion_name="NA", negative_ion_name="CL", water_name="HOH"):
+            atom = self._atom_idx_to_object[particle_index]
+            if atom.residue.name == positive_ion_name:
+                return True
+            elif atom.residue.name == negative_ion_name:
+                return True
+            elif atom.residue.name == water_name:
+                return True
+            else:
+                return False
+
+        assert type(particles) in [type(set()), int], f"`particles` must be an integer or a set, got {type(particles)}."
+
+        if isinstance(particles, int):
+            rest_id = [0, 1, 0]  # Set the default scale_id to nonrest solute
+            if not self._rest_region:
+                return rest_id  # If there are no rest regions, set everything as nonrest_solute bc these atoms are not scaled
+            else:
+                if particles in self._rest_region:  # Here, particles is a single int
+                    rest_id = [1, 0, 0]
+                elif _is_solvent(particles):  # If the particle is not in a rest region, check if it is a solvent atom
+                    rest_id = [0, 0, 1]
+                return rest_id
+
+
+        elif isinstance(particles, set):
+            rest_id = [0, 0, 1]  # Set the default scale_id to nonrest solute
+            if not self._rest_region:
+                return rest_id  # If there are no scale regions, set everything as nonrest bc these atoms are not scaled
+            else:
+                if particles.intersection(
+                        self._rest_region) != set():  # At least one of the particles is in the idx_th rest region
+                    if particles.issubset(self._rest_region):  # Then this term is wholly in the rest region
+                        rest_id = [1, 0, 0]
+                    else:  # It is inter region
+                        rest_id = [0, 1, 0]
+                return rest_id
+
+        else:
+            raise Exception(f"particles is of type {type(particles)}, but only `int` and `set` are allowable")
+
+    def _create_bond_force(self):
+
+        # Define the custom expression
+        bond_expression = "rest_scale * (K / 2) * (r - length)^2;"
+        bond_expression += "rest_scale = is_rest * lambda_rest_bonds * lambda_rest_bonds " \
+                           "+ is_inter * lambda_rest_bonds " \
+                           "+ is_nonrest;"
+
+        # Create custom force
+        custom_bond_force = openmm.CustomBondForce(bond_expression)
+        self._out_system.addForce(custom_bond_force)
+        self._out_system_forces[custom_bond_force.__class__.__name__] = custom_bond_force
+
+        # Add global parameters
+        custom_bond_force.addGlobalParameter("lambda_rest_bonds", 1.0)
+
+        # Add per-bond parameters for rest scaling -- these sets are disjoint
+        custom_bond_force.addPerBondParameter("is_rest")
+        custom_bond_force.addPerBondParameter("is_inter")
+        custom_bond_force.addPerBondParameter("is_nonrest")
+
+        # Add per-bond parameters for defining energy
+        custom_bond_force.addPerBondParameter('length')
+        custom_bond_force.addPerBondParameter('K')
+
+    def _create_angle_force(self):
+
+        # Define the custom expression
+        angle_expression = "rest_scale * (K / 2) * (theta - theta0)^2;"
+        angle_expression += "rest_scale = is_rest * lambda_rest_angles * lambda_rest_angles " \
+                            "+ is_inter * lambda_rest_angles " \
+                            "+ is_nonrest;"
+
+        # Create custom force
+        custom_angle_force = openmm.CustomAngleForce(angle_expression)
+        self._out_system.addForce(custom_angle_force)
+        self._out_system_forces[custom_angle_force.__class__.__name__] = custom_angle_force
+
+        # Add global parameters
+        custom_angle_force.addGlobalParameter("lambda_rest_angles", 1.0)
+
+        # Add per-angle parameters for rest scaling -- these sets are disjoint
+        custom_angle_force.addPerAngleParameter("is_rest")
+        custom_angle_force.addPerAngleParameter("is_inter")
+        custom_angle_force.addPerAngleParameter("is_nonrest")
+
+        # Add per-angle parameters for defining energy
+        custom_angle_force.addPerAngleParameter('theta0')
+        custom_angle_force.addPerAngleParameter('K')
+
+    def _create_torsion_force(self):
+
+        # Define the custom expression
+        torsion_expression = "rest_scale * (K * (1 + cos(periodicity * theta - phase)));"
+        torsion_expression += "rest_scale = is_rest * lambda_rest_torsions * lambda_rest_torsions " \
+                              "+ is_inter * lambda_rest_torsions " \
+                              "+ is_nonrest;"
+
+        # Create custom force
+        custom_torsion_force = openmm.CustomTorsionForce(torsion_expression)
+        self._out_system.addForce(custom_torsion_force)
+        self._out_system_forces[custom_torsion_force.__class__.__name__] = custom_torsion_force
+
+        # Add global parameters
+        custom_torsion_force.addGlobalParameter("lambda_rest_torsions", 1.0)
+
+        # Add per-torsion parameters for rest scaling -- these sets are disjoint
+        custom_torsion_force.addPerTorsionParameter("is_rest")
+        custom_torsion_force.addPerTorsionParameter("is_inter")
+        custom_torsion_force.addPerTorsionParameter("is_nonrest")
+
+        # Add per-torsion parameters for defining energy
+        custom_torsion_force.addPerTorsionParameter('periodicity')
+        custom_torsion_force.addPerTorsionParameter('phase')
+        custom_torsion_force.addPerTorsionParameter('K')
+
+    def _create_nonbonded_electrostatics_force(self):
+
+        # Define the custom expression
+        expression = self._default_electrostatics_expression
+        formatted_expression = expression.format(r_cutoff=self._r_cutoff.value_in_unit_system(unit.md_unit_system),
+                                                 delta=self._delta)
+
+        # Create the custom force
+        custom_nb_force = openmm.CustomNonbondedForce(formatted_expression)
+        self._out_system.addForce(custom_nb_force)
+        self._out_system_forces[custom_nb_force.__class__.__name__ + '_electrostatics'] = custom_nb_force
+
+        # Add global parameters
+        custom_nb_force.addGlobalParameter(f"lambda_rest_electrostatics", 1.0)
+
+        # Add per-particle parameters for rest scaling -- these three sets are disjoint
+        custom_nb_force.addPerParticleParameter("is_rest")
+        custom_nb_force.addPerParticleParameter("is_nonrest_solute")
+        custom_nb_force.addPerParticleParameter("is_nonrest_solvent")
+
+        # Add per-particle parameters for defining energy
+        custom_nb_force.addPerParticleParameter('charge')
+
+        # Handle some nonbonded attributes
+        old_system_nbf = self.og_forces['NonbondedForce']
+        standard_nonbonded_method = old_system_nbf.getNonbondedMethod()
+        if standard_nonbonded_method in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.PME,
+                                         openmm.NonbondedForce.Ewald]:
+            custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))
+            custom_nb_force.setUseSwitchingFunction(False)
+            custom_nb_force.setCutoffDistance(self._r_cutoff)
+            custom_nb_force.setUseLongRangeCorrection(False) # This should be off for electrostatics, but on for sterics
+
+        elif standard_nonbonded_method == openmm.NonbondedForce.NoCutoff:
+            custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))
+
+        else:
+            raise Exception(f"nonbonded method is not recognized")
+
+    def _create_nonbonded_sterics_force(self):
+
+        # Define the custom expression
+        expression = self._default_sterics_expression
+        formatted_expression = expression.format()
+
+        # Create the custom force
+        custom_nb_force = openmm.CustomNonbondedForce(formatted_expression)
+        self._out_system.addForce(custom_nb_force)
+        self._out_system_forces[custom_nb_force.__class__.__name__ + '_sterics'] = custom_nb_force
+
+        # Add global parameters
+        custom_nb_force.addGlobalParameter(f"lambda_rest_sterics", 1.0)
+
+        # Add per-particle parameters for rest scaling -- these three sets are disjoint
+        custom_nb_force.addPerParticleParameter("is_rest")
+        custom_nb_force.addPerParticleParameter("is_nonrest_solute")
+        custom_nb_force.addPerParticleParameter("is_nonrest_solvent")
+
+        # Add per-particle parameters for defining energy
+        custom_nb_force.addPerParticleParameter('sigma')
+        custom_nb_force.addPerParticleParameter('epsilon')
+
+        # Handle some nonbonded attributes
+        old_system_nbf = self.og_forces['NonbondedForce']
+        standard_nonbonded_method = old_system_nbf.getNonbondedMethod()
+        if standard_nonbonded_method in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.PME,
+                                         openmm.NonbondedForce.Ewald]:
+            custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))
+            custom_nb_force.setUseSwitchingFunction(False)
+            custom_nb_force.setCutoffDistance(self._r_cutoff)
+            custom_nb_force.setUseLongRangeCorrection(True) # This should be on for sterics, but off for electrostatics
+
+        elif standard_nonbonded_method == openmm.NonbondedForce.NoCutoff:
+            custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))
+
+        else:
+            raise Exception(f"nonbonded method is not recognized")
+
+    def _create_nonbonded_exceptions_force(self):
+
+        # Define the custom expression
+        expression = self._default_exceptions_expression
+        formatted_expression = expression.format(r_cutoff=self._r_cutoff.value_in_unit_system(unit.md_unit_system),
+                                                 delta=self._delta)
+
+        # Create the custom force
+        custom_bond_force = openmm.CustomBondForce(formatted_expression)
+        self._out_system.addForce(custom_bond_force)
+        self._out_system_forces[custom_bond_force.__class__.__name__] = custom_bond_force
+
+        # Add global parameters
+        custom_bond_force.addGlobalParameter(f"lambda_rest_electrostatics_exceptions", 1.0)
+        custom_bond_force.addGlobalParameter(f"lambda_rest_sterics_exceptions", 1.0)
+
+        # Add per-bond parameters for rest scaling -- these sets are disjoint
+        custom_bond_force.addPerBondParameter("is_rest")
+        custom_bond_force.addPerBondParameter("is_inter")
+        custom_bond_force.addPerBondParameter("is_nonrest")
+
+        # Add per-bond parameters for defining energy
+        custom_bond_force.addPerBondParameter('chargeProd')
+        custom_bond_force.addPerBondParameter('sigma')
+        custom_bond_force.addPerBondParameter('epsilon')
+
+        # Handle some nonbonded attributes
+        old_system_nbf = self.og_forces['NonbondedForce']
+        standard_nonbonded_method = old_system_nbf.getNonbondedMethod()
+        if standard_nonbonded_method in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.PME,
+                                         openmm.NonbondedForce.Ewald]:
+            custom_force.setUsesPeriodicBoundaryConditions(True)
+
+        elif standard_nonbonded_method == openmm.NonbondedForce.NoCutoff:
+            custom_force.setUsesPeriodicBoundaryConditions(False)
+
+        else:
+            raise Exception(f"nonbonded method is not recognized")
+
+    def _create_nonbonded_reciprocal_space_force(self):
+
+        # Create force
+        standard_nonbonded_force = openmm.NonbondedForce()
+        self._out_system.addForce(standard_nonbonded_force)
+        self._out_system_forces[standard_nonbonded_force.__class__.__name__] = standard_nonbonded_force
+
+        # TODO: For now, assume that this force will not be scaled
+
+        # Set nonbonded method and related attributes
+        old_system_nbf = self._og_system_forces['NonbondedForce']
+        standard_nonbonded_method = old_system_nbf.getNonbondedMethod()
+        standard_nonbonded_force.setNonbondedMethod(standard_nonbonded_method)
+        if standard_nonbonded_method in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.CutoffNonPeriodic]:
+            epsilon_solvent = old_system_nbf.getReactionFieldDielectric()
+            r_cutoff = old_system_nbf.getCutoffDistance()
+            standard_nonbonded_force.setReactionFieldDielectric(epsilon_solvent)
+            standard_nonbonded_force.setCutoffDistance(r_cutoff)
+        elif standard_nonbonded_method in [openmm.NonbondedForce.PME, openmm.NonbondedForce.Ewald]:
+            [alpha_ewald, nx, ny, nz] = old_system_nbf.getPMEParameters()
+            delta = old_system_nbf.getEwaldErrorTolerance()
+            r_cutoff = old_system_nbf.getCutoffDistance()
+            standard_nonbonded_force.setPMEParameters(alpha_ewald, nx, ny, nz)
+            standard_nonbonded_force.setEwaldErrorTolerance(delta)
+            standard_nonbonded_force.setCutoffDistance(r_cutoff)
+        elif standard_nonbonded_method in [openmm.NonbondedForce.NoCutoff]:
+            pass
+        else:
+            raise Exception("Nonbonded method %s not supported yet." % str(self._nonbonded_method))
+
+        # Set the use of dispersion correction
+        if old_system_nbf.getUseDispersionCorrection():
+            standard_nonbonded_force.setUseDispersionCorrection(True)
+        else:
+            standard_nonbonded_force.setUseDispersionCorrection(False)
+
+        # Set the use of switching function
+        if old_system_nbf.getUseSwitchingFunction():
+            switching_distance = old_system_nbf.getSwitchingDistance()
+            standard_nonbonded_force.setUseSwitchingFunction(True)
+            standard_nonbonded_force.setSwitchingDistance(switching_distance)
+        else:
+            standard_nonbonded_force.setUseSwitchingFunction(False)
+
+        # Disable direct space interactions
+        standard_nonbonded_force.setIncludeDirectSpace(False)
+
+    def _copy_bonds(self):
+        """
+        add bonds
+        """
+        og_bond_force = self._og_system_forces['HarmonicBondForce']
+        custom_bond_force = self._out_system_forces['CustomBondForce']
+
+        # Set periodicity
+        if og_bond_force.usesPeriodicBoundaryConditions():
+            custom_bond_force.setUsesPeriodicBoundaryConditions(True)
+
+        # Iterate over bonds in original bond force and copy to the custom bond force
+        for bond_idx in range(og_bond_force.getNumBonds()):
+            # Get particle indices and bond terms
+            p1, p2, length, k = og_bond_force.getBondParameters(bond_idx)
+
+            # Given the atom indices, get rest identifier
+            rest_id = self.get_rest_identifier(set([p1, p2]))
+
+            # Add bond
+            custom_bond_force.addBond(p1, p2, rest_id + [length, k])
+
+    def _copy_angles(self):
+        og_angle_force = self._og_system_forces['HarmonicAngleForce']
+        custom_angle_force = self._out_system_forces['CustomAngleForce']
+
+        # Set periodicity
+        if og_angle_force.usesPeriodicBoundaryConditions():
+            custom_angle_force.setUsesPeriodicBoundaryConditions(True)
+
+        # Iterate over angles in original angle force and copy to the custom angle force
+        for angle_idx in range(og_angle_force.getNumAngles()):
+            # Get particle indices and angle terms
+            p1, p2, p3, theta0, k = og_angle_force.getAngleParameters(angle_idx)
+
+            # Given the atom indices, get rest identifier
+            rest_id = self.get_rest_identifier(set([p1, p2, p3]))
+
+            # Add angle
+            custom_angle_force.addAngle(p1, p2, p3, rest_id + [theta0, k])
+
+    def _copy_torsions(self):
+        og_torsion_force = self._og_system_forces['PeriodicTorsionForce']
+        custom_torsion_force = self._out_system_forces['CustomTorsionForce']
+
+        # Set periodicity
+        if og_torsion_force.usesPeriodicBoundaryConditions():
+            custom_torsion_force.setUsesPeriodicBoundaryConditions(True)
+
+        # Iterate over torsions in original torsion force and copy to the custom torsion force
+        for torsion_idx in range(og_torsion_force.getNumTorsions()):
+            # Get particle indices and torsion terms
+            p1, p2, p3, p4, periodicity, phase, k = og_torsion_force.getTorsionParameters(torsion_idx)
+
+            # Given the atom indices, get rest identifier
+            rest_id = self.get_rest_identifier(set([p1, p2, p3, p4]))
+
+            # Add torsion
+            custom_torsion_force.addTorsion(p1, p2, p3, p4, rest_id + [periodicity, phase, k])
+
+    def _copy_nonbondeds(self):
+        og_nb_force = self._og_system_forces['NonbondedForce']
+        custom_electrostatics_force = self._out_system_forces['CustomNonbondedForce_electrostatics']
+        custom_sterics_force = self._out_system_forces['CustomNonbondedForce_sterics']
+
+        # Iterate over particles in original nonbonded force and copy to the custom forces
+        for particle_idx in range(self._num_particles):
+
+            # Get particle terms
+            q, sigma, epsilon = og_nb_force.getParticleParameters(particle_idx)
+
+            # Given atom index, get rest identifier
+            rest_id = self.get_identifier(particle_idx)
+
+            # Add particle to electrostatics force
+            custom_electrostatics_force.addParticle(rest_id + [q])
+
+            # Add particle to sterics force
+            custom_sterics_force.addParticle(rest_id + [sigma, epsilon])
+
+    def _copy_nonbondeds_exceptions(self):
+        og_nb_force = self._og_system_forces['NonbondedForce']
+        custom_exceptions_force = self._out_system_forces['CustomBondForce']
+        custom_electrostatics_force = self._out_system_forces['CustomNonbondedForce_electrostatics']
+        custom_sterics_force = self._out_system_forces['CustomNonbondedForce_sterics']
+
+        for exception_idx in range(og_nb_force.getNumExceptions()):
+
+            # Get particle indices and exception terms
+            p1, p2, chargeProd, sigma, epsilon = og_nb_force.getExceptionParameters(exception_idx)
+
+            # Given atom indices, get rest identifier
+            rest_id = self.get_identifier(set([p1, p2]))
+
+            # Add exception
+            custom_exceptions_force.addException(p1, p2, rest_id + [chargeProd, sigma, epsilon])
+
+            # Add exclusions to custom nb forces
+            custom_electrostatics_force.addExclusion(p1, p2)
+            custom_sterics_force.addException(p1, p2)
+
+    def _copy_nonbondeds_reciprocal_space(self):
+        og_nb_force = self._og_system_forces['NonbondedForce']
+        nb_force = self._out_system_forces['NonbondedForce']
+
+        # Iterate over particles in original nonbonded force and copy to the new nonbonded force
+        for particle_idx in range(self._num_particles):
+            # Get particle terms
+            q, sigma, epsilon = og_nb_force.getParticleParameters(particle_idx)
+
+            # Add particle
+            nb_force.addParticle(q, sigma, epsilon)
+
+        for exception_idx in range(og_nb_force.getNumExceptions()):
+
+            # Get particle indices and exception terms
+            p1, p2, chargeProd, sigma, epsilon = og_nb_force.getExceptionParameters(exception_idx)
+
+            # Add exception
+            nb_force.addException(p1, p2, chargeProd, sigma, epsilon)
+
+    @property
+    def REST_system(self):
+        return self._out_system

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -308,7 +308,7 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         "U_electrostatics;",
 
         # Define electrostatics functional form
-        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd  * erfc(alpha * r)/ r_eff_electrostatics;",
+        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd  * erfc(alpha * r)/ r;",
 
         # Define chargeProd (with REST scaling)
         "chargeProd = (charge1 * p1_electrostatics_rest_scale) * (charge2 * p2_electrostatics_rest_scale);",
@@ -325,16 +325,17 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
 
         # Define rest scale factors (scaled water rest)
-        "p1_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest1 + is_nonrest_solvent1 * is_rest2);",
-        "p2_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest2 + is_nonrest_solvent2 * is_rest1);",
+        #"p1_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
+        #"p2_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
+
+        "p1_electrostatics_rest_scale = 1;",
+        "p2_electrostatics_rest_scale = 1;",
 
         # Define alpha
         "alpha = sqrt(-log(2 * delta) / r_cutoff);",
         "delta = {delta};",
         "r_cutoff = {r_cutoff};",
 
-        # Define r_eff
-        "r_eff_electrostatics = sqrt(r^2);"
     ]
 
     _default_sterics_expression_list = [
@@ -343,7 +344,7 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
 
         # Define sterics functional form
         "U_sterics = 4 * epsilon * x * (x - 1.0);"
-        "x = (sigma / r_eff_sterics)^6;"
+        "x = (sigma / r)^6;"
 
         # Define sigma
         "sigma = (sigma1 + sigma2) / 2;",
@@ -361,12 +362,11 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
 
         # Define rest scale factors (scaled water rest)
-        "p1_sterics_rest_scale = lambda_rest_sterics * (is_rest1 + is_nonrest_solvent1 * is_rest2);",
-        "p2_sterics_rest_scale = lambda_rest_sterics * (is_rest2 + is_nonrest_solvent2 * is_rest1);",
+        #"p1_sterics_rest_scale = lambda_rest_sterics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
+        #"p2_sterics_rest_scale = lambda_rest_sterics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
 
-        # Define r_eff
-        "r_eff_sterics = sqrt(r^2);"
-
+        "p1_sterics_rest_scale = 1;",
+        "p2_sterics_rest_scale = 1;"
     ]
 
     _default_exceptions_expression_list = [
@@ -378,20 +378,16 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         "sterics_rest_scale = is_rest * lambda_rest_sterics_exceptions * lambda_rest_sterics_exceptions + is_inter * lambda_rest_sterics_exceptions + is_nonrest;",
 
         # Define electrostatics functional form
-        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd * erfc(alpha * r)/ r_eff_electrostatics;",
+        f"U_electrostatics = {ONE_4PI_EPS0} * chargeProd * erfc(alpha * r)/ r;",
 
         # Define sterics functional form
         "U_sterics = 4 * epsilon * x * (x - 1.0);",
-        "x = (sigma / r_eff_sterics)^6;",
+        "x = (sigma / r)^6;",
 
         # Define alpha
         "alpha = sqrt(-log(2 * delta) / r_cutoff);",
         "delta = {delta};",
         "r_cutoff = {r_cutoff};",
-
-        # Define r_eff
-        "r_eff_electrostatics = sqrt(r^2);",
-        "r_eff_sterics = sqrt(r^2);"
 
     ]
 

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -400,8 +400,7 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
     def __init__(self,
                  system,
                  topology,
-                 rest_region,
-                 use_dispersion_correction=False, # TODO: remove this?
+                 rest_region
                  **kwargs):
         """
         arguments
@@ -411,8 +410,6 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
                 topology of the system that will be rewritten
             rest_region : list of ints
                 list of atom indices that will be define the rest region
-            use_dispersion_correction : bool, default False
-                whether to use a dispersion correction
             r_cutoff : value in units of distance
                 cutoff distance (in nm) beyond which electrostatics are not calculated
             delta : float
@@ -459,7 +456,6 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
                 alpha_ewald = (1.0 / self._og_system_forces['NonbondedForce'].getCutoffDistance()) * np.sqrt(-np.log(2.0 * tol))
             self._alpha_ewald = alpha_ewald.value_in_unit_system(unit.md_unit_system)
         _logger.info(f"alpha_ewald is {self._alpha_ewald}")
-        self._use_dispersion_correction = use_dispersion_correction
 
         # Create REST system and add particles to it
         self._out_system = openmm.System()
@@ -507,8 +503,6 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         self._copy_torsions()
 
         # Create custom nonbonded and custom bond forces and add particles/bonds to them
-        # self._add_nonbonded_force_terms()
-        # self._add_nonbondeds()
         self._create_nonbonded_electrostatics_force()
         self._create_nonbonded_sterics_force()
         self._copy_nonbondeds()
@@ -753,7 +747,7 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
                 custom_nb_force.setUseSwitchingFunction(True)
                 custom_nb_force.setSwitchingDistance(old_system_nbf.getSwitchingDistance())
             custom_nb_force.setCutoffDistance(old_system_nbf.getCutoffDistance())
-            custom_nb_force.setUseLongRangeCorrection(True) # This should be on for sterics, but off for electrostatics
+            custom_nb_force.setUseLongRangeCorrection(old_system_nbf.getUseDispersionCorrection()) # This should be copied from the og nbf for sterics, but off for electrostatics
 
         elif standard_nonbonded_method == openmm.NonbondedForce.NoCutoff:
             custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -332,11 +332,8 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
 
         # Define rest scale factors (scaled water rest)
-        #"p1_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
-        #"p2_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
-
-        "p1_electrostatics_rest_scale = 1;",
-        "p2_electrostatics_rest_scale = 1;",
+        "p1_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
+        "p2_electrostatics_rest_scale = lambda_rest_electrostatics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
 
         # Define alpha
         "alpha = {alpha_ewald};"
@@ -367,11 +364,9 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         # "is_both_solvent = is_nonrest_solvent1 * is_nonrest_solvent2;",
 
         # Define rest scale factors (scaled water rest)
-        #"p1_sterics_rest_scale = lambda_rest_sterics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
-        #"p2_sterics_rest_scale = lambda_rest_sterics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
+        "p1_sterics_rest_scale = lambda_rest_sterics * (is_rest1 + is_nonrest_solvent1 * is_rest2) + 1 * (is_nonrest_solute1 + is_nonrest_solvent1 * is_nonrest_solute2 + is_nonrest_solvent1 * is_nonrest_solvent2);",
+        "p2_sterics_rest_scale = lambda_rest_sterics * (is_rest2 + is_nonrest_solvent2 * is_rest1) + 1 * (is_nonrest_solute2 + is_nonrest_solvent2 * is_nonrest_solute1 + is_nonrest_solvent2 * is_nonrest_solvent1);",
 
-        "p1_sterics_rest_scale = 1;",
-        "p2_sterics_rest_scale = 1;"
     ]
 
     _default_exceptions_expression_list = [

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -385,7 +385,7 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         "x = (sigma / r)^6;",
 
         # Define alpha
-        "alpha = sqrt(-log(2 * delta) / r_cutoff);",
+        "alpha = sqrt(-log(2 * delta)) / r_cutoff;",
         "delta = {delta};",
         "r_cutoff = {r_cutoff};",
 
@@ -755,7 +755,9 @@ class RESTTopologyFactoryV3(HybridTopologyFactory):
         if standard_nonbonded_method in [openmm.NonbondedForce.CutoffPeriodic, openmm.NonbondedForce.PME,
                                          openmm.NonbondedForce.Ewald]:
             custom_nb_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(standard_nonbonded_method))
-            custom_nb_force.setUseSwitchingFunction(False)
+            if old_system_nbf.getUseSwitchingFunction(): # This should be copied for sterics force, but not for electrostatics force
+                custom_nb_force.setUseSwitchingFunction(True)
+                custom_nb_force.setSwitchingDistance(old_system_nbf.getSwitchingDistance())
             custom_nb_force.setCutoffDistance(self._r_cutoff)
             custom_nb_force.setUseLongRangeCorrection(True) # This should be on for sterics, but off for electrostatics
 


### PR DESCRIPTION
## Description
This PR creates `RESTTopologyFactoryV3`, a class that generates a rest-like system where the energies are scaled according to rest with the following exception: scale rest-water interactions by beta/beta_0 (previously was being scaled by sqrt(beta/beta_0).

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
