### PR TITLE
unsampled endstates long range correction as an input yaml option

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,7 +13,7 @@ The full release history can be viewed `at the GitHub perses releases page <http
 
 Enhancements
 ------------
-- ``unsampled_endstates`` boolean option in input YAML file, for enabling/disabling creation of unsampled endstates long-range sterics correction. Issue `#1033 <https://github.com/choderalab/perses/issues/1033>`_ (`#1037 <https://github.com/choderalab/perses/pull/1037>`_).
+- Introduce ``unsampled_endstates`` boolean option in input YAML file, for enabling/disabling creation of unsampled endstates long-range sterics correction. Issue `#1033 <https://github.com/choderalab/perses/issues/1033>`_ (`#1037 <https://github.com/choderalab/perses/pull/1037>`_).
 
 0.9.5 - Release
 ---------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,13 @@ This section lists features and improvements of note in each release.
 
 The full release history can be viewed `at the GitHub perses releases page <https://github.com/choderalab/perses/releases>`_.
 
+0.10.0 - Release
+----------------
+
+Enhancements
+------------
+- ``unsampled_endstates`` boolean option in input YAML file, for enabling/disabling creation of unsampled endstates long-range sterics correction. Issue `#1033 <https://github.com/choderalab/perses/issues/1033>`_ (`#1037 <https://github.com/choderalab/perses/pull/1037>`_).
+
 0.9.5 - Release
 ---------------
 

--- a/examples/protein-ligand/cli/protein-ligand.yaml
+++ b/examples/protein-ligand/cli/protein-ligand.yaml
@@ -46,7 +46,7 @@ fe_type: repex
 checkpoint_interval: 50 
 
 #number of iterations
-n_cycles: 1
+n_cycles: 4
 
 #The number of SAMS states
 n_states: 3
@@ -67,9 +67,13 @@ atom_selection: not water
 phases:
     - complex
     - solvent
-    - vacuum
+#    - vacuum
 
 #timestep in fs
 timestep: 4.
 
 h_constraints: True
+
+offline-freq: 2
+
+unsampled_endstates: True

--- a/examples/protein-ligand/cli/protein-ligand.yaml
+++ b/examples/protein-ligand/cli/protein-ligand.yaml
@@ -67,13 +67,13 @@ atom_selection: not water
 phases:
     - complex
     - solvent
-#    - vacuum
+    - vacuum
 
 #timestep in fs
 timestep: 4.
 
-h_constraints: True
-
+# Interval in iterations to use for offline real time analysis
 offline-freq: 2
 
+# Create unsampled endstates for long-range sterics correction
 unsampled_endstates: True

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -326,6 +326,10 @@ def getSetupOptions(filename, override_string=None):
     if 'platform' not in setup_options:
         setup_options['platform'] = None  # defaults to choosing best platform
 
+    # Handling unsampled_endstates long range correction flag
+    if 'unsampled_endstates' not in setup_options:
+        setup_options['unsampled_endstates'] = True   # True by default (matches class default)
+
     os.makedirs(trajectory_directory, exist_ok=True)
 
 
@@ -658,10 +662,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                 if phase == 'vacuum':
                     endstates = False
                 else:
-                    # TODO: Make this True when dispersed.utils.create_endstates is fixed
-                    _logger.info("Disabling creation of endstates with expanded cutoffs in order to support new "
-                                 "alchemical factories.")
-                    endstates = False
+                    endstates = setup_options['unsampled_endstates']
 
                 if setup_options['fe_type'] == 'fah':
                     _logger.info('SETUP FOR FAH DONE')


### PR DESCRIPTION

## Description

This exposes the `unsampled_endstates` boolean option in the input YAML file for enabling/disabling the creation of unsampled endstates as a long-range steric correction.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1033 

## How has this been tested?

Tested locally with protein-ligand cli example. Output of matrix as follows, for `n_states=3`. Dimensions of `3x3` vs `5x5` (Format is not great, sorry).

| `unsampled_endstates:False`  | `unsampled_endstates:True` |
| ------------- | ------------- |
| Deltaf_ij:<br>   0.000  20.018  -3.468<br> -20.018   0.000 -23.485<br> 3.468  23.485   0.000 | Deltaf_ij:<br>   0.000   7.158  21.007  -4.126  -9.088<br> -7.158   0.000  13.848 -11.284 -16.247<br> -21.007 -13.848   0.000 -25.133 -30.095<br>   4.126  11.284  25.133   0.000  -4.962<br>   9.088  16.247  30.095   4.962   0.000 |

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
``unsampled_endstates`` boolean option in input YAML file, for enabling/disabling creation of unsampled endstates long-range sterics correction.
```