### PR TITLE
only split after first colon when doing an override

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -1033,7 +1033,7 @@ def _process_overrides(overrides, yaml_options):
 
     overrides_dict = {}
     for opt in overrides:
-        key, val = opt.split(":")
+        key, val = opt.split(":", maxsplit=1)
 
         # Check for duplicates
         if key in overrides_dict:


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

Allows users to specify an override like `--override  foo:bar:baz` to be split into `foo` and `bar:baz` instead of `foo` `bar` `baz` which would break our parser. Common use case is to have a url as a key, ie `some_path:http://s3.aws.com`

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1060 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

Tested locally.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Fixes bug where if a `:` was in a key, we could not override the arguement in our perses-cli. 
```
