### PR TITLE
Disable CI failure if codecov fails 

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -94,4 +94,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/.github/workflows/self-hosted-gpu-test.yml
+++ b/.github/workflows/self-hosted-gpu-test.yml
@@ -109,7 +109,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./perses/coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false
 
   stop-runner:
     name: Stop self-hosted EC2 runner


### PR DESCRIPTION
Quick change to ignore issues we hare having with codecov while we wait to hear from them:
https://community.codecov.com/t/too-many-uploads-to-this-commit-code-invalid/3384