### PR TITLE
Allow `generate_dipeptide_top_pos_sys` to accept `demap_CBs`

### DIFF
--- a/perses/tests/test_topology_proposal.py
+++ b/perses/tests/test_topology_proposal.py
@@ -202,6 +202,7 @@ def generate_dipeptide_top_pos_sys(topology,
                                    positions,
                                    system_generator,
                                    extra_sidechain_map=None,
+                                   demap_CBs=False,
                                    conduct_geometry_prop=True,
                                    conduct_htf_prop = False,
                                    validate_energy_bookkeeping=True,
@@ -227,7 +228,7 @@ def generate_dipeptide_top_pos_sys(topology,
 
     # Create a top proposal
     print(f"making topology proposal")
-    topology_proposal = point_mutation_engine.propose(current_system=system, current_topology=topology, extra_sidechain_map=extra_sidechain_map)
+    topology_proposal = point_mutation_engine.propose(current_system=system, current_topology=topology, extra_sidechain_map=extra_sidechain_map, demap_CBs=demap_CBs)
 
     if not conduct_geometry_prop:
         return topology_proposal


### PR DESCRIPTION
## Description

This PR piggy backs off of https://github.com/choderalab/perses/pull/860, where I forgot to allow `demap_CBs` to be passed to `generate_dipeptide_top_pos_sys`.

## Motivation and context

This is necessary because to enable generating protein mutation test systems with demapped CBs.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
