### PR TITLE
Fix slow CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -90,7 +90,7 @@ jobs:
         shell: bash -l {0}
         run: |
           export TRAVIS=true
-          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" 
+          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" perses/tests
 
       - name: Codecov
         if: ${{ github.repository == 'choderalab/perses'


### PR DESCRIPTION
## Description

Our CI is taking longer than it should because some tests are not being skipped correctly. 

## Motivation and context

We are currently running tests in a suboptimal way. Because we don't include the `perses/tests` as the last argument to pytest, ti doesn't see our `conftest.py` which means fixtures and markers may not be detected correctly. For example, running `pytest --markers` on `main` will not print these markers:
```
@pytest.mark.slow: mark test as slow to run
@pytest.mark.gpu_ci: mark test as useful to run on GPU
@pytest.mark.gpu_needed: mark test as GPU required
```
But running `pytest --markers perses/tests` will.
## How has this been tested?

Locally and on CI

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
