### PR TITLE
WIP: Optional oechem for AtomMapper

### DIFF
--- a/perses/rjmc/atom_mapping.py
+++ b/perses/rjmc/atom_mapping.py
@@ -614,7 +614,7 @@ def _n_atoms(mol):
     if isinstance(mol, Molecule):
         return mol.n_atoms
     else:
-        return mol.GetNumAtoms()  # ?
+        return mol.NumAtoms()
 
 class AtomMapper(object):
     """
@@ -858,7 +858,7 @@ class AtomMapper(object):
         self._assign_ring_ids(new_scaffold, assign_atoms=True, assign_bonds=False)
 
         # Check arguments
-        if (old_oescaffold.NumAtoms()==0) or (new_oescaffold.NumAtoms()==0):
+        if (_n_atoms(old_scaffold) == 0) or (_n_atoms(new_scaffold) == 0):
             # We can't do anything with empty scaffolds
             _logger.debug(f'One or more scaffolds had no atoms')
             scaffold_maps = list()

--- a/perses/rjmc/atom_mapping.py
+++ b/perses/rjmc/atom_mapping.py
@@ -19,8 +19,10 @@ try:
     from openeye import oechem
 except ImportError:
     HAS_OECHEM = False
+    from perses.utils.off import get_scaffold
 else:
     HAS_OECHEM = True
+    from perses.utils.openeye import get_scaffold
 
 ################################################################################
 # LOGGER
@@ -849,12 +851,11 @@ class AtomMapper(object):
             self._assign_ring_ids(old_mol)
             self._assign_ring_ids(new_mol)
 
-        from perses.utils.openeye import get_scaffold
-        old_oescaffold = get_scaffold(old_oemol)
-        new_oescaffold = get_scaffold(new_oemol)
+        old_scaffold = get_scaffold(old_mol)
+        new_scaffold = get_scaffold(new_mol)
 
-        self._assign_ring_ids(old_oescaffold, assign_atoms=True, assign_bonds=False)
-        self._assign_ring_ids(new_oescaffold, assign_atoms=True, assign_bonds=False)
+        self._assign_ring_ids(old_scaffold, assign_atoms=True, assign_bonds=False)
+        self._assign_ring_ids(new_scaffold, assign_atoms=True, assign_bonds=False)
 
         # Check arguments
         if (old_oescaffold.NumAtoms()==0) or (new_oescaffold.NumAtoms()==0):

--- a/perses/rjmc/atom_mapping.py
+++ b/perses/rjmc/atom_mapping.py
@@ -22,43 +22,6 @@ except ImportError:
 else:
     HAS_OECHEM = True
 
-# AtomMapper default settings
-if HAS_OECHEM:
-    _AtomMapper_DEFAULT_EXPRESSIONS = {
-        # weak requirements for mapping atoms == more atoms mapped, more in core
-        # atoms need to match in aromaticity. Same with bonds.
-        # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
-            'weak' : {
-                #'atom' : oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic, #| oechem.OEExprOpts_IntType
-                #'bond' : oechem.OEExprOpts_DefaultBonds
-                'atom' : oechem.OEExprOpts_RingMember,
-                'bond' : oechem.OEExprOpts_RingMember
-            },
-        # default atom expression, requires same aromaticitiy and hybridization
-        # bonds need to match in bond order
-        # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
-        'default' : {
-            'atom' : oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember,
-            #'atom' : oechem.OEExprOpts_Hybridization, #| oechem.OEExprOpts_IntType
-            'bond' : oechem.OEExprOpts_DefaultBonds
-        },
-        # strong requires same hybridization AND the same atom type
-        # bonds are same as default, require them to match in bond order
-        'strong' : {
-            'atom' : oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_AtomicNumber | oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember,
-            #'atom' : oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms, # This seems broken for biopolymers due to OEExprOpts_HvyDegree, which does not seem to be working properly
-            'bond' : oechem.OEExprOpts_DefaultBonds
-        }
-    }
-else:
-    # TODO...
-    _AtomMapper_DEFAULT_EXPRESSIONS = {
-        'weak': {'atom': 0, 'bond': 0},
-        'default': {'atom': 0, 'bond': 0},
-        'string': {'atom': 0, 'bond': 0},
-    }
-
-
 ################################################################################
 # LOGGER
 ################################################################################
@@ -584,6 +547,44 @@ class AtomMapping(object):
 ################################################################################
 # ATOM MAPPERS
 ################################################################################
+
+# AtomMapper default settings, for each toolkit
+# ideally gives similar(ish) results..
+if HAS_OECHEM:
+    _AtomMapper_DEFAULT_EXPRESSIONS = {
+        # weak requirements for mapping atoms == more atoms mapped, more in core
+        # atoms need to match in aromaticity. Same with bonds.
+        # maps ethane to ethene, CH3 to NH2, but not benzene to cyclohexane
+            'weak' : {
+                #'atom' : oechem.OEExprOpts_EqAromatic | oechem.OEExprOpts_EqNotAromatic, #| oechem.OEExprOpts_IntType
+                #'bond' : oechem.OEExprOpts_DefaultBonds
+                'atom' : oechem.OEExprOpts_RingMember,
+                'bond' : oechem.OEExprOpts_RingMember
+            },
+        # default atom expression, requires same aromaticitiy and hybridization
+        # bonds need to match in bond order
+        # ethane to ethene wouldn't map, CH3 to NH2 would map but CH3 to HC=O wouldn't
+        'default' : {
+            'atom' : oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember,
+            #'atom' : oechem.OEExprOpts_Hybridization, #| oechem.OEExprOpts_IntType
+            'bond' : oechem.OEExprOpts_DefaultBonds
+        },
+        # strong requires same hybridization AND the same atom type
+        # bonds are same as default, require them to match in bond order
+        'strong' : {
+            'atom' : oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_AtomicNumber | oechem.OEExprOpts_Aromaticity | oechem.OEExprOpts_RingMember,
+            #'atom' : oechem.OEExprOpts_Hybridization | oechem.OEExprOpts_HvyDegree | oechem.OEExprOpts_DefaultAtoms, # This seems broken for biopolymers due to OEExprOpts_HvyDegree, which does not seem to be working properly
+            'bond' : oechem.OEExprOpts_DefaultBonds
+        }
+    }
+else:
+    # TODO...
+    _AtomMapper_DEFAULT_EXPRESSIONS = {
+        'weak': {'atom': 0, 'bond': 0},
+        'default': {'atom': 0, 'bond': 0},
+        'string': {'atom': 0, 'bond': 0},
+    }
+
 
 class AtomMapper(object):
     """

--- a/perses/utils/__init__.py
+++ b/perses/utils/__init__.py
@@ -1,2 +1,3 @@
 from perses.utils.data import *
 from perses.utils.openeye import *
+from perses.utils.off import *

--- a/perses/utils/off.py
+++ b/perses/utils/off.py
@@ -1,0 +1,2 @@
+def get_scaffold(molecule, adjustHcount=False):
+    raise NotImplementedError


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

An attempt to make the `AtomMapper` optionally require OEChem, by either taking an OEMol or openff.Molecule object.  N.B. I'm not sure if this is even the right approach, as an openff Molecule can also be either an rdkit or oechem currently, so maybe a better approach is to completely commit to OpenFF objects (as it is already also OEChem) and instead "undress" the openff molecule invisibly to the user.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #820 ?

This is mostly just an afternoon of seeing how baked in OEChem is, and if removal is possible, it seems reasonable.

I was also reading up on the state of LOMAP ([here](https://github.com/MobleyLab/Lomap/pull/54) in particular) and it seems like ultimately many of the implementations I'll need to do this already will exist there (or directly in rdkit, see above), but I agree with the discussion there that this API is more manageable.

I'm happy developing on this branch (and into perses) for now, but ultimately a way forward might be to lift AtomMapper (et al) out into a "Lomap3" package which is maintained by OpenFE.  Still mulling that idea over, but what are the thoughts of removing this class from Perses and having OpenFE supply a dependency?