### PR TITLE
Fix RelativeFEPSetup bug preventing user from controlling the padding in solvent phase

### DIFF
--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -826,8 +826,6 @@ class RelativeFEPSetup(object):
         #hs = [atom for atom in modeller.topology.atoms() if atom.element.symbol in ['H'] and atom.residue.name not in ['MOL','OLD','NEW']]
         #modeller.delete(hs)
         #modeller.addHydrogens(forcefield=self._system_generator.forcefield)
-        _logger.info(f'box_dimensions: {box_dimensions}')
-        _logger.info(f'solvent padding: {self._padding}')
         run_solvate = True
 
         if phase == 'vacuum':
@@ -839,8 +837,10 @@ class RelativeFEPSetup(object):
         if run_solvate:
             _logger.info(f"\tpreparing to add solvent")
             if box_dimensions is None:
+                _logger.info(f'solvent padding: {self._padding}')
                 modeller.addSolvent(self._system_generator.forcefield, model=model, padding=self._padding, ionicStrength=ionic_strength)
             else:
+                _logger.info(f'box_dimensions: {box_dimensions}')
                 modeller.addSolvent(self._system_generator.forcefield, model=model, ionicStrength=ionic_strength, boxSize=box_dimensions)
         solvated_topology = modeller.getTopology()
         if phase == 'complex' and self._padding == 0. and box_dimensions is not None:

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -829,8 +829,7 @@ class RelativeFEPSetup(object):
         _logger.info(f'box_dimensions: {box_dimensions}')
         _logger.info(f'solvent padding: {self._padding}')
         run_solvate = True
-        if phase == 'solvent':
-            self._padding = 9. * unit.angstrom
+
         if phase == 'vacuum':
             run_solvate = False
             _logger.info(f"\tSkipping solvation of vacuum perturbation")

--- a/perses/tests/test_relative_setup.py
+++ b/perses/tests/test_relative_setup.py
@@ -305,5 +305,25 @@ def test_relative_setup_charge_change():
     charge_diff = int(old_system_charge_sum - new_system_charge_sum)
     assert np.isclose(charge_diff, 0), f"charge diff is {charge_diff} but should be zero."
 
+
+def test_relative_setup_solvent_padding():
+    """
+    Check that the user inputted solvent_padding argument to `RelativeFEPSetup` actually changes the padding for the solvent phase
+    """
+    from perses.app.relative_setup import RelativeFEPSetup
+    import numpy as np
+
+    input_solvent_padding = 1.7 * unit.nanometers
+    smiles_filename = resource_filename("perses", os.path.join("data", "test.smi"))
+    fe_setup = RelativeFEPSetup(
+        ligand_input=smiles_filename,
+        old_ligand_index=0,
+        new_ligand_index=1,
+        forcefield_files=["amber14/tip3p.xml"],
+        small_molecule_forcefield="gaff-2.11",
+        phases=["solvent"],
+        solvent_padding=input_solvent_padding)
+    assert input_solvent_padding == fe_setup._padding
+
 # if __name__=="__main__":
 #     test_run_cdk2_iterations_repex()

--- a/perses/tests/test_relative_setup.py
+++ b/perses/tests/test_relative_setup.py
@@ -323,7 +323,7 @@ def test_relative_setup_solvent_padding():
         small_molecule_forcefield="gaff-2.11",
         phases=["solvent"],
         solvent_padding=input_solvent_padding)
-    assert input_solvent_padding == fe_setup._padding
+    assert input_solvent_padding == fe_setup._padding, f"Input solvent padding, {input_solvent_padding}, is different from setup object solvent padding, {fe_setup._padding}."
 
 # if __name__=="__main__":
 #     test_run_cdk2_iterations_repex()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->
This PR fixes a bug that prevents the user from choosing the padding size (for adding solvent) when the phase is solvent. 

Note: I found this when I was trying to write the small molecule repex internal consistency tests.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->
Currently the code always uses a 9 angstrom padding whenever the phase is solvent. I removed the code that does this.

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Added `tests/test_relative_setup.py::test_relative_setup_solvent_padding`

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Fix bug in RelativeFEPSetup that prevents user from controlling the padding when solvating for solvent phase calculations. 
```
