### PR TITLE
Fix typo in test_resume.py

### DIFF
--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -362,7 +362,10 @@ class PointMutationExecutor(object):
                                                         validate_energy_bookkeeping=validate_bool)
 
             # Check for charge change...
-            self._handle_charge_changes(topology_proposal, new_positions)
+            if phase != 'vacuum':
+                self._handle_charge_changes(topology_proposal, new_positions)
+            else:
+                _logger.info("Skipping counterion because phase is vacuum.")
 
             if generate_unmodified_hybrid_topology_factory:
                 repartitioned_endstate = None

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -23,6 +23,7 @@ temperature = 300 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT
 ring_amino_acids = ['TYR', 'PHE', 'TRP', 'PRO', 'HIS', 'HID', 'HIE', 'HIP']
+KNOWN_PHASES = ['vacuum', 'complex', 'solvent']
 
 # Set up logger
 import logging
@@ -197,6 +198,9 @@ class PointMutationExecutor(object):
 
         """
         from openeye import oechem
+
+        if not phase in KNOWN_PHASES:
+            raise ValueError(f"phase '{phase}' unknown; must be one of {KNOWN_PHASES}")
 
         # First thing to do is load the apo protein to mutate...
         if protein_filename.endswith('pdb'):

--- a/perses/tests/test_resume.py
+++ b/perses/tests/test_resume.py
@@ -247,7 +247,7 @@ def test_resume_protein_mutation_no_checkpoint(tmp_path):
             flatten_exceptions=True,
             conduct_endstate_validation=False,
             barostat=None,
-            phase="vaccum",
+            phase="vacuum",
             periodic_forcefield_kwargs=None,
             nonperiodic_forcefield_kwargs={"nonbondedMethod": app.NoCutoff},
         )


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail. -->
Fixes typo that causes the test to be run in solvent instead of vacuum.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #990 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
