### PR TITLE
Stop uploading coverage reports on nightly CI runs

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -91,7 +91,9 @@ jobs:
           popd
 
       - name: Codecov
+        if: ${{ github.repository == 'choderalab/perses'
+                && github.event != 'schedule' }}
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true

--- a/.github/workflows/self-hosted-gpu-test.yml
+++ b/.github/workflows/self-hosted-gpu-test.yml
@@ -106,10 +106,12 @@ jobs:
           pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "gpu_ci or gpu_needed"
 
       - name: Codecov
+        if: ${{ github.repository == 'choderalab/perses'
+                && github.event != 'schedule' }}
         uses: codecov/codecov-action@v1
         with:
           file: ./perses/coverage.xml
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
   stop-runner:
     name: Stop self-hosted EC2 runner


### PR DESCRIPTION
We had an issue where codecov would fail to upload reports when we uploaded too many with the same commit hash, this will prevent reports being uploaded when we don't expect anything to change.