### PR TITLE
Fix water selection for counterion

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -559,7 +559,7 @@ class PolymerProposalEngine(ProposalEngine):
         # Create trajectory
         traj = md.Trajectory(new_positions[np.newaxis, ...], md.Topology.from_openmm(new_topology))
 
-        # Define water_atoms and query_atoms
+        # Define water atoms and query atoms (the latter should encompass all non water/ion atoms)
         water_atoms = traj.topology.select(f"water")
         ion_selection = [f'not resn {ion}' for ion in ion_names]
         ion_selection_final = ' and '.join(ion_selection)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

Currently, we choose a water at least X nm from protein to change into an ion. If there are glycan residues, the current implementation is incorrect, as a water may be chosen near a glycan, which we don't want. 

This PR changes the selection string from `protein` to `not water and not resn NA and not resn CL and not resn ZN`. The ions in the selection string may be supplied to the method as a list of strings.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
