### PR TITLE
Fix cutoff and lifting parameters in `RESTCapableHybridTopologyFactory`

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -3031,7 +3031,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
                  new_positions,
 
                  # rest scaling arguments
-                 rest_radius=0.3,
+                 rest_radius=0.3 * unit.nanometers,
 
                  # nonbonded parameters
                  w_lifting=0.3 * unit.nanometers,
@@ -3047,7 +3047,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
                 positions of coordinates of old system
             new_positions : [m,3] np.ndarray of float
                 positions of coordinates of new system
-            rest_radius : float, default 0.3
+            rest_radius : unit.nanometers, default 0.3 * unit.nanometers
                 radius for rest region, in nanometers
             w_lifting : unit.nanometers, default 0.3 * unit.nanometers
                 maximal distance to add for the 4th dimension lifting, in nanometers
@@ -3136,7 +3136,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
         # Generate rest region
         self._rest_radius = rest_radius
         self._rest_region = self._generate_rest_region()
-        _logger.info(f"Rest radius: {self._rest_radius} nm")
+        _logger.info(f"Rest radius: {self._rest_radius}")
         _logger.info(f"Rest region: {self._rest_region}")
 
         # Prep look up dict for determining if atom is solvent
@@ -3222,7 +3222,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
         # Retrieve neighboring atoms within self._rest_radius nm of the query atoms
         traj = md.Trajectory(np.array(self._hybrid_positions), self._hybrid_topology)
         solute_atoms = list(traj.topology.select("is_protein"))
-        rest_atoms = list(md.compute_neighbors(traj, self._rest_radius, query_indices, haystack_indices=solute_atoms)[0])
+        rest_atoms = list(md.compute_neighbors(traj, self._rest_radius.value_in_unit_system(unit.md_unit_system), query_indices, haystack_indices=solute_atoms)[0])
 
         # Retrieve full residues for all atoms in rest region
         residues = [atom.residue.index for atom in traj.topology.atoms if atom.index in rest_atoms]

--- a/perses/app/relative_point_mutation_setup.py
+++ b/perses/app/relative_point_mutation_setup.py
@@ -139,8 +139,8 @@ class PointMutationExecutor(object):
                  conduct_endstate_validation=True,
                  flatten_torsions=False,
                  flatten_exceptions=False,
-                 rest_radius=0.3,
-                 w_scale=0.3,
+                 rest_radius=0.3 * unit.nanometer,
+                 w_lifting=0.3 * unit.nanometer,
                  generate_unmodified_hybrid_topology_factory=True,
                  generate_repartitioned_hybrid_topology_factory=False,
                  generate_rest_capable_hybrid_topology_factory=False,
@@ -216,10 +216,10 @@ class PointMutationExecutor(object):
                 in the HybridTopologyFactory, flatten torsions involving unique new atoms at lambda = 0 and unique old atoms are lambda = 1
             flatten_exceptions : bool, default False
                 in the HybridTopologyFactory, flatten exceptions involving unique new atoms at lambda = 0 and unique old atoms at lambda = 1
-            rest_radius : float, default 0.3
+            rest_radius : unit.nanometer, default 0.3 * unit.nanometer
                 radius for rest region, in nanometers
-            w_scale : float, default 0.3
-                scale factor for lifting term
+            w_lifting : unit.nanometer, default 0.3 * unit.nanometer
+                maximal distance for lifting term, in nanometers
             generate_unmodified_hybrid_topology_factory : bool, default True
                 whether to generate a vanilla HybridTopologyFactory
             generate_repartitioned_hybrid_topology_factory : bool, default False
@@ -404,16 +404,16 @@ class PointMutationExecutor(object):
             # Create hybrid factories
             if generate_unmodified_hybrid_topology_factory:
                 repartitioned_endstate = None
-                self.generate_htf(HybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_scale)
+                self.generate_htf(HybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_lifting)
             if generate_repartitioned_hybrid_topology_factory:
                 for repartitioned_endstate in [0, 1]:
-                    self.generate_htf(RepartitionedHybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_scale)
+                    self.generate_htf(RepartitionedHybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_lifting)
             if generate_rest_capable_hybrid_topology_factory:
                 repartitioned_endstate = None
                 if rest_radius is None:
                     _logger.info("Trying to generate a RESTCapableHybridTopologyFactory, but rest_radius was not specified. Using 0.2 nm...")
                     rest_radius = 0.2
-                self.generate_htf(RESTCapableHybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_scale)
+                self.generate_htf(RESTCapableHybridTopologyFactory, topology_proposal, pos, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_lifting)
 
             # Gather energies needed for validating endstate energies
             if not topology_proposal.unique_new_atoms:
@@ -468,7 +468,7 @@ class PointMutationExecutor(object):
             else:
                 pass
 
-    def generate_htf(self, factory, topology_proposal, old_positions, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_scale):
+    def generate_htf(self, factory, topology_proposal, old_positions, new_positions, flatten_exceptions, flatten_torsions, repartitioned_endstate, is_complex, rest_radius, w_lifting):
         """
         Generate hybrid factory.
 
@@ -492,10 +492,10 @@ class PointMutationExecutor(object):
         is_complex : bool
             if False, the factory is generated for the apo protein
             otherwise, the factory is generated for the complex
-        rest_radius : float, default 0.2
+        rest_radius : unit.nanometer, default 0.3 * unit.nanometer
             radius for rest region, in nanometers
-        w_scale : float
-            maximum offset to add for the 4th dimension lifting
+        w_lifting : unit.nanometer, default 0.3 * unit.nanometer
+            maximum distance to use for the 4th dimension lifting, in nanometers
 
         """
 
@@ -520,7 +520,7 @@ class PointMutationExecutor(object):
                                       endstate=repartitioned_endstate,
                                       flatten_torsions=flatten_torsions,
                                       rest_radius=rest_radius,
-                                      w_scale=w_scale)
+                                      w_lifting=w_lifting)
         if is_complex:
             if factory == HybridTopologyFactory:
                 self.complex_htf = htf

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -1092,9 +1092,9 @@ def _generate_htf(phase: str, topology_proposal_dictionary: dict, setup_options:
         except KeyError:
             _logger.info("'rest_radius' not specified. Using default value.")
         try:
-            rest_specific_options.update({'w_scale': setup_options['w_scale']})
+            rest_specific_options.update({'w_lifting': setup_options['w_lifting']})
         except KeyError:
-            _logger.info("'w_scale' not specified. Using default value.")
+            _logger.info("'w_lifting' not specified. Using default value.")
 
         # update htf_setup_dictionary with new parameters
         htf_setup_dict.update(rest_specific_options)


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This PR addresses the following problem: 

The `RESTCapableHybridTopologyFactory` is not performing lifting to the 4th dimension correctly in vacuum. We are maximally lifting to 100 nm, which is much too large. The maximal lifting distance is currently defined by `w_scale * r_cutoff`. For vacuum, we set `r_cutoff` to be 100 nm, which is the distance we want to use when calling `CustomNonbondedForce.setCutoffDistance()`, but we do not want the maximal lifting distance to be that large, therefore, we need to remove the dependence of the maximal lifting distance on `r_cutoff`. 

In fact, we actually don't need the maximal lifting distance to depend on 2 parameters, we can use just 1 parameter, which I'll call `w_lifting`, that defines the maximal lifting distance in nanometers.

This PR does the following: 
- Renames `r_cutoff` to `cutoff`. `cutoff` is copied from the real system and if the nonbonded method is vacuum, `cutoff` is set to 100 nm. `cutoff` is only used when setting the cutoff distance in the `CustomNonbondedForce`s via `setCutoffDistance` and not in the custom expression when defining lifting expressions.
- When defining the lifting expressions, use a single user-controlled parameter (`w_lifting`) 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Bug fix in the `RESTCapableHybridTopologyFactory` lifting expression -- fixed by separating the cutoff distance from the lifting distance.
```
