### PR TITLE
Fix box vector handling in topology proposal

### DIFF
--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -170,6 +170,7 @@ def append_topology(destination_topology, source_topology, exclude_residue_name=
         If specified, any residues matching this name are excluded.
 
     """
+    destination_topology.setPeriodicBoxVectors(source_topology.getPeriodicBoxVectors())
     if exclude_residue_name is None:
         exclude_residue_name = "   " #something with 3 characters that is never a residue name
     new_atoms = {}
@@ -696,9 +697,6 @@ class PolymerProposalEngine(ProposalEngine):
         # new_chemical_state_key : str
         new_chemical_state_key = self.compute_state_key(new_topology)
         # new_system : simtk.openmm.System
-
-        # Copy periodic box vectors from current topology
-        new_topology.setPeriodicBoxVectors(current_topology.getPeriodicBoxVectors())
 
         # Build system
         # TODO: Remove build_system() branch once we convert entirely to new openmm-forcefields SystemBuilder


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This PR makes sure that when a source topology is being copied to a destination topology, the source topology's box vectors are copied to the destination topology.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
OpenMM only writes out box vectors to DCD files if the `topology.getPeriodicBoxVectors()` is not None: https://github.com/openmm/openmm/issues/3418

I ran a simulation and the box vectors were not saved because `htf._topology_proposal.old_topology` does not have box vectors. This PR addresses the problem by adding a line that copies the box vectors from the source to destination topology in `append_topology()`. It removes the line in `_propose()` that does this for the new topology only.


## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
