### PR TITLE
Fix endstate energy validation test for flattened htfs

### DIFF
--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -855,6 +855,9 @@ def flattenedHybridTopologyFactory_energies(topology, chain, system, positions, 
 
         # Create geometry proposals
         for _ in range(5):
+            # We do not allow the geometry engine to conduct energy validation for ring amino acids because we insert
+            # biasing torsions for ring transformations (to ensure the amino acids are somewhat in the right geometry),
+            # which will corrupt the energy addition during energy validation.
             validate_energy_bookkeeping = False if mutant in ring_amino_acids else True
             new_positions, logp_proposal = geometry_engine.propose(topology_proposal, positions, beta,
                                                                        validate_energy_bookkeeping=validate_energy_bookkeeping)

--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -802,10 +802,11 @@ def flattenedHybridTopologyFactory_energies(topology, chain, system, positions, 
     from perses.annihilation.relative import RepartitionedHybridTopologyFactory
     from perses.tests.utils import validate_endstate_energies
 
+    ring_amino_acids = ['TYR', 'PHE', 'TRP', 'PRO', 'HIS', 'HID', 'HIE', 'HIP']
     ENERGY_THRESHOLD = 1e-6 #kJ/mol
 
     # Create point mutation engine to mutate residue at id 2 to a random amino acid
-    aminos_updated = [amino for amino in aminos if amino not in ['ALA', 'PRO', 'HIS', 'TRP', 'PHE', 'TYR']]
+    aminos_updated = [amino for amino in aminos if amino not in ['ALA', 'PRO']]
     mutant = random.choice(aminos_updated)
     print(f'Making mutation ALA->{mutant}')
     point_mutation_engine = PointMutationEngine(wildtype_topology=topology,
@@ -854,10 +855,11 @@ def flattenedHybridTopologyFactory_energies(topology, chain, system, positions, 
 
         # Create geometry proposals
         for _ in range(5):
+            validate_energy_bookkeeping = False if mutant in ring_amino_acids else True
             new_positions, logp_proposal = geometry_engine.propose(topology_proposal, positions, beta,
-                                                                       validate_energy_bookkeeping=True)
+                                                                       validate_energy_bookkeeping=validate_energy_bookkeeping)
             logp_reverse = geometry_engine.logp_reverse(topology_proposal, new_positions, positions, beta,
-                                                    validate_energy_bookkeeping=True)
+                                                    validate_energy_bookkeeping=validate_energy_bookkeeping)
             # Check potential energy
             platform = openmm.Platform.getPlatformByName('Reference')
             integrator = LangevinIntegrator(temperature=temperature)


### PR DESCRIPTION
## Description

`flattenedHybridTopologyFactory_energies` was not passing for transformations involving ring amino acids because `validate_energy_bookkeeping` was always set to `True` in the function. It should only be set to `True` if it doesn't involve the transformation does not involve a ring amino acid.

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
