### PR TITLE
Fix rest factory

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -3024,10 +3024,10 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
                  new_positions,
 
                  # rest scaling arguments
-                 rest_radius=0.2,
+                 rest_radius=0.3,
 
                  # nonbonded parameters
-                 w_scale=0.1,
+                 w_scale=0.3,
 
                  **kwargs):
 
@@ -3040,9 +3040,9 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
                 positions of coordinates of old system
             new_positions : [m,3] np.ndarray of float
                 positions of coordinates of new system
-            rest_radius : float, default 0.2
+            rest_radius : float, default 0.3
                 radius for rest region, in nanometers
-            w_scale : float
+            w_scale : float, default 0.3
                 maximum offset to add for the 4th dimension lifting
         """
 
@@ -4025,7 +4025,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
             custom_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(self._nonbonded_method))
             custom_force.setUseSwitchingFunction(False)
             custom_force.setCutoffDistance(self._r_cutoff)
-            custom_force.setUseLongRangeCorrection(old_system_nbf.getUseDispersionCorrection()) # This should be copied from the og nbf for sterics, but off for electrostatics
+            custom_force.setUseLongRangeCorrection(False)
 
         elif self._nonbonded_method == openmm.NonbondedForce.NoCutoff:
             custom_force.setNonbondedMethod(self._translate_nonbonded_method_to_custom(self._nonbonded_method))

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2717,11 +2717,11 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
     For example, for each bond, the additional parameters are: length_old, length_new, K_old, K_new
 
     The nonbonded interactions are handled with 4 forces:
-    - CustomNonbondedForce - direct space PME electrostatics interactions (with long range correction off)
-    - CustomNonbondedForce - steric interactions for scaled interactions (with long range correction off)
-    - CustomBondForce - electrostatics (uses Coulomb and not PME) and steric exceptions
-    - NonbondedForce - reciprocal space PME electrostatics interactions/exceptions
-    - NonbondedForce - steric interactions for non-scaled interactions (with long range correction on)
+    - CustomNonbondedForce_electrostatics - direct space PME electrostatics interactions (with long range correction off)
+    - CustomNonbondedForce_sterics - steric interactions for scaled interactions (with long range correction off)
+    - CustomBondForce_exceptions - electrostatics (uses Coulomb and not PME) and scaled steric exceptions
+    - NonbondedForce_reciprocal - reciprocal space PME electrostatics interactions/exceptions (with long range correction off)
+    - NonbondedForce_sterics - steric interactions for non-scaled interactions/exceptions (with long range correction on)
     * Note that 'scaled interaction' means at least one atom in the interaction is scaled via rest or alchemically.
     Aka at least one atom in the interaction is part of at least one of the following atom classes: rest, inter, core, unique old, unique new.
 
@@ -4128,6 +4128,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
             - CustomNonbondedForce for electrostatics interactions (not exceptions)
             - CustomNonbondedForce for sterics interactions (not exceptions)
             - NonbondedForce for reciprocal space electrostatic interactions and exceptions
+            - NonbondedForce for non-scaled steric interactions and exceptions
 
         """
 
@@ -4292,7 +4293,10 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
 
     def _copy_exceptions(self):
         """
-        Add exceptions to the CustomBondForce for exceptions and the NonbondedForce for the reciprocal space.
+        Add exceptions to:
+            - CustomBondForce for scaled exceptions
+            - NonbondedForce for the reciprocal space interactions and exceptions
+            - NonbondedForce for non-scaled sterics interactions and exceptions
         """
 
         # Retrieve old and new nb forces
@@ -4380,7 +4384,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
             chargeProd_product_old = p1_params[-2] * p2_params[-2]
             chargeProd_product_new = p1_params[-1] * p2_params[-1]
 
-            # Add exclusions to the custon nb forces and bond to the custom bond force
+            # Add exclusions to the custom nb forces and bond to the custom bond force
             params = (hybrid_index_pair[0], hybrid_index_pair[1],
                                    rest_id + alch_id +
                                    [chargeProd_old, chargeProd_new, chargeProd_product_old, chargeProd_product_new, sigma_old, sigma_new, epsilon_old_bond, epsilon_new_bond])

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -3894,9 +3894,9 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
         self._hybrid_system_forces[name] = custom_force
 
         # Add global parameters
-        custom_force.addGlobalParameter(f"lambda_rest_electrostatics", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_electrostatics_old", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_electrostatics_new", 0.0)
+        custom_force.addGlobalParameter("lambda_rest_electrostatics", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_electrostatics_old", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_electrostatics_new", 0.0)
 
         # Add per-particle parameters for rest scaling -- these three sets are disjoint
         custom_force.addPerParticleParameter("is_rest")
@@ -3983,9 +3983,9 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
         custom_force.addInteractionGroup(environment_rest_atoms, environment_nonrest_atoms)
 
         # Add global parameters
-        custom_force.addGlobalParameter(f"lambda_rest_sterics", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_sterics_old", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_sterics_new", 0.0)
+        custom_force.addGlobalParameter("lambda_rest_sterics", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_sterics_old", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_sterics_new", 0.0)
 
         # Add per-particle parameters for rest scaling -- these three sets are disjoint
         custom_force.addPerParticleParameter("is_rest")
@@ -4250,12 +4250,12 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
         self._hybrid_system_forces[name] = custom_force
 
         # Add global parameters
-        custom_force.addGlobalParameter(f"lambda_rest_electrostatics_exceptions", 1.0)
-        custom_force.addGlobalParameter(f"lambda_rest_sterics_exceptions", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_electrostatics_exceptions_old", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_electrostatics_exceptions_new", 0.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_sterics_exceptions_old", 1.0)
-        custom_force.addGlobalParameter(f"lambda_alchemical_sterics_exceptions_new", 0.0)
+        custom_force.addGlobalParameter("lambda_rest_electrostatics_exceptions", 1.0)
+        custom_force.addGlobalParameter("lambda_rest_sterics_exceptions", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_electrostatics_exceptions_old", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_electrostatics_exceptions_new", 0.0)
+        custom_force.addGlobalParameter("lambda_alchemical_sterics_exceptions_old", 1.0)
+        custom_force.addGlobalParameter("lambda_alchemical_sterics_exceptions_new", 0.0)
 
         # Add per-bond parameters for rest scaling -- these sets are disjoint
         custom_force.addPerBondParameter("is_rest")

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -114,8 +114,8 @@ class PointMutationExecutor(object):
                  apo_box_dimensions=None,
                  flatten_torsions=False,
                  flatten_exceptions=False,
-                 rest_radius=0.2,
-                 w_scale=0.2,
+                 rest_radius=0.3,
+                 w_scale=0.3,
                  generate_unmodified_hybrid_topology_factory=True,
                  generate_repartitioned_hybrid_topology_factory=False,
                  generate_rest_capable_hybrid_topology_factory=False,
@@ -185,9 +185,9 @@ class PointMutationExecutor(object):
                 in the htf, flatten torsions involving unique new atoms at lambda = 0 and unique old atoms are lambda = 1
             flatten_exceptions : bool, default False
                 in the htf, flatten exceptions involving unique new atoms at lambda = 0 and unique old atoms at lambda = 1
-            rest_radius : float, default 0.2
+            rest_radius : float, default 0.3
                 radius for rest region, in nanometers
-            w_scale : float, default 0.2
+            w_scale : float, default 0.3
                 scale factor for lifting term
             generate_unmodified_hybrid_topology_factory : bool, default True
                 whether to generate a vanilla HybridTopologyFactory

--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -1005,6 +1005,12 @@ def run_RESTCapableHybridTopologyFactory_energies(test_name, phase, use_point_en
                                                  )
         htf = solvent_delivery.get_apo_rest_htf()
 
+        # For theses tests, we need to turn the LRC on for the CustomNonbondedForce scaled steric interactions,
+        # since there is no way to turn the LRC on for the non-scaled interactions only
+        force_dict = {force.getName(): index for index, force in enumerate(htf.hybrid_system.getForces())}
+        custom_force = hybrid_system.getForce(force_dict['CustomNonbondedForce_sterics'])
+        custom_force.setUseLongRangeCorrection(True)
+
     # validating endstate energies
     if use_point_energies:
         for endstate in [0, 1]:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
- Turn the long range correction off by default for CustomNonbondedForce_sterics and turn it on for the tests
- Change default w_scale and rest_radius to 0.3
- Remove unnecessary f string in global parameter strings
- Edit docstrings

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Updates defaults, cleans up some unnecessary code, and updates docstrings to reflect changes made previously.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Existing tests in `tests/test_relative.py::test_RESTCapableHybridTopologyFactory_energies_{GPU}()`

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
