### PR TITLE
add installation instructions to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ without warning. If you do use this code, do so at your own risk. We appreciate 
 about potential problems with the code, but may not be able to address your issue until other development activities
 have concluded.
 
+## Install
+
+See our installation instructions [here](https://perses.readthedocs.io/en/latest/installation.html).
+
+### Quick Start
+
+In a fresh conda environment:
+
+```
+$ conda config --add channels conda-forge openeye
+$ conda install perses openeye-toolkits
+```
+
 ## Manifest
 
 * `perses/` - Package containing code for performing expanded ensemble simulations


### PR DESCRIPTION
## Description

Our readme didn't have how to install perses, so I added a quick start and also linked our more thorough documentation.

