### PR TITLE
Benchmark DeltaG plots now shift data to experimental DeltaG mean.

### DIFF
--- a/benchmarks/benchmark_analysis.py
+++ b/benchmarks/benchmark_analysis.py
@@ -211,12 +211,12 @@ plotting.plot_DDGs(fe.graph,
                    figsize=5,
                    filename='./plot_relative.png'
                    )
-# Absolute plot
+# Absolute plot, with experimental data shifted to correct mean
+experimental_mean_dg = np.asarray([node[1]["exp_DG"] for node in fe.graph.nodes(data=True)]).mean()
 plotting.plot_DGs(fe.graph,
                   target_name=f'{target}',
                   title=f'Absolute binding energies - {target}',
                   figsize=5,
-                  filename='./plot_absolute.png'
+                  filename='./plot_absolute.png',
+                  shift=experimental_mean_dg,
                   )
-
-


### PR DESCRIPTION
## Description

Currently, the DeltaG calculated vs experiment comparison plots subtract the mean from both axes, leading to nonsensical experimental axes:
![espaloma-plot_absolute-mean](https://user-images.githubusercontent.com/3656088/162648330-973a2de0-8847-4700-afef-47622a3b8020.png)
This PR adds back the experimental mean free energy to both axes so that the experimental range is correct:
![image](https://user-images.githubusercontent.com/3656088/162648198-88987447-b86c-4cdf-9636-830c94002398.png)

cc: https://github.com/openforcefield/openff-arsenic/issues/42

## Motivation and context

Resolves what was originally suspected to be an issue with `openff-arsenic` but was just an incorrect usage:
https://github.com/openforcefield/openff-arsenic/issues/42
 
## How has this been tested?

The attached plot has been generated.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Benchmarking now produces a calculated versus experimental DeltaG plot that correctly centers both axes on the mean experimental binding free energy.
```
