### PR TITLE
Fix atom masses in vanilla HybridTopologyFactory

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2534,9 +2534,6 @@ class RepartitionedHybridTopologyFactory(HybridTopologyFactory):
         hybrid_to_old_map = self._hybrid_to_old_map
         hybrid_to_new_map = self._hybrid_to_new_map
 
-        #create the forces...
-        self._hybrid_system_forces['NonbondedForce'] = openmm.NonbondedForce()
-
         for particle_index in range(self._hybrid_system.getNumParticles()):
             if particle_index in self._atom_classes['unique_old_atoms']:
                 scale = 0.0 if self._endstate == 1 else 1.0

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -237,13 +237,20 @@ class HybridTopologyFactory(object):
         # TODO: Refactor this into self._add_particles()
         _logger.info("Adding and mapping old atoms to hybrid system...")
         for particle_idx in range(self._topology_proposal.n_atoms_old):
-            particle_mass = self._old_system.getParticleMass(particle_idx)
+            particle_mass_old = self._old_system.getParticleMass(particle_idx)
+            
+            if particle_idx in self._topology_proposal.old_to_new_atom_map.keys():
+                particle_index_in_new_system = self._topology_proposal.old_to_new_atom_map[particle_idx]
+                particle_mass_new = self._new_system.getParticleMass(particle_index_in_new_system)
+                particle_mass = (particle_mass_old + particle_mass_new) / 2 # Take the average of the masses if the atom is mapped
+            else:
+                particle_mass = particle_mass_old
+            
             hybrid_idx = self._hybrid_system.addParticle(particle_mass)
             self._old_to_hybrid_map[particle_idx] = hybrid_idx
 
             # If the particle index in question is mapped, make sure to add it to the new to hybrid map as well.
             if particle_idx in self._topology_proposal.old_to_new_atom_map.keys():
-                particle_index_in_new_system = self._topology_proposal.old_to_new_atom_map[particle_idx]
                 self._new_to_hybrid_map[particle_index_in_new_system] = hybrid_idx
 
         # Next, add the remaining unique atoms from the new system to the hybrid system and map accordingly.


### PR DESCRIPTION
## Description
Takes the average of old and new system masses for mapped (environment/core) atoms.

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Currently, the `HybridTopologyFactory` adds all environment/core/unique old atoms to the hybrid system using the mass of the particle in the old system. It then adds unique new atoms using the mass of the particle in the new system.

To improve stability, we want to average the old and new system masses for any mapped atom (environment/core atoms). 

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #910

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
