### PR TITLE
Add timestamp and ligands name to output parsed yaml file

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -1166,8 +1166,8 @@ def _generate_parsed_yaml(setup_options, input_yaml_file_path):
     yaml_parse_name = f"perses-{time}-{yaml_name}"
     # Add timestamp information
     setup_options["timestamp"] = time
-    # Read input sdf file and save into list
-    ligands_list = Molecule.from_file(setup_options['ligand_file'])
+    # Read input sdf file and save into list -- We don't check stereochemistry
+    ligands_list = Molecule.from_file(setup_options['ligand_file'], allow_undefined_stereo=True)
     # Get names according to indices in parsed setup options
     setup_options['old_ligand_name'] = ligands_list[setup_options['old_ligand_index']].name
     setup_options['new_ligand_name'] = ligands_list[setup_options['new_ligand_index']].name

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -749,7 +749,7 @@ def run(yaml_filename=None, override_string=None):
     _logger.debug(f"Setup Options {setup_options}")
 
     # Generate yaml file with parsed setup options
-    _generate_parsed_yaml(setup_options=setup_options, input_yaml_filename=yaml_filename)
+    _generate_parsed_yaml(setup_options=setup_options, input_yaml_file_path=yaml_filename)
 
     # The name of the reporter file includes the phase name, so we need to check each
     # one
@@ -1138,16 +1138,30 @@ def _validate_endstate_energies_for_htf(hybrid_topology_factory_dict: dict, topo
         for endstate in [0, 1]:
             validate_endstate_energies_point(current_htf, endstate=endstate, minimize=True)
 
-def _generate_parsed_yaml(setup_options, input_yaml_filename):
+
+def _generate_parsed_yaml(setup_options, input_yaml_file_path):
     """
     Creates YAML file with parsed setup options in the working directory of the simulation.
 
     It adds timestamp and ligands names information (old and new).
+
+    Parameters
+    ----------
+    setup_options: dict
+        Dictionary with perses setup options. Meant to be the returned dictionary from 
+        ``perses.app.setup_relative_calculation.getSetupOptions``,
+    input_yaml_file_path: str or Path object
+        Path to input yaml file with perses parameters
+
+    Returns
+    -------
+    out_yaml_path: str
+        String with the path to the generated parsed yaml file.
     """
     from openff.toolkit.topology import Molecule
     # The parsed yaml file will live in the experiment directory to avoid race conditions with other experiments
     yaml_path = Path(setup_options['trajectory_directory'])
-    yaml_name = Path(input_yaml_filename).name  # extract name from input/template yaml file.
+    yaml_name = Path(input_yaml_file_path).name  # extract name from input/template yaml file.
     time = datetime.datetime.now().strftime("%Y-%m-%d-%H:%M:%S")
     yaml_parse_name = f"perses-{time}-{yaml_name}"
     # Add timestamp information
@@ -1158,8 +1172,11 @@ def _generate_parsed_yaml(setup_options, input_yaml_filename):
     setup_options['old_ligand_name'] = ligands_list[setup_options['old_ligand_index']].name
     setup_options['new_ligand_name'] = ligands_list[setup_options['new_ligand_index']].name
     # Write parsed and added setup options into yaml file
-    with open(Path.joinpath(yaml_path, yaml_parse_name), "w") as outfile:
+    out_file_path = Path.joinpath(yaml_path, yaml_parse_name)
+    with open(out_file_path, "w") as outfile:
         yaml.dump(setup_options, outfile)
+
+    return out_file_path
 
 
 

--- a/perses/data/Tyk2_ligands_example/tyk2_0_3.yaml
+++ b/perses/data/Tyk2_ligands_example/tyk2_0_3.yaml
@@ -1,0 +1,79 @@
+#provide the full path of the protein PDB file
+protein_pdb: Tyk2_protein.pdb
+#provide the path to the ligand file with coordinates
+ligand_file: Tyk2_ligands_shifted.sdf 
+
+#The ligand file contains multiple ligands. Choose the indices of the ligands
+#between which we should compute a relative free energy
+old_ligand_index: 0
+new_ligand_index: 3
+
+# OpenMM ffxml force field files installed via the openmm-forcefields package
+# for biopolymers and solvents.
+# Note that small molecule force field files should NOT be included here.
+forcefield_files:
+    - amber/ff14SB.xml # ff14SB protein force field
+    - amber/tip3p_standard.xml # TIP3P and recommended monovalent ion parameters
+    - amber/tip3p_HFE_multivalent.xml # for divalent ions
+    - amber/phosaa10.xml # HANDLES THE TPO
+
+# Small molecule force field
+# We recommnd one of ['gaff-1.81', 'gaff-2.11', 'smirnoff99Frosst-1.1.0', 'openff-2.0.0']
+small_molecule_forcefield: openff-2.0.0 
+
+#the temperature and pressure of the simulation, as well as how much solvent paddding to add
+#units:
+#pressure: atm
+#temperature: Kelvin
+#padding: angstroms
+pressure: 1.0
+temperature: 300.0
+solvent_padding: 9.0
+
+atom_expression:
+    - IntType
+bond_expession:
+    - DefaultBonds
+
+#number of equilibrium steps per move application
+n_steps_per_move_application: 1
+
+#the type of free energy calculation.
+#currently, this could be either nonequilibrium, sams or repex
+fe_type: repex 
+
+#checkpoint interval in iterations:
+checkpoint_interval: 50 
+
+#number of iterations
+n_cycles: 4
+
+#The number of SAMS states
+n_states: 3
+
+#the number of equilibration iterations:
+n_equilibration_iterations: 0
+
+#where to put the trajectories
+trajectory_directory: temp/offlig10to24 
+
+#how to prefix the trajectory files (project-specific name)
+trajectory_prefix: out 
+
+#which atoms to save (MDTraj selection syntax)
+atom_selection: not water 
+
+#which phases do we want to run. Any combination or number of complex, solvent or vacuum will be accepted 
+phases:
+    - complex
+    - solvent
+    - vacuum
+
+#timestep in fs
+timestep: 4.
+
+# Interval in iterations to use for offline real time analysis
+offline-freq: 2
+
+# Create unsampled endstates for long-range sterics correction
+unsampled_endstates: True


### PR DESCRIPTION
## Description

Adds timestamp and ligands names (old and new) metadata to the generated perses yaml file.

Wrote a new function that encapsulates the generation of the parsed YAML file and adds the mentioned metadata.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #998 

## How has this been tested?
Created automated unit test for yaml generation in `test_relative_setup.py`. Also tested locally with running the `examples/protein-ligand/cli` example.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Perses output yaml file now adds timestamp and ligands names information (for old and new ligands).
```
