### PR TITLE
Following upstream change in main branch name.

### DIFF
--- a/benchmarks/benchmark_analysis.py
+++ b/benchmarks/benchmark_analysis.py
@@ -153,7 +153,7 @@ def to_arsenic_csv(experimental_data: dict, simulation_data: list, out_csv: str 
 # Defining command line arguments
 # fetching targets from github repo
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
-targets_url = f"{base_repo_url}/raw/master/data/targets.yml"
+targets_url = f"{base_repo_url}/raw/main/data/targets.yml"
 with urllib.request.urlopen(targets_url) as response:
     targets_dict = yaml.safe_load(response.read())
 # get the possible choices from targets yaml file
@@ -178,9 +178,9 @@ target = args.target
 # Download experimental data
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
 # TODO: Let's cache this data when we set up the initial simulations in case it changes in between setting up and running the calculations and analysis.
-# TODO: Let's also be sure to use a specific release tag rather than 'master'
+# TODO: Let's also be sure to use a specific release tag rather than 'main'
 target_dir = targets_dict[target]['dir']
-ligands_url = f"{base_repo_url}/raw/master/data/{target_dir}/00_data/ligands.yml"
+ligands_url = f"{base_repo_url}/raw/main/data/{target_dir}/00_data/ligands.yml"
 with urllib.request.urlopen(ligands_url) as response:
     yaml_contents = response.read()
     print(yaml_contents)

--- a/benchmarks/run_benchmarks.py
+++ b/benchmarks/run_benchmarks.py
@@ -100,7 +100,7 @@ def run_relative_perturbation(lig_a_idx, lig_b_idx, reverse=False, tidy=True):
 # Defining command line arguments
 # fetching targets from github repo
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
-targets_url = f"{base_repo_url}/raw/master/data/targets.yml"
+targets_url = f"{base_repo_url}/raw/main/data/targets.yml"
 with fetch_url_contents(targets_url) as response:
     targets_dict = yaml.safe_load(response.read())
 # get the possible choices from targets yaml file
@@ -132,12 +132,12 @@ is_reversed = args.reversed
 # Fetch protein pdb file
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
 target_dir = targets_dict[target]['dir']
-pdb_url = f"{base_repo_url}/raw/master/data/{target_dir}/01_protein/crd/protein.pdb"
+pdb_url = f"{base_repo_url}/raw/main/data/{target_dir}/01_protein/crd/protein.pdb"
 pdb_file = retrieve_file_url(pdb_url)
 
 # Fetch cofactors crystalwater pdb file
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
-cofactors_url = f"{base_repo_url}/raw/master/data/{target_dir}/01_protein/crd/cofactors_crystalwater.pdb"
+cofactors_url = f"{base_repo_url}/raw/main/data/{target_dir}/01_protein/crd/cofactors_crystalwater.pdb"
 cofactors_file = retrieve_file_url(cofactors_url)
 
 # Concatenate protein with cofactors pdbs
@@ -145,12 +145,12 @@ concatenate_files((pdb_file, cofactors_file), 'target.pdb')
 
 # Fetch ligands sdf files and concatenate them in one
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
-ligands_url = f"{base_repo_url}/raw/master/data/{target_dir}/00_data/ligands.yml"
+ligands_url = f"{base_repo_url}/raw/main/data/{target_dir}/00_data/ligands.yml"
 with fetch_url_contents(ligands_url) as response:
     ligands_dict = yaml.safe_load(response.read())
 ligand_files = []
 for ligand in ligands_dict.keys():
-    ligand_url = f"{base_repo_url}/raw/master/data/{target_dir}/02_ligands/{ligand}/crd/{ligand}.sdf"
+    ligand_url = f"{base_repo_url}/raw/main/data/{target_dir}/02_ligands/{ligand}/crd/{ligand}.sdf"
     ligand_file = retrieve_file_url(ligand_url)
     ligand_files.append(ligand_file)
 # concatenate sdfs
@@ -159,7 +159,7 @@ concatenate_files(ligand_files, 'ligands.sdf')
 # run simulation
 # fetch edges information
 # TODO: This part should be done using plbenchmarks API - once there is a conda pkg
-edges_url = f"{base_repo_url}/raw/master/data/{target_dir}/00_data/edges.yml"
+edges_url = f"{base_repo_url}/raw/main/data/{target_dir}/00_data/edges.yml"
 with fetch_url_contents(edges_url) as response:
     edges_dict = yaml.safe_load(response.read())
 edges_list = list(edges_dict.values())  # suscriptable edges object - note dicts are ordered for py>=3.7


### PR DESCRIPTION
## Description

Changing the url strings for benchmarks.

## Motivation and context

Scripts were failing because the upstream branch was renamed to `main`.

## How has this been tested?

Local and HPC system runs of benchmarks

