### PR TITLE
Closing reporter in resume tests

### DIFF
--- a/perses/tests/test_resume.py
+++ b/perses/tests/test_resume.py
@@ -86,200 +86,207 @@ def test_cli_resume_repex():
 
 
 @pytest.mark.gpu_ci
-def test_resume_small_molecule(tmp_path):
+def test_resume_small_molecule():
 
-    os.chdir(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp_path:
+        os.chdir(tmp_path)
 
-    smiles_filename = resource_filename("perses", os.path.join("data", "test.smi"))
-    fe_setup = RelativeFEPSetup(
-        ligand_input=smiles_filename,
-        old_ligand_index=0,
-        new_ligand_index=1,
-        forcefield_files=[],
-        small_molecule_forcefield="gaff-2.11",
-        phases=["vacuum"],
-    )
+        smiles_filename = resource_filename("perses", os.path.join("data", "test.smi"))
+        fe_setup = RelativeFEPSetup(
+            ligand_input=smiles_filename,
+            old_ligand_index=0,
+            new_ligand_index=1,
+            forcefield_files=[],
+            small_molecule_forcefield="gaff-2.11",
+            phases=["vacuum"],
+        )
 
-    htf = HybridTopologyFactory(
-        topology_proposal=fe_setup._vacuum_topology_proposal,
-        current_positions=fe_setup._vacuum_positions_old,
-        new_positions=fe_setup._vacuum_positions_new,
-        neglected_new_angle_terms=fe_setup._vacuum_forward_neglected_angles,
-        neglected_old_angle_terms=fe_setup._vacuum_reverse_neglected_angles,
-        softcore_LJ_v2=True,
-        interpolate_old_and_new_14s=False,
-    )
+        htf = HybridTopologyFactory(
+            topology_proposal=fe_setup._vacuum_topology_proposal,
+            current_positions=fe_setup._vacuum_positions_old,
+            new_positions=fe_setup._vacuum_positions_new,
+            neglected_new_angle_terms=fe_setup._vacuum_forward_neglected_angles,
+            neglected_old_angle_terms=fe_setup._vacuum_reverse_neglected_angles,
+            softcore_LJ_v2=True,
+            interpolate_old_and_new_14s=False,
+        )
 
-    # Build the hybrid repex samplers
-    _logger = logging.getLogger()
-    _logger.setLevel(logging.DEBUG)
-    selection = "not water"
-    checkpoint_interval = 5
-    n_states = 3
-    n_cycles = 10
-    lambda_protocol = LambdaProtocol(functions="default")
-    reporter_file = tmp_path / "cdk2_solvent.nc"
-    reporter = MultiStateReporter(
-        reporter_file,
-        analysis_particle_indices=htf.hybrid_topology.select(selection),
-        checkpoint_interval=checkpoint_interval,
-    )
-    hss = HybridRepexSampler(
-        mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
-            timestep=4.0 * unit.femtoseconds,
-            collision_rate=5.0 / unit.picosecond,
-            n_steps=250,
-            reassign_velocities=False,
-            n_restart_attempts=20,
-            splitting="V R R R O R R R V",
-            constraint_tolerance=1e-06,
-        ),
-        hybrid_factory=htf,
-        online_analysis_interval=10,
-    )
-    hss.setup(
-        n_states=n_states,
-        temperature=300 * unit.kelvin,
-        storage_file=reporter,
-        lambda_protocol=lambda_protocol,
-    )
-    hss.extend(n_cycles)
-    del hss
+        # Build the hybrid repex samplers
+        _logger = logging.getLogger()
+        _logger.setLevel(logging.DEBUG)
+        selection = "not water"
+        checkpoint_interval = 5
+        n_states = 3
+        n_cycles = 10
+        lambda_protocol = LambdaProtocol(functions="default")
+        reporter_file = os.path.join(tmp_path, "cdk2_solvent.nc")
+        reporter = MultiStateReporter(
+            reporter_file,
+            analysis_particle_indices=htf.hybrid_topology.select(selection),
+            checkpoint_interval=checkpoint_interval,
+        )
+        hss = HybridRepexSampler(
+            mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
+                timestep=4.0 * unit.femtoseconds,
+                collision_rate=5.0 / unit.picosecond,
+                n_steps=250,
+                reassign_velocities=False,
+                n_restart_attempts=20,
+                splitting="V R R R O R R R V",
+                constraint_tolerance=1e-06,
+            ),
+            hybrid_factory=htf,
+            online_analysis_interval=10,
+        )
+        hss.setup(
+            n_states=n_states,
+            temperature=300 * unit.kelvin,
+            storage_file=reporter,
+            lambda_protocol=lambda_protocol,
+        )
+        hss.extend(n_cycles)
+        # Close reporter - Needed to avoid eventual fatal seg faults
+        reporter.close()
+        del hss
 
-    # Load repex simulation
-    reporter = MultiStateReporter(reporter_file, checkpoint_interval=10)
-    simulation = HybridRepexSampler.from_storage(reporter)
+        # Load repex simulation
+        reporter = MultiStateReporter(reporter_file, checkpoint_interval=10)
+        simulation = HybridRepexSampler.from_storage(reporter)
 
-    # Resume simulation
-    simulation.extend(5)
+        # Resume simulation
+        simulation.extend(5)
 
-    assert simulation.iteration == 15
+        assert simulation.iteration == 15
 
 
 @pytest.mark.gpu_ci
 def test_resume_protein_mutation_with_checkpoint(tmp_path):
 
-    os.chdir(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp_path:
+        os.chdir(tmp_path)
 
-    pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
-    solvent_delivery = PointMutationExecutor(
-        pdb_filename,
-        "1",
-        "2",
-        "THR",
-        flatten_torsions=True,
-        flatten_exceptions=True,
-        conduct_endstate_validation=False,
-        barostat=None,
-        phase="vacuum",
-        periodic_forcefield_kwargs=None,
-        nonperiodic_forcefield_kwargs={"nonbondedMethod": app.NoCutoff},
-    )
-    htf = solvent_delivery.get_apo_htf()
+        pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
+        solvent_delivery = PointMutationExecutor(
+            pdb_filename,
+            "1",
+            "2",
+            "THR",
+            flatten_torsions=True,
+            flatten_exceptions=True,
+            conduct_endstate_validation=False,
+            barostat=None,
+            phase="vacuum",
+            periodic_forcefield_kwargs=None,
+            nonperiodic_forcefield_kwargs={"nonbondedMethod": app.NoCutoff},
+        )
+        htf = solvent_delivery.get_apo_htf()
 
-    # Build the hybrid repex samplers
-    _logger = logging.getLogger()
-    _logger.setLevel(logging.DEBUG)
-    selection = "not water"
-    checkpoint_interval = 5
-    n_states = 3
-    n_cycles = 10
-    lambda_protocol = LambdaProtocol(functions="default")
-    reporter_file = tmp_path / "cdk2_solvent.nc"
-    reporter = MultiStateReporter(
-        reporter_file,
-        analysis_particle_indices=htf.hybrid_topology.select(selection),
-        checkpoint_interval=checkpoint_interval,
-    )
-    hss = HybridRepexSampler(
-        mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
-            timestep=4.0 * unit.femtoseconds,
-            collision_rate=5.0 / unit.picosecond,
-            n_steps=250,
-            reassign_velocities=False,
-            n_restart_attempts=20,
-            splitting="V R R R O R R R V",
-            constraint_tolerance=1e-06,
-        ),
-        hybrid_factory=htf,
-        online_analysis_interval=10,
-    )
-    hss.setup(
-        n_states=n_states,
-        temperature=300 * unit.kelvin,
-        storage_file=reporter,
-        lambda_protocol=lambda_protocol,
-    )
-    hss.extend(n_cycles)
-    del hss
+        # Build the hybrid repex samplers
+        _logger = logging.getLogger()
+        _logger.setLevel(logging.DEBUG)
+        selection = "not water"
+        checkpoint_interval = 5
+        n_states = 3
+        n_cycles = 10
+        lambda_protocol = LambdaProtocol(functions="default")
+        reporter_file = os.path.join(tmp_path, "cdk2_solvent.nc")
+        reporter = MultiStateReporter(
+            reporter_file,
+            analysis_particle_indices=htf.hybrid_topology.select(selection),
+            checkpoint_interval=checkpoint_interval,
+        )
+        hss = HybridRepexSampler(
+            mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
+                timestep=4.0 * unit.femtoseconds,
+                collision_rate=5.0 / unit.picosecond,
+                n_steps=250,
+                reassign_velocities=False,
+                n_restart_attempts=20,
+                splitting="V R R R O R R R V",
+                constraint_tolerance=1e-06,
+            ),
+            hybrid_factory=htf,
+            online_analysis_interval=10,
+        )
+        hss.setup(
+            n_states=n_states,
+            temperature=300 * unit.kelvin,
+            storage_file=reporter,
+            lambda_protocol=lambda_protocol,
+        )
+        hss.extend(n_cycles)
+        # Close reporter - Needed to avoid eventual fatal seg faults
+        reporter.close()
+        del hss
 
-    # Load repex simulation
-    reporter = MultiStateReporter(reporter_file, checkpoint_interval=10)
-    simulation = HybridRepexSampler.from_storage(reporter)
+        # Load repex simulation
+        reporter = MultiStateReporter(reporter_file, checkpoint_interval=10)
+        simulation = HybridRepexSampler.from_storage(reporter)
 
-    # Resume simulation
-    simulation.extend(5)
+        # Resume simulation
+        simulation.extend(5)
 
-    assert simulation.iteration == 15
+        assert simulation.iteration == 15
 
 
 @pytest.mark.gpu_ci
 def test_resume_protein_mutation_no_checkpoint(tmp_path):
 
-    os.chdir(tmp_path)
+    with tempfile.TemporaryDirectory() as tmp_path:
+        os.chdir(tmp_path)
 
-    pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
+        pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
 
-    solvent_delivery = PointMutationExecutor(
-        pdb_filename,
-        "1",
-        "2",
-        "ASP",
-        flatten_torsions=True,
-        flatten_exceptions=True,
-        conduct_endstate_validation=False,
-        barostat=None,
-        phase="vaccum",
-        periodic_forcefield_kwargs=None,
-        nonperiodic_forcefield_kwargs={"nonbondedMethod": app.NoCutoff},
-    )
-    htf = solvent_delivery.get_apo_htf()
+        solvent_delivery = PointMutationExecutor(
+            pdb_filename,
+            "1",
+            "2",
+            "ASP",
+            flatten_torsions=True,
+            flatten_exceptions=True,
+            conduct_endstate_validation=False,
+            barostat=None,
+            phase="vaccum",
+            periodic_forcefield_kwargs=None,
+            nonperiodic_forcefield_kwargs={"nonbondedMethod": app.NoCutoff},
+        )
+        htf = solvent_delivery.get_apo_htf()
 
-    # Build the hybrid repex samplers
-    _logger = logging.getLogger()
-    _logger.setLevel(logging.DEBUG)
-    selection = "not water"
-    checkpoint_interval = 5
-    n_states = 3
-    n_cycles = 10
-    lambda_protocol = LambdaProtocol(functions="default")
-    reporter_file = tmp_path / "cdk2_solvent.nc"
-    reporter = MultiStateReporter(
-        reporter_file,
-        analysis_particle_indices=htf.hybrid_topology.select(selection),
-        checkpoint_interval=checkpoint_interval,
-    )
-    hss = HybridRepexSampler(
-        mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
-            timestep=4.0 * unit.femtoseconds,
-            collision_rate=5.0 / unit.picosecond,
-            n_steps=250,
-            reassign_velocities=False,
-            n_restart_attempts=20,
-            splitting="V R R R O R R R V",
-            constraint_tolerance=1e-06,
-        ),
-        hybrid_factory=htf,
-        online_analysis_interval=10,
-    )
-    hss.setup(
-        n_states=n_states,
-        temperature=300 * unit.kelvin,
-        storage_file=reporter,
-        lambda_protocol=lambda_protocol,
-    )
+        # Build the hybrid repex samplers
+        _logger = logging.getLogger()
+        _logger.setLevel(logging.DEBUG)
+        selection = "not water"
+        checkpoint_interval = 5
+        n_states = 3
+        n_cycles = 10
+        lambda_protocol = LambdaProtocol(functions="default")
+        reporter_file = os.path.join(tmp_path, "cdk2_solvent.nc")
+        reporter = MultiStateReporter(
+            reporter_file,
+            analysis_particle_indices=htf.hybrid_topology.select(selection),
+            checkpoint_interval=checkpoint_interval,
+        )
+        hss = HybridRepexSampler(
+            mcmc_moves=mcmc.LangevinSplittingDynamicsMove(
+                timestep=4.0 * unit.femtoseconds,
+                collision_rate=5.0 / unit.picosecond,
+                n_steps=250,
+                reassign_velocities=False,
+                n_restart_attempts=20,
+                splitting="V R R R O R R R V",
+                constraint_tolerance=1e-06,
+            ),
+            hybrid_factory=htf,
+            online_analysis_interval=10,
+        )
+        hss.setup(
+            n_states=n_states,
+            temperature=300 * unit.kelvin,
+            storage_file=reporter,
+            lambda_protocol=lambda_protocol,
+        )
 
-    hss.extend(n_cycles)
-    hss.extend(5)
+        hss.extend(n_cycles)
+        hss.extend(5)
 
-    assert hss.iteration == 15
+        assert hss.iteration == 15

--- a/perses/tests/test_resume.py
+++ b/perses/tests/test_resume.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shutil
 import subprocess
 import tempfile
 
@@ -17,12 +16,13 @@ from perses.annihilation.relative import HybridTopologyFactory
 from perses.app.relative_point_mutation_setup import PointMutationExecutor
 from perses.app.relative_setup import RelativeFEPSetup
 from perses.samplers.multistate import HybridRepexSampler
+from perses.tests.utils import enter_temp_directory
 
 
 @pytest.mark.gpu_ci
 def test_cli_resume_repex():
 
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with enter_temp_directory() as temp_dir:
         os.chdir(temp_dir)
         # Need to get path to examples dir
         protein_pdb = resource_filename(
@@ -88,7 +88,8 @@ def test_cli_resume_repex():
 @pytest.mark.gpu_ci
 def test_resume_small_molecule():
 
-    with tempfile.TemporaryDirectory() as tmp_path:
+    with enter_temp_directory() as tmp_path:
+        cwd = os.getcwd()  # get current working dir to come back to it
         os.chdir(tmp_path)
 
         smiles_filename = resource_filename("perses", os.path.join("data", "test.smi"))
@@ -162,7 +163,7 @@ def test_resume_small_molecule():
 @pytest.mark.gpu_ci
 def test_resume_protein_mutation_with_checkpoint(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_path:
+    with enter_temp_directory() as tmp_path:
         os.chdir(tmp_path)
 
         pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")
@@ -232,7 +233,7 @@ def test_resume_protein_mutation_with_checkpoint(tmp_path):
 @pytest.mark.gpu_ci
 def test_resume_protein_mutation_no_checkpoint(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_path:
+    with enter_temp_directory() as tmp_path:
         os.chdir(tmp_path)
 
         pdb_filename = resource_filename("perses", "data/ala_vacuum.pdb")


### PR DESCRIPTION
## Description

This PR closes reporter/storage files in tests and handles better temporary directory on them.

## Motivation and context

New `openmmtools` was making tests to fail with fatal errors apparently due to how we were using `netCDF`. https://github.com/choderalab/perses/runs/6250638087?check_suite_focus=true#step:9:160

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

Tested locally.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
