### PR TITLE
Rename second CustomBondForce in HybridTopologyFactory system and update docstrings

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -1835,7 +1835,7 @@ class HybridTopologyFactory(object):
 
 
         nonbonded_exceptions_force = openmm.CustomBondForce(old_new_nonbonded_exceptions)
-        name = nonbonded_exceptions_force.__class__.__name__ + '_exceptions'        
+        name = f"{nonbonded_exceptions_force.__class__.__name__}_exceptions"        
         nonbonded_exceptions_force.setName(name)
         self._hybrid_system.addForce(nonbonded_exceptions_force)
         _logger.debug(f"\thandle_old_new_exceptions: {nonbonded_exceptions_force} added to hybrid system")

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -1823,6 +1823,8 @@ class HybridTopologyFactory(object):
 
 
         nonbonded_exceptions_force = openmm.CustomBondForce(old_new_nonbonded_exceptions)
+        name = nonbonded_exceptions_force.__class__.__name__ + '_exceptions'        
+        nonbonded_exceptions_force.setName(name)
         self._hybrid_system.addForce(nonbonded_exceptions_force)
         _logger.debug(f"\thandle_old_new_exceptions: {nonbonded_exceptions_force} added to hybrid system")
 

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -37,7 +37,7 @@ class HybridTopologyFactory(object):
     - PeriodicTorsionForce -- handles torsions involving `environment_atoms`, `unique_old_atoms` and `unique_new_atoms` (these are never scaled)
     - NonbondedForce -- handles all electrostatic interactions, environment-environment steric interactions
     - CustomNonbondedForce -- handle all non environment-environment sterics
-    - CustomBondForce -- handles all electrostatics and sterics exceptions involving unique old/new atoms when interpolate_14s is True, otherwise the electrostatics/sterics exception is in the NonbondedForce
+    - CustomBondForce_exceptions -- handles all electrostatics and sterics exceptions involving unique old/new atoms when interpolate_14s is True, otherwise the electrostatics/sterics exception is in the NonbondedForce
     * where `interactions` refers to any pair of atoms that is not 1-2, 1-3, 1-4
 
     This class can be tested using perses.tests.utils.validate_endstate_energies(), as is done by perses.tests.test_relative.compare_energies

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -28,6 +28,18 @@ class HybridTopologyFactory(object):
     environment_atom : these atoms are mapped, and are not part of a changing residue. Their interactions are always
         on and are alchemically unmodified.
 
+    Here are the forces in the hybrid system:
+    - CustomBondForce -- handles bonds involving `core_atoms` (these are interpolated)
+    - HarmonicBondForce -- handles bonds involving `environment_atoms`, `unique_old_atoms` and `unique_new_atoms` (these are never scaled)
+    - CustomAngleForce -- handles angles involving `core_atoms` (these are interpolated)
+    - HarmonicAngleForce -- handles angles involving `environment_atoms`, `unique_old_atoms` and `unique_new_atoms` (these are never scaled)
+    - CustomTorsionForce -- handles torsions involving `core_atoms` (these are interpolated)
+    - PeriodicTorsionForce -- handles torsions involving `environment_atoms`, `unique_old_atoms` and `unique_new_atoms` (these are never scaled)
+    - NonbondedForce -- handles all electrostatic interactions, environment-environment steric interactions
+    - CustomNonbondedForce -- handle all non environment-environment sterics
+    - CustomBondForce -- handles all electrostatics and sterics exceptions involving unique old/new atoms when interpolate_14s is True, otherwise the electrostatics/sterics exception is in the NonbondedForce
+    * where `interactions` refers to any pair of atoms that is not 1-2, 1-3, 1-4
+
     This class can be tested using perses.tests.utils.validate_endstate_energies(), as is done by perses.tests.test_relative.compare_energies
 
     Properties

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -27,12 +27,7 @@ class RESTTopologyFactory(HybridTopologyFactory):
         a. `CustomBondForce`: rewrite `HarmonicBondForce`
         b. `CustomAngleForce`: rewrite `HarmonicAngleForce`
         c. `CustomTorsionForce`: rewrite `PeriodicTorsionForce`
-        d. `NonbondedForce`: solvent-solvent
-            solvent sterics and electrostatics and exceptions are treated in standard form (no scaling), but solute terms are _all_ zeroed
-        e. `CustomNonbondedForce`: solvent-solute and solute-solute
-            creates a solvent and solute interaction group. the solute interacts with itself with a rescaling factor, and the solvent interacts with solute (via separate rescaling factor)
-        f. `CustomBondForce`:
-            since we cannot appropriately treat exceptions in the solute region or the solute/solvent region, we need to treat them as an exception force
+        d. `NonbondedForce`: rewrite `NonbondedForce` using offsets to allow for rest scaling
     """
     _known_forces = {'HarmonicBondForce', 'HarmonicAngleForce', 'PeriodicTorsionForce', 'NonbondedForce', 'MonteCarloBarostat'}
 


### PR DESCRIPTION
## Description

- Renames second `CustomBondForce` in `HybridTopologyFactory` system to `CustomBondForce_exceptions`
- Updates docstring in `HybridTopologyFactory` to contain the list of forces present in the hybrid system
- Fixes docstring for RESTTopologyFactory to accurately reflect the forces in the system 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
This change is necessary because https://github.com/choderalab/perses/pull/1007 changes `compute_potential_components()` to use a dictionary where the keys are force names and values are energies.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
