### PR TITLE
add small molecule charge change support with test

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -116,7 +116,7 @@ class PointMutationExecutor(object):
         arguments
             protein_filename : str
                 path to protein (to mutate); .pdb
-                Note: if there are nonstandard residues, the PDB should contain the standard residue name but the atoms/positions should correspond to the nonstandard residue. E.g. if I want to include HID, the PDB should contain HIS for the residue name, but the atoms should correspond to the atoms present in HID. You can use openmm.app.Modeller.addHydrogens() to generate a PDB like this. The same is true for the ligand_input, if its a PDB. 
+                Note: if there are nonstandard residues, the PDB should contain the standard residue name but the atoms/positions should correspond to the nonstandard residue. E.g. if I want to include HID, the PDB should contain HIS for the residue name, but the atoms should correspond to the atoms present in HID. You can use openmm.app.Modeller.addHydrogens() to generate a PDB like this. The same is true for the ligand_input, if its a PDB.
             mutation_chain_id : str
                 name of the chain to be mutated
             mutation_residue_id : str
@@ -312,15 +312,7 @@ class PointMutationExecutor(object):
                                                         validate_energy_bookkeeping=validate_bool)
 
             # Check for charge change...
-            charge_diff = point_mutation_engine._get_charge_difference(current_resname=topology_proposal.old_topology.residue_topology.name,
-                                                                       new_resname=topology_proposal.new_topology.residue_topology.name)
-            _logger.info(f"charge diff: {charge_diff}")
-            if charge_diff != 0:
-                new_water_indices_to_ionize = point_mutation_engine.get_water_indices(charge_diff, new_positions, topology_proposal.new_topology, radius=0.8)
-                _logger.info(f"new water indices to ionize {new_water_indices_to_ionize}")
-                self._get_ion_and_water_parameters(topology_proposal.old_system, topology_proposal.old_topology)
-                self._transform_waters_into_ions(new_water_indices_to_ionize, topology_proposal.new_system, charge_diff)
-                PointMutationExecutor._modify_atom_classes(new_water_indices_to_ionize, topology_proposal)
+            self._handle_charge_changes(topology_proposal, new_positions)
 
             if generate_unmodified_hybrid_topology_factory:
                 repartitioned_endstate = None
@@ -408,124 +400,6 @@ class PointMutationExecutor(object):
     def get_apo_rhtf_1(self):
         return self.apo_rhtf_1
 
-    def _get_ion_and_water_parameters(self, system, topology, positive_ion_name="NA", negative_ion_name="CL", water_name="HOH"):
-        '''
-        Get the charge, sigma, and epsilon for the positive and negative ions. Also get the charge of the water atoms. Set
-        these parameters as class variables.
-
-        Parameters
-        ----------
-        system : simtk.openmm.System
-            the system from which to retrieve parameters
-        topology : app.Topology
-            the topology corresponding to the above system from which to retrieve atom indices
-        positive_ion_name : str, "NA"
-            the residue name of each positive ion
-        negative_ion_name : str, "CL"
-            the residue name of each negative ion
-        water_name : str, "HOH"
-            the residue name of each water
-
-        '''
-
-        # Get the indices
-        pos_index = None
-        neg_index = None
-        O_index = None
-        H_index = None
-        for atom in topology.atoms():
-            if atom.residue.name == positive_ion_name and not pos_index:
-                pos_index = atom.index
-            elif atom.residue.name == negative_ion_name and not neg_index:
-                neg_index = atom.index
-            elif atom.residue.name == water_name and (not O_index or not H_index):
-                if atom.name == 'O':
-                    O_index = atom.index
-                elif atom.name == 'H1':
-                    H_index = atom.index
-        assert pos_index is not None, f"Error occurred when trying to turn a water into an ion: No positive ions with residue name {positive_ion_name} found"
-        assert neg_index is not None, f"Error occurred when trying to turn a water into an ion: No negative ions with residue name {negative_ion_name} found"
-        assert O_index is not None, f"Error occurred when trying to turn a water into an ion: No O atoms with residue name {water_name} and atom name O found"
-        assert H_index is not None, f"Error occurred when trying to turn a water into an ion: No water atoms with residue name {water_name} and atom name H1 found"
-
-        # Get parameters from nonbonded force
-        force_dict = {i.__class__.__name__: i for i in system.getForces()}
-        if 'NonbondedForce' in [i for i in force_dict.keys()]:
-            nbf = force_dict['NonbondedForce']
-            pos_charge, pos_sigma, pos_epsilon = nbf.getParticleParameters(pos_index)
-            neg_charge, neg_sigma, neg_epsilon = nbf.getParticleParameters(neg_index)
-            O_charge, _, _ = nbf.getParticleParameters(O_index)
-            H_charge, _, _ = nbf.getParticleParameters(H_index)
-
-        self._pos_charge = pos_charge
-        self._pos_sigma = pos_sigma
-        self._pos_epsilon = pos_epsilon
-        self._neg_charge = neg_charge
-        self._neg_sigma = neg_sigma
-        self._neg_epsilon = neg_epsilon
-        self._O_charge = O_charge
-        self._H_charge = H_charge
-
-    def _transform_waters_into_ions(self, water_atoms, system, charge_diff):
-        """
-        given a system and an array of ints (corresponding to atoms to turn into ions), modify the nonbonded particle parameters in the system such that the Os are turned into the ion of interest and the charges of the Hs are zeroed.
-
-        Parameters
-        ----------
-        water_atoms : np.array(int)
-            integers corresponding to particle indices to neutralize
-        system : simtk.openmm.System
-            system to modify
-        charge_diff : int
-            the charge difference between the old_system - new_system
-
-        Returns
-        -------
-        modify system in place
-
-        """
-        # Determine which ion to turn the water into
-        if charge_diff < 0: # Turn water into Cl-
-            ion_charge, ion_sigma, ion_epsilon = self._neg_charge, self._neg_sigma, self._neg_epsilon
-        elif charge_diff > 0: # Turn water into Na+
-            ion_charge, ion_sigma, ion_epsilon = self._pos_charge, self._pos_sigma, self._pos_epsilon
-
-        # Scale the nonbonded terms of the water atoms
-        force_dict = {i.__class__.__name__: i for i in system.getForces()}
-        if 'NonbondedForce' in [i for i in force_dict.keys()]:
-            nbf = force_dict['NonbondedForce']
-            for idx in water_atoms:
-                idx = int(idx)
-                charge, sigma, epsilon = nbf.getParticleParameters(idx)
-                if charge == self._O_charge:
-                    nbf.setParticleParameters(idx, ion_charge, ion_sigma, ion_epsilon)
-                elif charge == self._H_charge:
-                    nbf.setParticleParameters(idx, charge*0.0, sigma, epsilon)
-                else:
-                    raise Exception(f"Trying to modify an atom that is not part of a water residue. Atom index: {idx}")
-
-    @staticmethod
-    def _modify_atom_classes(water_atoms, topology_proposal):
-        """
-        Modifies:
-        - topology proposal._core_new_to_old_atom_map - add the ion(s) to neutralize
-        - topology_proposal._new_environment_atoms - remove the ion(s) to neutralize
-        - topology_proposal._old_environment_atoms - remove the ion(s) to neutralize
-
-        Parameters
-        ----------
-        water_atoms : np.array(int)
-            integers corresponding to particle indices to turn into ions
-        topology_proposal : perses.rjmc.TopologyProposal
-            topology_proposal to modify
-
-        """
-        for new_index in water_atoms:
-            old_index = topology_proposal._new_to_old_atom_map[new_index]
-            topology_proposal._core_new_to_old_atom_map[new_index] = old_index
-            topology_proposal._new_environment_atoms.remove(new_index)
-            topology_proposal._old_environment_atoms.remove(old_index)
-
     def _solvate(self,
                topology,
                positions,
@@ -585,3 +459,34 @@ class PointMutationExecutor(object):
         solvated_system = self.system_generator.create_system(solvated_topology)
 
         return solvated_topology, solvated_positions, solvated_system
+
+    def _handle_charge_changes(self, topology_proposal, new_positions):
+        """
+        modifies the atom mapping in the topology proposal and the new system parameters to handle the transformation of
+        waters into appropriate counterions upon a charge-changing ligand transformation
+        """
+        from perses.utils.smallmolecules import get_ion_and_water_parameters, transform_waters_into_ions
+        from perses.rjmc.topology_proposal import modify_atom_classes
+
+        # use a different charge difference modifier
+        charge_diff = PointMutationEngine._get_charge_difference(topology_proposal.old_topology.residue_topology.name,
+                                                                 topology_proposal.new_topology.residue_topology.name)
+        if charge_diff != 0: # then handle this.
+            new_water_indices_to_ionize = SmallMoleculeSetProposalEngine.get_water_indices(charge_diff = charge_diff,
+                                                                                           new_positions = new_positions,
+                                                                                           new_topology = topology_proposal.new_topology,
+                                                                                           radius=0.8)
+            _logger.info(f"new water indices to ionize {new_water_indices_to_ionize}")
+            particle_parameters = get_ion_and_water_parameters(system=topology_proposal.old_system,
+                                                               topology = topology_proposal.old_system,
+                                                               positive_ion_name="NA",
+                                                               negative_ion_name="CL",
+                                                               water_name="HOH")
+            # modify new system in place
+            transform_waters_into_ions(water_atoms = new_water_indices_to_ionize,
+                                       system = topology_proposal._new_system,
+                                       charge_diff = charge_diff,
+                                       particle_parameter_dict = particle_parameters)
+
+            # modify the topology proposal
+            modify_atom_classes(new_water_indices_to_ionize, topology_proposal)

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -418,6 +418,8 @@ class RelativeFEPSetup(object):
                 self._complex_forward_neglected_angles = self._geometry_engine.forward_neglected_angle_terms
                 self._complex_reverse_neglected_angles = self._geometry_engine.reverse_neglected_angle_terms
             self._complex_geometry_engine = copy.deepcopy(self._geometry_engine)
+            self._handle_charge_changes(topology_proposal = self._complex_topology_proposal,
+                                        new_positions = self._complex_positions_new_solvated)
 
 
         if 'solvent' in phases:
@@ -470,6 +472,8 @@ class RelativeFEPSetup(object):
                 self._solvent_forward_neglected_angles = self._geometry_engine.forward_neglected_angle_terms
                 self._solvent_reverse_neglected_angles = self._geometry_engine.reverse_neglected_angle_terms
             self._solvent_geometry_engine = copy.deepcopy(self._geometry_engine)
+            self._handle_charge_changes(topology_proposal = self._solvent_topology_proposal,
+                                        new_positions = self._ligand_positions_new_solvated)
 
         if 'vacuum' in phases:
             _logger.info(f"Detected solvent...")
@@ -847,6 +851,34 @@ class RelativeFEPSetup(object):
             _logger.info('Both trajectory_directory and trajectory_prefix need to be provided to save .pdb')
 
         return solvated_topology, solvated_positions, solvated_system
+
+    def _handle_charge_changes(self, topology_proposal, new_positions):
+        """
+        modifies the atom mapping in the topology proposal and the new system parameters to handle the transformation of
+        waters into appropriate counterions upon a charge-changing ligand transformation
+        """
+        from perses.utils.smallmolecules import get_ion_and_water_parameters, transform_waters_into_ions
+        from perses.rjmc.topology_proposal import modify_atom_classes
+        charge_diff = SmallMoleculeSetProposalEngine._get_charge_difference(self._ligand_oemol_old, self._ligand_oemol_new)
+        if charge_diff != 0: # then handle this.
+            new_water_indices_to_ionize = SmallMoleculeSetProposalEngine.get_water_indices(charge_diff = charge_diff,
+                                                                                           new_positions = new_positions,
+                                                                                           new_topology = topology_proposal.new_topology,
+                                                                                           radius=0.8)
+            _logger.info(f"new water indices to ionize {new_water_indices_to_ionize}")
+            particle_parameters = get_ion_and_water_parameters(system=topology_proposal.old_system,
+                                                               topology = topology_proposal.old_system,
+                                                               positive_ion_name="NA",
+                                                               negative_ion_name="CL",
+                                                               water_name="HOH")
+            # modify new system in place
+            transform_waters_into_ions(water_atoms = new_water_indices_to_ionize,
+                                       system = topology_proposal._new_system,
+                                       charge_diff = charge_diff,
+                                       particle_parameter_dict = particle_parameters)
+
+            # modify the topology proposal
+            modify_atom_classes(new_water_indices_to_ionize, topology_proposal)
 
     @property
     def complex_topology_proposal(self):

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -436,6 +436,85 @@ class ProposalEngine(object):
     def chemical_state_list(self):
         raise NotImplementedError("This ProposalEngine does not expose a list of possible chemical states.")
 
+    @staticmethod
+    def _get_charge_difference(current_oemol, new_oemol):
+        """
+        return the charge of the old res - charge new res
+
+        Parameters
+        ----------
+        current_resname : str
+            three letter identifier for original residue
+        new_resname : str
+            three letter identifier for new residue
+
+        Returns
+        -------
+        chargediff : int
+            charge(old_res) - charge(old_res)
+        """
+        # retrieve the total charge
+        old_charge = sum([atom.GetFormalCharge() for atom in current_oemol.GetAtoms()])
+        new_charge = sum([atom.GetFormalCharge() for atom in new_oemol.GetAtoms()])
+        total_chargediff = old_charge - new_charge
+        assert type(total_chargediff) == int
+        return total_chargediff
+
+    @staticmethod
+    def get_water_indices(charge_diff,
+                               new_positions,
+                               new_topology,
+                               radius=0.8):
+        """
+        Choose random water(s) (at least `radius` nm away from the protein) to turn into ion(s). Returns the atom indices of the water(s) (index w.r.t. new_topology)
+
+        Parameters
+        ----------
+        charge_diff : int
+            the charge difference between the old_system - new_system
+        new_positions : np.ndarray(N, 3)
+            positions (nm) of atoms corresponding to new_topology
+        new_topology : openmm.Topology
+            topology of new system
+        radius : float, default 0.8
+            minimum distance (in nm) that all candidate waters must be from 'protein atoms'
+
+        Returns
+        -------
+        ion_indices : np.array(abs(charge_diff)*3)
+            indices of water atoms to be turned into ions
+        """
+
+        import mdtraj as md
+        from mdtraj.core.residue_names import _SOLVENT_TYPES
+
+        # Create trajectory
+        traj = md.Trajectory(new_positions[np.newaxis, ...], md.Topology.from_openmm(new_topology))
+
+        # Define water atoms
+        water_atoms = traj.topology.select("water")
+
+        # Define solute atoms
+        # TODO: Update this once we either (1) get solvent as a keyword into the MDTraj DSL, or (2) transition to MDAnalysis
+        solvent_types = list(_SOLVENT_TYPES)
+        solute_atoms = [atom.index for atom in traj.topology.atoms if atom.residue.name not in solvent_types]
+
+        # Get water atoms within radius of protein
+        neighboring_atoms = md.compute_neighbors(traj, radius, solute_atoms, haystack_indices=water_atoms)[0]
+
+        # Get water atoms outside of radius of protein
+        nonneighboring_residues = set([atom.residue.index for atom in traj.topology.atoms if (atom.index in water_atoms) and (atom.index not in neighboring_atoms)])
+        assert len(nonneighboring_residues) > 0, "there are no available nonneighboring waters"
+        # Choose N random nonneighboring waters, where N is determined based on the charge_diff
+        choice_residues = np.random.choice(list(nonneighboring_residues), size=abs(charge_diff), replace=False)
+
+        # Get the atom indices in the water(s)
+        choice_indices = np.array([[atom.index for atom in traj.topology.residue(res).atoms] for res in choice_residues])
+
+        return np.ndarray.flatten(choice_indices)
+
+
+
 class PolymerProposalEngine(ProposalEngine):
     """
     Base class for ProposalEngine implementations that modify polymer components of systems.
@@ -527,60 +606,6 @@ class PolymerProposalEngine(ProposalEngine):
                 resname_to_charge[resname] += 1
 
         return resname_to_charge[current_resname] - resname_to_charge[new_resname]
-
-    @staticmethod
-    def get_water_indices(charge_diff,
-                               new_positions,
-                               new_topology,
-                               radius=0.8):
-        """
-        Choose random water(s) (at least `radius` nm away from the protein) to turn into ion(s). Returns the atom indices of the water(s) (index w.r.t. new_topology)
-
-        Parameters
-        ----------
-        charge_diff : int
-            the charge difference between the old_system - new_system
-        new_positions : np.ndarray(N, 3)
-            positions (nm) of atoms corresponding to new_topology
-        new_topology : openmm.Topology
-            topology of new system
-        radius : float, default 0.8
-            minimum distance (in nm) that all candidate waters must be from 'protein atoms'
-
-        Returns
-        -------
-        ion_indices : np.array(abs(charge_diff)*3)
-            indices of water atoms to be turned into ions
-        """
-
-        import mdtraj as md
-        from mdtraj.core.residue_names import _SOLVENT_TYPES
-
-        # Create trajectory
-        traj = md.Trajectory(new_positions[np.newaxis, ...], md.Topology.from_openmm(new_topology))
-
-        # Define water atoms
-        water_atoms = traj.topology.select("water")
-
-        # Define solute atoms
-        # TODO: Update this once we either (1) get solvent as a keyword into the MDTraj DSL, or (2) transition to MDAnalysis
-        solvent_types = list(_SOLVENT_TYPES)
-        solute_atoms = [atom.index for atom in traj.topology.atoms if atom.residue.name not in solvent_types]
-
-        # Get water atoms within radius of protein
-        neighboring_atoms = md.compute_neighbors(traj, radius, solute_atoms, haystack_indices=water_atoms)[0]
-
-        # Get water atoms outside of radius of protein
-        nonneighboring_residues = set([atom.residue.index for atom in traj.topology.atoms if (atom.index in water_atoms) and (atom.index not in neighboring_atoms)])
-        assert len(nonneighboring_residues) > 0, "there are no available nonneighboring waters"
-        # Choose N random nonneighboring waters, where N is determined based on the charge_diff
-        choice_residues = np.random.choice(list(nonneighboring_residues), size=abs(charge_diff), replace=False)
-
-        # Get the atom indices in the water(s)
-        choice_indices = np.array([[atom.index for atom in traj.topology.residue(res).atoms] for res in choice_residues])
-
-        return np.ndarray.flatten(choice_indices)
-
 
 
     def propose(self,
@@ -1119,14 +1144,14 @@ class PolymerProposalEngine(ProposalEngine):
                             demap_CBs=False):
         """
         Construct atom map (key: index to atom in new residue, value: index to atom in old residue) to supply as an argument to the TopologyProposal.
-        
+
         By default, the atom map:
         1) Maps all backbone atoms (exception: for GLY, do not map HA2 and HA3)
         2) Map CBs only (no other sidechain atoms)
-        
+
         If additional sidechains should be mapped, extra_sidechain_map can be supplied to supplement the default map.
         If CBs should be demapped, set demap_CBs=True.
-        
+
         Parameters
         ----------
         residue_map : list(tuples)
@@ -1159,7 +1184,7 @@ class PolymerProposalEngine(ProposalEngine):
         """
         from pkg_resources import resource_filename
         import openeye.oechem as oechem
-        
+
         # Retrieve map of old to new residues
         # old_to_new_residues : dict, key : simtk.openmm.app.topology.Residue old residue, value : simtk.openmm.app.topology.Residue new residue
         old_to_new_residues = {}
@@ -1195,7 +1220,7 @@ class PolymerProposalEngine(ProposalEngine):
         for atom in old_res.atoms():
             old_atom_index = atom.index
             old_atom_name = atom.name
-            
+
             if old_atom_name in backbone_atoms:
                 if old_res_name == 'GLY' and old_atom_name in ['HA2', 'HA3']: # Do not map HA if old residue GLY
                     continue
@@ -1204,14 +1229,14 @@ class PolymerProposalEngine(ProposalEngine):
                 else:
                     new_atom_index = new_res_name_to_index[old_atom_name]
                     local_atom_map[new_atom_index] = old_atom_index
-            
+
             elif old_atom_name in sidechain_atoms:
                 if new_res_name == 'GLY': # Do not map sidechain atoms if GLY
                     continue
                 else:
                     new_atom_index = new_res_name_to_index[old_atom_name]
                     local_atom_map[new_atom_index] = old_atom_index
-        
+
         # Validate extra_sidechain_map
         if extra_sidechain_map:
             assert type(extra_sidechain_map) is dict, "extra_sidechain_map must be a dict"
@@ -1219,15 +1244,15 @@ class PolymerProposalEngine(ProposalEngine):
             new_res_indices = [atom.index for atom in new_res.atoms()]
             assert all([index in new_res_indices for index in extra_sidechain_map.keys()]), "at least one of the new indices in extra_sidechain_map is not present in the new_topology"
             assert all([index in old_res_indices for index in extra_sidechain_map.values()]), "at least one of the new indices in extra_sidechain_map is not present in the old_topology"
-        
+
             # Add extra_sidechain_map to local_atom_map
             local_atom_map.update(extra_sidechain_map)
-        
+
         _logger.info(f"local_atom_map: {local_atom_map}")
-        
+
         mapped_atoms = [(new_res_index_to_name[new_idx], old_res_index_to_name[old_idx]) for new_idx, old_idx in local_atom_map.items()]
-        _logger.info(f"the mapped atom names are: {mapped_atoms}")            
-            
+        _logger.info(f"the mapped atom names are: {mapped_atoms}")
+
         # Retrieve old and new oemols
         old_residue_pdb_filename = resource_filename('perses', os.path.join('data', 'amino_acid_templates', f"{old_res_name}.pdb"))
         new_residue_pdb_filename = resource_filename('perses', os.path.join('data', 'amino_acid_templates', f"{new_res_name}.pdb"))
@@ -1239,9 +1264,9 @@ class PolymerProposalEngine(ProposalEngine):
         # new_res_to_oemol_map : dict, key : int new atom index (OpenMM topology), value : int new atom index (oemol)
         old_res_to_oemol_map = {atom.index: old_oemol.GetAtom(oechem.OEHasAtomName(atom.name)).GetIdx() for atom in old_res.atoms()}
         new_res_to_oemol_map = {atom.index: new_oemol.GetAtom(oechem.OEHasAtomName(atom.name)).GetIdx() for atom in new_res.atoms()}
-            
+
         return local_atom_map, old_res_to_oemol_map, new_res_to_oemol_map, old_oemol, new_oemol
-    
+
 
     def _get_mol_atom_matches(self, current_molecule, proposed_molecule, first_atom_index_old, first_atom_index_new):
         """
@@ -2585,3 +2610,24 @@ class SmallMoleculeSetProposalEngine(ProposalEngine):
                 pass
         removed_smiles = smiles_set.difference(safe_smiles)
         return safe_smiles, removed_smiles
+
+def modify_atom_classes(water_atoms, topology_proposal):
+    """
+    Modifies:
+    - topology proposal._core_new_to_old_atom_map - add the ion(s) to neutralize
+    - topology_proposal._new_environment_atoms - remove the ion(s) to neutralize
+    - topology_proposal._old_environment_atoms - remove the ion(s) to neutralize
+
+    Parameters
+    ----------
+    water_atoms : np.array(int)
+        integers corresponding to particle indices to turn into ions
+    topology_proposal : perses.rjmc.TopologyProposal
+        topology_proposal to modify
+
+    """
+    for new_index in water_atoms:
+        old_index = topology_proposal._new_to_old_atom_map[new_index]
+        topology_proposal._core_new_to_old_atom_map[new_index] = old_index
+        topology_proposal._new_environment_atoms.remove(new_index)
+        topology_proposal._old_environment_atoms.remove(old_index)

--- a/perses/tests/test_relative_setup.py
+++ b/perses/tests/test_relative_setup.py
@@ -255,5 +255,55 @@ def test_host_guest_deterministic_geometries():
                  use_given_geometries = True
                  )
 
+def test_relative_setup_charge_change():
+    """
+    execute `RelativeFEPSetup` in solvent/complex phase on a charge change and assert that the modified new system and old system charge difference is zero.
+    also assert endstate validation.
+    """
+    from perses.app.relative_setup import RelativeFEPSetup
+    import numpy as np
+    # Setup directory
+    ligand_sdf = resource_filename("perses", "data/bace-example/Bace_ligands_shifted.sdf")
+    host_pdb = resource_filename("perses", "data/bace-example/Bace_protein.pdb/receptor.pdb")
+
+    setup = RelativeFEPSetup(
+                 ligand_input = ligand_sdf,
+                 old_ligand_index=0,
+                 new_ligand_index=12,
+                 forcefield_files = ['amber/ff14SB.xml','amber/tip3p_standard.xml','amber/tip3p_HFE_multivalent.xml'],
+                 phases = ['solvent', 'vacuum'],
+                 protein_pdb_filename=host_pdb,
+                 receptor_mol2_filename=None,
+                 pressure=1.0 * unit.atmosphere,
+                 temperature=300.0 * unit.kelvin,
+                 solvent_padding=9.0 * unit.angstroms,
+                 ionic_strength=0.15 * unit.molar,
+                 hmass=4*unit.amus,
+                 neglect_angles=False,
+                 map_strength='default',
+                 atom_expr=None,
+                 bond_expr=None,
+                 anneal_14s=False,
+                 small_molecule_forcefield='gaff-2.11',
+                 small_molecule_parameters_cache=None,
+                 trajectory_directory=None,
+                 trajectory_prefix=None,
+                 spectator_filenames=None,
+                 nonbonded_method = 'PME',
+                 complex_box_dimensions=None,
+                 solvent_box_dimensions=None,
+                 remove_constraints=False,
+                 use_given_geometries = False
+                 )
+
+    # sum all of the charges of topology.
+    """strictly speaking, this is redundant because endstate validation is done in the `RelativeFEPSetup`"""
+    old_nbf = [force for force in setup._solvent_topology_proposal._old_system.getForces() if force.__class__.__name__ == 'NonbondedForce'][0]
+    new_nbf = [force for force in setup._solvent_topology_proposal._new_system.getForces() if force.__class__.__name__ == 'NonbondedForce'][0]
+    old_system_charge_sum = sum([old_nbf.getParticleParameters(i)[0].value_in_unit_system(unit.md_unit_system) for i in range(old_nbf.getNumParticles())])
+    new_system_charge_sum = sum([old_nbf.getParticleParameters(i)[0].value_in_unit_system(unit.md_unit_system) for i in range(new_nbf.getNumParticles())])
+    charge_diff = int(old_system_charge_sum - new_system_charge_sum)
+    assert np.isclose(charge_diff, 0), f"charge diff is {charge_diff} but should be zero."
+
 # if __name__=="__main__":
 #     test_run_cdk2_iterations_repex()

--- a/perses/utils/smallmolecules.py
+++ b/perses/utils/smallmolecules.py
@@ -284,7 +284,7 @@ def render_protein_residue_atom_mapping(topology_proposal, filename, width = 120
         width : int
             width of image
         height : int
-            height of image 
+            height of image
     """
     from perses.utils.smallmolecules import render_atom_mapping
     oe_res_maps = {}
@@ -350,3 +350,108 @@ def generate_ligands_figure(molecules,figsize=None,filename='ligands.png'):
     oedepict.OEWriteImage(filename, image)
 
     return
+
+def get_ion_and_water_parameters(system, topology, positive_ion_name="NA", negative_ion_name="CL", water_name="HOH"):
+    '''
+    Get the charge, sigma, and epsilon for the positive and negative ions. Also get the charge of the water atoms.
+
+    Parameters
+    ----------
+    system : simtk.openmm.System
+        the system from which to retrieve parameters
+    topology : app.Topology
+        the topology corresponding to the above system from which to retrieve atom indices
+    positive_ion_name : str, "NA"
+        the residue name of each positive ion
+    negative_ion_name : str, "CL"
+        the residue name of each negative ion
+    water_name : str, "HOH"
+        the residue name of each water
+
+    Returns
+    -------
+    particle_parameter_dict : dict
+        parameter dict containing lookup parameters for water/ion nonbonded parameters.
+        Keys contain {pos_charge, pos_sigma, pos_epsilon, neg_charge, neg_sigma, neg_epsilon, O_charge, H_charge}
+
+    '''
+
+    # Get the indices
+    pos_index = None
+    neg_index = None
+    O_index = None
+    H_index = None
+    for atom in topology.atoms():
+        if atom.residue.name == positive_ion_name and not pos_index:
+            pos_index = atom.index
+        elif atom.residue.name == negative_ion_name and not neg_index:
+            neg_index = atom.index
+        elif atom.residue.name == water_name and (not O_index or not H_index):
+            if atom.name == 'O':
+                O_index = atom.index
+            elif atom.name == 'H1':
+                H_index = atom.index
+    assert pos_index is not None, f"Error occurred when trying to turn a water into an ion: No positive ions with residue name {positive_ion_name} found"
+    assert neg_index is not None, f"Error occurred when trying to turn a water into an ion: No negative ions with residue name {negative_ion_name} found"
+    assert O_index is not None, f"Error occurred when trying to turn a water into an ion: No O atoms with residue name {water_name} and atom name O found"
+    assert H_index is not None, f"Error occurred when trying to turn a water into an ion: No water atoms with residue name {water_name} and atom name H1 found"
+
+    # Get parameters from nonbonded force
+    force_dict = {i.__class__.__name__: i for i in system.getForces()}
+    if 'NonbondedForce' in [i for i in force_dict.keys()]:
+        nbf = force_dict['NonbondedForce']
+        pos_charge, pos_sigma, pos_epsilon = nbf.getParticleParameters(pos_index)
+        neg_charge, neg_sigma, neg_epsilon = nbf.getParticleParameters(neg_index)
+        O_charge, _, _ = nbf.getParticleParameters(O_index)
+        H_charge, _, _ = nbf.getParticleParameters(H_index)
+
+    particle_parameter_dict = {'pos_charge' : pos_charge,
+                               'pos_sigma' : pos_sigma,
+                               'pos_epsilon' : pos_epsilon,
+                               'neg_charge' : neg_charge,
+                               'neg_sigma' : neg_sigma,
+                               'neg_epsilon' : neg_epsilon,
+                               'O_charge' : O_charge,
+                               'H_charge' : H_charge}
+    return particle_parameter_dict
+
+def transform_waters_into_ions(water_atoms, system, charge_diff, particle_parameter_dict):
+    """
+    given a system and an array of ints (corresponding to atoms to turn into ions), modify the nonbonded particle parameters in the system such that the Os are turned into the ion of interest and the charges of the Hs are zeroed.
+
+    Parameters
+    ----------
+    water_atoms : np.array(int)
+        integers corresponding to particle indices to neutralize
+    system : simtk.openmm.System
+        system to modify
+    charge_diff : int
+        the charge difference between the old_system - new_system
+    particle_parameter_dict : dict
+        parameter dict containing lookup parameters for water/ion nonbonded parameters.
+        Keys contain {pos_charge, pos_sigma, pos_epsilon, neg_charge, neg_sigma, neg_epsilon, O_charge, H_charge}
+
+    Returns
+    -------
+    modify system in place
+    """
+    _dict = particle_parameter_dict
+    # Determine which ion to turn the water into
+    if charge_diff < 0: # Turn water into Cl-
+        ion_charge, ion_sigma, ion_epsilon = _dict['neg_charge'], _dict['neg_sigma'], _dict['neg_epsilon']
+    elif charge_diff > 0: # Turn water into Na+
+        ion_charge, ion_sigma, ion_epsilon = _dict['pos_charge'], _dict['pos_sigma'], _dict['pos_epsilon']
+
+    # Scale the nonbonded terms of the water atoms
+    force_dict = {i.__class__.__name__: i for i in system.getForces()}
+    if 'NonbondedForce' in [i for i in force_dict.keys()]:
+        nbf = force_dict['NonbondedForce']
+        for idx in water_atoms:
+            idx = int(idx)
+            charge, sigma, epsilon = nbf.getParticleParameters(idx)
+            if charge == _dict['O_charge']:
+                nbf.setParticleParameters(idx, ion_charge, ion_sigma, ion_epsilon)
+            elif charge == _dict['H_charge']:
+                nbf.setParticleParameters(idx, charge*0.0, sigma, epsilon)
+            else:
+                raise Exception(f"Trying to modify an atom that is not part of a water residue. Atom index: {idx}")


### PR DESCRIPTION
## Description

add small-molecule charge change support and attempt to generalize the existing protein mutation charge change functionality to avoid code duplication

## Motivation and context

adds [this support](https://github.com/choderalab/perses/issues/862)

## How has this been tested?

performs a `RelativeFEPSetup` on two `Bace` ligands with unequal charge, performs energy validation and asserts both systems are neutral after modification
