### PR TITLE
Speed up functions for retrieving old/new positions from hybrid positions

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2155,9 +2155,8 @@ class HybridTopologyFactory(object):
         # making sure hybrid positions are simtk.unit.Quantity objects
         if not isinstance(hybrid_positions, unit.Quantity):
             hybrid_positions = unit.Quantity(hybrid_positions, unit=unit.nanometer)
-        old_positions = unit.Quantity(np.zeros([n_atoms_old, 3]), unit=unit.nanometer)
-        for idx in range(n_atoms_old):
-            old_positions[idx, :] = hybrid_positions[idx, :]
+        hybrid_indices = [self._old_to_hybrid_map[idx] for idx in range(n_atoms_old)]
+        old_positions = unit.Quantity(hybrid_positions[hybrid_indices, :], unit=unit.nanometer)
         return old_positions
 
     def new_positions(self, hybrid_positions):
@@ -2178,9 +2177,8 @@ class HybridTopologyFactory(object):
         # making sure hybrid positions are simtk.unit.Quantity objects
         if not isinstance(hybrid_positions, unit.Quantity):
             hybrid_positions = unit.Quantity(hybrid_positions, unit=unit.nanometer)
-        new_positions = unit.Quantity(np.zeros([n_atoms_new, 3]), unit=unit.nanometer)
-        for idx in range(n_atoms_new):
-            new_positions[idx, :] = hybrid_positions[self._new_to_hybrid_map[idx], :]
+        hybrid_indices = [self._new_to_hybrid_map[idx] for idx in range(n_atoms_new)]
+        new_positions = unit.Quantity(hybrid_positions[hybrid_indices, :], unit=unit.nanometer)
         return new_positions
 
     @property


### PR DESCRIPTION
## Description

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1005 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

The existing test `test_relative.py::test_position_output()` passes.

I added a timer to this test and here are the times with the old approach vs new approach (this PR):
- with old approach:
	- old_positions(): 0.04454398155212402
	- new_positions(): 0.04473400115966797
- with new approach
	- old_positions(): 0.001668691635131836
	- new_positions(): 0.001196146011352539

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
