### PR TITLE
`RESTCapableHybridTopologyFactory` working with small molecules

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -700,7 +700,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                         hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                     )
                     hss[phase].setup(n_states=n_states, temperature=temperature, storage_file=reporter,
-                                     lambda_protocol=lambda_protocol, endstates=endstates)
+                                     endstates=endstates)
                     # We need to specify contexts AFTER setup
                     hss[phase].energy_context_cache = energy_context_cache
                     hss[phase].sampler_context_cache = sampler_context_cache

--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -38,8 +38,8 @@ class HybridCompatibilityMixin(object):
 
         # Retrieve class name, hybrid system, and hybrid positions
         factory_name = self._hybrid_factory.__class__.__name__
-        hybrid_system = self._factory.hybrid_system
-        positions = self._factory.hybrid_positions
+        hybrid_system = self._hybrid_factory.hybrid_system
+        positions = self._hybrid_factory.hybrid_positions
 
         # Create alchemical state and lambda protocol
         if factory_name == 'HybridTopologyFactory':


### PR DESCRIPTION
## Description

the `lambda_protocol` option for the Sampler object was being specified forcing a specific HTF to be used. It is now left undefined for the Sampler to automatically detect and choose according to the HTF.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1039 

## How has this been tested?

Tested locally with partial tyk2 benchmark simulation

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Bug fix when trying to use the new `RESTCapableHybridTopologyFactory` in the small molecule pipeline -- fixed by not specifying a protocol, hence allowing the `HybridCompatibilityMixin` object to automatically handle it.
```
