### PR TITLE
Fixes to visualization module

### DIFF
--- a/perses/tests/test_visualization.py
+++ b/perses/tests/test_visualization.py
@@ -18,9 +18,9 @@ def test_protein_mutation():
     v.load()
     v.format(zoom_distance=3, rotate_x_angle=270, rotate_y_angle=180, rotate_z_angle=270)
     v.save_frames(outfile_prefix=os.path.join(input_directory, "frame"), dpi=300, equilibration_frames=2)
-    frames = [os.path.join(input_directory, "frame-%05d.png" % (i)) for i in range(10)]
+    frames = [os.path.join(input_directory, "frame-%05d.png" % (i)) for i in range(1, 11)]
     v.save_mp4(frames, outfile=os.path.join(input_directory, "movie.mp4"), fps=5)
-    for i in range(10):
+    for i in range(1, 11):
         os.remove(os.path.join(input_directory, "frame-%05d.png" % (i)))
     os.remove(os.path.join(input_directory, "movie.mp4"))
 
@@ -38,8 +38,8 @@ def test_small_molecule():
     v.load()
     v.format(zoom_distance=3, rotate_x_angle=180, rotate_y_angle=180, rotate_z_angle=270)
     v.save_frames(outfile_prefix=os.path.join(input_directory, "frame"), dpi=300, equilibration_frames=2)
-    frames = [os.path.join(input_directory, "frame-%05d.png" % (i)) for i in range(10)]
+    frames = [os.path.join(input_directory, "frame-%05d.png" % (i)) for i in range(1, 11)]
     v.save_mp4(frames, outfile=os.path.join(input_directory, "movie.mp4"), fps=5)
-    for i in range(10):
+    for i in range(1, 11):
         os.remove(os.path.join(input_directory, "frame-%05d.png" % (i)))
     os.remove(os.path.join(input_directory, "movie.mp4"))


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. -->
Make fixes to the visualization module related to:
- Pymol frames are 1-indexed, but the module had been assuming it was 0-indexed
- Bug: `self._unique_old/new` should be `self._unique_old/new_selection`
- Renaming an object after loading isn't working, so instead, just load the objects as `old` and `new` directly
- Allow color of old residue to be different from the color of the new residue
- Change background protein transparency
- Remove "hide spheres" when we are using stick representation (shouldn't be necessary)
- Do not allow stick/sphere transparencies to fade to transparency 1.0 (completely transparent) -- make the max transparency 0.7, as there are weird visual artifacts when it is 1.0 (the stick/sphere looks white)
- Clarifications to comments/docstrings

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
