### PR TITLE
Fix create_endstates_from_real_systems

### DIFF
--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -1110,6 +1110,59 @@ def run_unsampled_endstate_energies(test_name, use_point_energies=True, use_md_e
         vanilla_htf = solvent_delivery.get_apo_htf()
         htfs = [htf, vanilla_htf]
 
+    elif test_name == 'tyk2':
+        import tempfile
+        from perses.utils.url_utils import retrieve_file_url
+        from perses.annihilation.relative import HybridTopologyFactory, RESTCapableHybridTopologyFactory
+        from perses.app.relative_setup import RelativeFEPSetup
+
+        def concatenate_files(input_files, output_file):
+            """
+            Concatenate files given in input_files iterator into output_file.
+            """
+            with open(output_file, 'w') as outfile:
+                for filename in input_files:
+                    with open(filename) as infile:
+                        for line in infile:
+                            outfile.write(line)
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            # Fetch ligands sdf files and concatenate them in one
+            base_repo_url = "https://github.com/openforcefield/protein-ligand-benchmark"
+            ligand_files = []
+            for ligand in ['lig_ejm_42', 'lig_ejm_54']:
+                ligand_url = f"{base_repo_url}/raw/main/data/2020-02-07_tyk2/02_ligands/{ligand}/crd/{ligand}.sdf"
+                ligand_file = retrieve_file_url(ligand_url)
+                ligand_files.append(ligand_file)
+            concatenate_files(ligand_files, os.path.join(temp_dir, 'ligands.sdf'))
+            ligands_filename = os.path.join(temp_dir, 'ligands.sdf')
+
+            # Retrieve host PDB
+            pdb_url = f"{base_repo_url}/raw/main/data/2020-02-07_tyk2/01_protein/crd/protein.pdb"
+            host_pdb = retrieve_file_url(pdb_url)
+
+            # Generate topology proposal, old/new positions
+            fe_setup = RelativeFEPSetup(
+                ligand_input=ligands_filename,
+                protein_pdb_filename=host_pdb,
+                old_ligand_index=0,
+                new_ligand_index=1,
+                forcefield_files=['amber/ff14SB.xml', 'amber/tip3p_standard.xml', 'amber/tip3p_HFE_multivalent.xml'],
+                small_molecule_forcefield="gaff-2.11",
+                phases=["complex"],
+            )
+
+            # Generate htfs
+            factories = [HybridTopologyFactory, RESTCapableHybridTopologyFactory]
+            htfs = []
+            for factory in factories:
+                htf =factory(
+                    topology_proposal=fe_setup.complex_topology_proposal,
+                    current_positions=fe_setup.complex_old_positions,
+                    new_positions=fe_setup.complex_new_positions
+                )
+                htfs.append(htf)
+
     else:
         raise Exception(f"You specified test case name: {test_name}, but the allowed test_names are: 'ala-dipeptide' and 'barstar'")
 
@@ -1154,8 +1207,11 @@ def test_unsampled_endstate_energies_GPU():
    Only run this on a GPU as the CPU is too slow.
    """
 
-    # Alanine dipeptide in solvent -- Run MD energy validation test
-    run_unsampled_endstate_energies('ala-dipeptide', use_point_energies=False, use_md_energies=True)
-
-    # Apo barstar -- Run point and MD energy validation test
-    run_unsampled_endstate_energies('barstar', use_point_energies=True, use_md_energies=True)
+    # # Alanine dipeptide in solvent -- Run MD energy validation test
+    # run_unsampled_endstate_energies('ala-dipeptide', use_point_energies=False, use_md_energies=True)
+    #
+    # # Apo barstar -- Run point and MD energy validation tests
+    # run_unsampled_endstate_energies('barstar', use_point_energies=True, use_md_energies=True)
+    #
+    # Tyk2 -- Run point and MD energy validation tests
+    run_unsampled_endstate_energies('tyk2', use_point_energies=True, use_md_energies=True)

--- a/perses/tests/test_relative.py
+++ b/perses/tests/test_relative.py
@@ -1207,11 +1207,11 @@ def test_unsampled_endstate_energies_GPU():
    Only run this on a GPU as the CPU is too slow.
    """
 
-    # # Alanine dipeptide in solvent -- Run MD energy validation test
-    # run_unsampled_endstate_energies('ala-dipeptide', use_point_energies=False, use_md_energies=True)
-    #
-    # # Apo barstar -- Run point and MD energy validation tests
-    # run_unsampled_endstate_energies('barstar', use_point_energies=True, use_md_energies=True)
-    #
+    # Alanine dipeptide in solvent -- Run MD energy validation test
+    run_unsampled_endstate_energies('ala-dipeptide', use_point_energies=False, use_md_energies=True)
+
+    # Apo barstar -- Run point and MD energy validation tests
+    run_unsampled_endstate_energies('barstar', use_point_energies=True, use_md_energies=True)
+
     # Tyk2 -- Run point and MD energy validation tests
     run_unsampled_endstate_energies('tyk2', use_point_energies=True, use_md_energies=True)

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -1210,8 +1210,8 @@ def validate_unsampled_endstates_point(htf, hybrid_system, endstate=0, minimize=
         assert np.isclose(other_value, hybrid_value)
 
     # Check that the nonbonded (rest of the components) force energies are concordant
-    nonbonded_other_values = [components_other[key] for key in components_other.keys() if key not in bonded_keys and 'Force' in key]  # Do not include thermostats in barostats
-    print([key for key in components_other.keys() if key not in bonded_keys])
+    nonbonded_other_values = [components_other[key] for key in components_other.keys() if key not in bonded_keys and 'Force' in key]  # Do not include thermostats and barostats
+    print([key for key in components_other.keys() if key not in bonded_keys and 'Force' in key])
     print(f"Nonbondeds -- og: {np.sum(nonbonded_other_values)}, hybrid: {components_hybrid['NonbondedForce']}")
     assert np.isclose([components_hybrid['NonbondedForce']], np.sum(nonbonded_other_values))
 


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This PR fixes `create_endstates_from_real_systems()`, which was not creating the unsampled endstates properly. The global parameters in the valence forces (of the unsampled endstate systems generated by `create_endstates_from_real_systems()`) were not being set according to the appropriate endstate. They were always defaulting to the lambda = 0 endstate, meaning that the unsampled endstate at lambda = 1 had a hybrid system with valence terms set for the lambda = 0 endstate. I've introduced a fix that sets the default values for global parameters in the valence forces according to the right endstate. The fix is based on what is done in `create_endstates()` [here](https://github.com/choderalab/perses/blob/d0bec4d822592e06679036aa6345fd2a3a20102f/perses/dispersed/utils.py#L501-L506). 

This bug was not caught by the existing tests likely because the valence terms are pretty similar for the lambda = 0 and 1 systems in ala dipeptide and barstar. Therefore, I've included one of the tyk2 transformations with large error bars (from which was originally discovered this bug) as a test -- this additional test case should cover transformations where the valence terms are quite different at the lambda = 0 vs 1 endstates. 

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves https://github.com/choderalab/perses/issues/1041

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added tyk2 test in `test_relative.py` -- the transformation tested here is one that had large error bars as noted in #1041

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Bug fix in the `create_endstates_from_real_systems()` -- fixed by setting the global parameters for valence forces to the appropriate endstate. Also added tyk2 transformation test.
```
