### PR TITLE
Feat/enable cloud io

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -88,9 +88,12 @@ jobs:
 
       - name: Test the package
         shell: bash -l {0}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.S3_TEST_KEY }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_TEST_SECRET }}
         run: |
           export TRAVIS=true
-          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" perses/tests
+          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" -k test_s3_yaml_read perses/tests
 
       - name: Codecov
         if: ${{ github.repository == 'choderalab/perses'

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -93,7 +93,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.S3_TEST_SECRET }}
         run: |
           export TRAVIS=true
-          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" -k test_s3_yaml_read perses/tests
+          pytest -v --cov-report xml --cov=perses --durations=0 -a "not advanced" -n auto -m "not gpu_needed" perses/tests
 
       - name: Codecov
         if: ${{ github.repository == 'choderalab/perses'

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -49,3 +49,4 @@ dependencies:
   - arsenic
   - click
   - rich
+  - cloudpathlib

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -49,4 +49,4 @@ dependencies:
   - arsenic
   - click
   - rich
-  - cloudpathlib
+  - cloudpathlib-all

--- a/perses/analysis/fah_analysis.py
+++ b/perses/analysis/fah_analysis.py
@@ -1,3 +1,4 @@
+from cloudpathlib import AnyPath
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -107,7 +108,7 @@ def free_energies(
     """
 
     # load pandas dataframe from FAH
-    work = pd.read_pickle(work_file_path)
+    work = pd.read_pickle(AnyPath(work_file_path))
 
     # convert columns to numeric
     for c in [
@@ -124,7 +125,7 @@ def free_energies(
 
     details = {}
     for path in details_file_path:
-        with open(path, "r") as f:
+        with open(AnyPath(path), "r") as f:
             new = json.load(f)
             details = {**details, **new}
 

--- a/perses/app/cli.py
+++ b/perses/app/cli.py
@@ -2,6 +2,7 @@
 import logging
 import os
 import openmm.testInstallation
+from cloudpathlib import AnyPath
 
 import click
 import openmmtools.utils
@@ -83,7 +84,7 @@ def _test_platform(platform_name):
 
 
 @click.command()
-@click.option("--yaml", type=click.Path(exists=True, dir_okay=False), required=True,
+@click.option("--yaml", type=click.Path(path_type=AnyPath), required=True,
               help='Input yaml file with simulation parameters and options.')
 @click.option("--platform-name", "--platform", type=str, default=None,
               help='Platform name to be used during the simulation. (i.e. cuda, OpenCL, CPU, Reference).')

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -11,6 +11,8 @@ import simtk.unit as unit
 from simtk import openmm
 import logging
 import datetime
+from cloudpathlib import AnyPath
+
 
 # TODO: Move logging filters to utils module
 class TimeFilter(logging.Filter):
@@ -152,7 +154,7 @@ def make_core_file(numSteps,
 
     # Serialize core.xml
     import dicttoxml
-    with open(f'{directory}/core.xml', 'wt') as outfile:
+    with open(AnyPath(f'{directory}/core.xml'), 'wt') as outfile:
         #core_parameters = create_core_parameters(phase)
         xml = dicttoxml.dicttoxml(core_parameters, custom_root='config', attr_type=False)
         from xml.dom.minidom import parseString
@@ -512,7 +514,7 @@ def run_neq_fah_setup(ligand_file,
             pass
 
         import yaml
-        metadata_filename = f'{dir}/metadata.yaml'
+        metadata_filename = AnyPath(f'{dir}/metadata.yaml')
         with open(metadata_filename, 'wt') as outfile:
             outfile.write(yaml.dump(metadata))
 
@@ -559,7 +561,7 @@ def run_neq_fah_setup(ligand_file,
         # TODO: This is really clunky.
         # TODO: Improve the way we serialize these atom mappings
         htf = htfs[phase]
-        np.savez(f'{dir}/hybrid_atom_mappings.npz',
+        np.savez(AnyPath(f'{dir}/hybrid_atom_mappings.npz'),
                  # Full system maps
                  hybrid_to_old_map=htf._hybrid_to_old_map,
                  hybrid_to_new_map=htf._hybrid_to_new_map,
@@ -583,7 +585,7 @@ def run_neq_fah_setup(ligand_file,
         # NOTE: This uses a fragile, slow, and inconvenient numpy savez + pickle scheme
         # TODO: Replace this with a better serialization scheme to enable more rapid access to useful information
         _logger.info(f'Serializing hybrid topology factory...')
-        np.savez_compressed(f'{dir}/htf',htfs[phase])
+        np.savez_compressed(AnyPath(f'{dir}/htf'),htfs[phase])
 
         # Serialize the hybrid_system OpenMM System for execution on Folding@home
         _logger.info(f'Serializing hybrid System...')
@@ -639,6 +641,7 @@ def run(yaml_filename=None):
 
     # Read setup options from the YAML file
     import yaml
+    yaml_filename = AnyPath(yaml_filename)
     yaml_file = open(yaml_filename, 'r')
     setup_options = yaml.load(yaml_file, Loader=yaml.FullLoader)
     yaml_file.close()

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -199,7 +199,7 @@ class RelativeFEPSetup(object):
 
 
         if self._use_given_geometries:
-            assert self._ligand_input.suffex == '.sdf' or self._ligand_input.suffex == '.mol2', f"cannot use deterministic atom placement if the ligand input files do not contain geometry information (e.g. in .sdf or .mol2 format)"
+            assert self._ligand_input.suffix == '.sdf' or self._ligand_input.suffix == '.mol2', f"cannot use deterministic atom placement if the ligand input files do not contain geometry information (e.g. in .sdf or .mol2 format)"
             assert 'complex' in phases, f"cannot use deterministic atom placement if complex is not in the specified phases to generate"
             # TODO: add deterministic geometry proposal to solvent and vacuum
 

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -166,24 +166,24 @@ class RelativeFEPSetup(object):
 
         if protein_pdb_filename:
             self.protein_pdb_filename = AnyPath(protein_pdb_filename)
-        else: 
+        else:
             self.protein_pdb_filename = protein_pdb_filename
-        
+
         if receptor_mol2_filename:
             self.receptor_mol2_filename = AnyPath(receptor_mol2_filename)
         else:
             self.receptor_mol2_filename = receptor_mol2_filename
-        
+
         if small_molecule_parameters_cache:
             self.small_molecule_parameters_cache = AnyPath(small_molecule_parameters_cache)
         else:
             self.small_molecule_parameters_cache = small_molecule_parameters_cache
-        
+
         if trajectory_prefix:
             self._trajectory_prefix = AnyPath(trajectory_prefix)
         else:
             self._trajectory_prefix = trajectory_prefix
-        
+
         if trajectory_directory:
             self._trajectory_directory = AnyPath(trajectory_directory)
         else:
@@ -194,7 +194,7 @@ class RelativeFEPSetup(object):
                 self.forcefield_files = [AnyPath(forcefield_file) for forcefield_file in forcefield_files]
             else:
                 self.forcefield_files = AnyPath(forcefield_files)
-        else: 
+        else:
             self.forcefield_files = forcefield_files
 
 

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -10,6 +10,7 @@ from perses.rjmc.geometry import FFAllAngleGeometryEngine
 from openmmtools.states import ThermodynamicState, CompoundThermodynamicState, SamplerState
 
 import pymbar
+from cloudpathlib import AnyPath
 import simtk.openmm as openmm
 import simtk.openmm.app as app
 import simtk.unit as unit
@@ -159,10 +160,46 @@ class RelativeFEPSetup(object):
         self._solvent_box_dimensions = solvent_box_dimensions
         self._use_given_geometries = use_given_geometries
         self._given_geometries_tolerance = given_geometries_tolerance
-        self._ligand_input = ligand_input
+        self.small_molecule_forcefield = small_molecule_forcefield
+        if ligand_input:
+            self._ligand_input = AnyPath(ligand_input)
+
+        if protein_pdb_filename:
+            self.protein_pdb_filename = AnyPath(protein_pdb_filename)
+        else: 
+            self.protein_pdb_filename = protein_pdb_filename
+        
+        if receptor_mol2_filename:
+            self.receptor_mol2_filename = AnyPath(receptor_mol2_filename)
+        else:
+            self.receptor_mol2_filename = receptor_mol2_filename
+        
+        if small_molecule_parameters_cache:
+            self.small_molecule_parameters_cache = AnyPath(small_molecule_parameters_cache)
+        else:
+            self.small_molecule_parameters_cache = small_molecule_parameters_cache
+        
+        if trajectory_prefix:
+            self._trajectory_prefix = AnyPath(trajectory_prefix)
+        else:
+            self._trajectory_prefix = trajectory_prefix
+        
+        if trajectory_directory:
+            self._trajectory_directory = AnyPath(trajectory_directory)
+        else:
+            self._trajectory_directory = trajectory_directory
+
+        if forcefield_files:
+            if isinstance(forcefield_files, (list, set, tuple)):
+                self.forcefield_files = [AnyPath(forcefield_file) for forcefield_file in forcefield_files]
+            else:
+                self.forcefield_files = AnyPath(forcefield_files)
+        else: 
+            self.forcefield_files = forcefield_files
+
 
         if self._use_given_geometries:
-            assert self._ligand_input[-3:] == 'sdf' or self._ligand_input[-4:] == 'mol2', f"cannot use deterministic atom placement if the ligand input files do not contain geometry information (e.g. in .sdf or .mol2 format)"
+            assert self._ligand_input.suffex == '.sdf' or self._ligand_input.suffex == '.mol2', f"cannot use deterministic atom placement if the ligand input files do not contain geometry information (e.g. in .sdf or .mol2 format)"
             assert 'complex' in phases, f"cannot use deterministic atom placement if complex is not in the specified phases to generate"
             # TODO: add deterministic geometry proposal to solvent and vacuum
 
@@ -193,15 +230,12 @@ class RelativeFEPSetup(object):
                 self._nonbonded_method = app.NoCutoff
 
 
-        self._trajectory_prefix = trajectory_prefix
-        self._trajectory_directory = trajectory_directory
 
         beta = 1.0 / (kB * temperature)
 
-        mol_list = []
+        self.mol_list = []
 
         #all legs need ligands so do this first
-        self._ligand_input = ligand_input
         self._old_ligand_index = old_ligand_index
         self._new_ligand_index = new_ligand_index
         _logger.info(f"Handling files for ligands and indices...")
@@ -209,7 +243,7 @@ class RelativeFEPSetup(object):
             # Make sure the input file exists
             if not os.path.isfile(self._ligand_input):
                 raise FileNotFoundError(f"Input file at {self._ligand_input} does not exist.")
-            if self._ligand_input[-3:] == 'smi': #
+            if self._ligand_input.suffix == '.smi': #
                 _logger.info(f"Detected .smi format.  Proceeding...")
                 _logger.info('  Note that SMILES does not contain geometry information for use in mapping')
                 self._ligand_smiles_old = load_smi(self._ligand_input,self._old_ligand_index)
@@ -226,8 +260,8 @@ class RelativeFEPSetup(object):
                 self._ligand_oemol_new = generate_unique_atom_names(self._ligand_oemol_new)
                 _logger.info(f"\tsuccessfully created old and new systems from smiles")
 
-                mol_list.append(self._ligand_oemol_old)
-                mol_list.append(self._ligand_oemol_new)
+                self.mol_list.append(self._ligand_oemol_old)
+                self.mol_list.append(self._ligand_oemol_new)
 
                 # forcefield_generators needs to be able to distinguish between the two ligands
                 # while topology_proposal needs them to have the same residue name
@@ -239,15 +273,15 @@ class RelativeFEPSetup(object):
                 self._ligand_topology_new = forcefield_generators.generateTopologyFromOEMol(self._ligand_oemol_new)
                 _logger.info(f"\tsuccessfully generated topologies for both oemols.")
 
-            elif self._ligand_input[-3:] == 'sdf' or self._ligand_input[-4:] == 'mol2': #
+            elif self._ligand_input.suffix == '.sdf' or self._ligand_input.suffix == '.mol2': #
                 _logger.info(f"Detected .sdf format.  Proceeding...") #TODO: write checkpoints for sdf format
                 self._ligand_oemol_old = createOEMolFromSDF(self._ligand_input, index=self._old_ligand_index, allow_undefined_stereo=True)
                 self._ligand_oemol_new = createOEMolFromSDF(self._ligand_input, index=self._new_ligand_index, allow_undefined_stereo=True)
                 # self._ligand_oemol_old = generate_unique_atom_names(self._ligand_oemol_old)
                 # self._ligand_oemol_new = generate_unique_atom_names(self._ligand_oemol_new)
 
-                mol_list.append(self._ligand_oemol_old)
-                mol_list.append(self._ligand_oemol_new)
+                self.mol_list.append(self._ligand_oemol_old)
+                self.mol_list.append(self._ligand_oemol_new)
 
                 self._ligand_positions_old = extractPositionsFromOEMol(self._ligand_oemol_old)
                 self._ligand_positions_new = extractPositionsFromOEMol(self._ligand_oemol_new)
@@ -276,8 +310,8 @@ class RelativeFEPSetup(object):
             self._ligand_oemol_old.SetTitle("OLD")
             self._ligand_oemol_new.SetTitle("NEW")
 
-            mol_list.append(self._ligand_oemol_old)
-            mol_list.append(self._ligand_oemol_new)
+            self.mol_list.append(self._ligand_oemol_old)
+            self.mol_list.append(self._ligand_oemol_new)
 
             # forcefield_generators needs to be able to distinguish between the two ligands
             # while topology_proposal needs them to have the same residue name
@@ -346,12 +380,12 @@ class RelativeFEPSetup(object):
         from openmmforcefields.generators import SystemGenerator
         _logger.info(f'PME tolerance: {self._pme_tol}')
         forcefield_kwargs = {'removeCMMotion': False, 'ewaldErrorTolerance': self._pme_tol, 'constraints' : self._h_constraints, 'rigidWater': self._rigid_water, 'hydrogenMass' : self._hmass}
-        if small_molecule_forcefield is None or small_molecule_forcefield == 'None':
-            self._system_generator = SystemGenerator(forcefields=forcefield_files, barostat=barostat, forcefield_kwargs=forcefield_kwargs,
+        if self.small_molecule_forcefield is None or self.small_molecule_forcefield == 'None':
+            self._system_generator = SystemGenerator(forcefields=self.forcefield_files, barostat=barostat, forcefield_kwargs=forcefield_kwargs,
                                       periodic_forcefield_kwargs = {'nonbondedMethod': self._nonbonded_method})
         else:
-            self._system_generator = SystemGenerator(forcefields=forcefield_files, barostat=barostat, forcefield_kwargs=forcefield_kwargs,
-                                                     small_molecule_forcefield=small_molecule_forcefield, molecules=molecules, cache=small_molecule_parameters_cache, periodic_forcefield_kwargs = {'nonbondedMethod': self._nonbonded_method})
+            self._system_generator = SystemGenerator(forcefields=self.forcefield_files, barostat=barostat, forcefield_kwargs=forcefield_kwargs,
+                                                     small_molecule_forcefield=self.small_molecule_forcefield, molecules=molecules, cache=self.small_molecule_parameters_cache, periodic_forcefield_kwargs = {'nonbondedMethod': self._nonbonded_method})
         _logger.info("successfully created SystemGenerator to create ligand systems")
 
         _logger.info(f"executing SmallMoleculeSetProposalEngine...")
@@ -376,7 +410,7 @@ class RelativeFEPSetup(object):
         if 'complex' in phases:
             _logger.info('Generating the topology proposal from the complex leg')
             _logger.info(f"setting up complex phase...")
-            self._setup_complex_phase(protein_pdb_filename,receptor_mol2_filename,mol_list)
+            self._setup_complex_phase()
             self._complex_topology_old_solvated, self._complex_positions_old_solvated, self._complex_system_old_solvated = self._solvate_system(
             self._complex_topology_old, self._complex_positions_old,phase='complex',box_dimensions=self._complex_box_dimensions, ionic_strength=self._ionic_strength)
             _logger.info(f"successfully generated complex topology, positions, system")
@@ -551,32 +585,23 @@ class RelativeFEPSetup(object):
                 self._vacuum_reverse_neglected_angles = self._geometry_engine.reverse_neglected_angle_terms
             self._vacuum_geometry_engine = copy.deepcopy(self._geometry_engine)
 
-    def _setup_complex_phase(self,protein_pdb_filename,receptor_mol2_filename,mol_list):
+    def _setup_complex_phase(self):
         """
         Runs setup on the protein/receptor file for relative simulations
-
-        Parameters
-        ----------
-        protein_pdb_filename : str, default None
-            Protein pdb filename. If none, receptor_mol2_filename must be provided
-        receptor_mol2_filename : str, default None
-            Receptor mol2 filename. If none, protein_pdb_filename must be provided
         """
         # TODO: What if you get both protein pdb and receptor mol2?
         # It might be a better idea to have something to auto-detect the format or a kwarg to specify it.
-        if protein_pdb_filename:
-            self._protein_pdb_filename = protein_pdb_filename
-            protein_pdbfile = open(self._protein_pdb_filename, 'r')
+        if self.protein_pdb_filename:
+            protein_pdbfile = open(self.protein_pdb_filename, 'r')
             pdb_file = app.PDBFile(protein_pdbfile)
             protein_pdbfile.close()
             self._receptor_positions_old = pdb_file.positions
             self._receptor_topology_old = pdb_file.topology
             self._receptor_md_topology_old = md.Topology.from_openmm(self._receptor_topology_old)
 
-        elif receptor_mol2_filename:
-            self._receptor_mol2_filename = receptor_mol2_filename
-            self._receptor_mol = createOEMolFromSDF(self._receptor_mol2_filename)
-            mol_list.append(self._receptor_mol)
+        elif self.receptor_mol2_filename:
+            self._receptor_mol = createOEMolFromSDF(self.receptor_mol2_filename)
+            self.mol_list.append(self._receptor_mol)
             self._receptor_positions_old = extractPositionsFromOEMol(self._receptor_mol)
             self._receptor_topology_old = forcefield_generators.generateTopologyFromOEMol(self._receptor_mol)
             self._receptor_md_topology_old = md.Topology.from_openmm(self._receptor_topology_old)
@@ -849,13 +874,13 @@ class RelativeFEPSetup(object):
         solvated_positions = modeller.getPositions()
 
         # canonicalize the solvated positions: turn tuples into np.array
-        solvated_positions = unit.quantity.Quantity(value = np.array([list(atom_pos) for atom_pos in solvated_positions.value_in_unit_system(unit.md_unit_system)]), unit = unit.nanometers)
+        ssuffixolvated_positions = unit.quantity.Quantity(value = np.array([list(atom_pos) for atom_pos in solvated_positions.value_in_unit_system(unit.md_unit_system)]), unit = unit.nanometers)
         _logger.info(f"\tparameterizing...")
         solvated_system = self._system_generator.create_system(solvated_topology)
         _logger.info(f"\tSystem parameterized")
 
         if self._trajectory_directory is not None and self._trajectory_prefix is not None:
-            pdb_filename = f"{self._trajectory_directory}/{self._trajectory_prefix}-{phase}.pdb"
+            pdb_filename = AnyPath(f"{self._trajectory_directory}/{self._trajectory_prefix}-{phase}.pdb")
             with open(pdb_filename, 'w') as outfile:
                 PDBFile.writeFile(solvated_topology, solvated_positions, outfile)
         else:
@@ -1118,7 +1143,7 @@ class NonequilibriumSwitchingFEP(DaskClient):
         self._hybrid_system = self._factory.hybrid_system
         self._initial_hybrid_positions = self._factory.hybrid_positions
         self._n_equil_steps = n_equilibrium_steps_per_iteration
-        self._trajectory_prefix = trajectory_prefix
+        self._trajectory_prefix = AnyPath(trajectory_prefix)
         self._trajectory_directory = trajectory_directory
         self._atom_selection = atom_selection
         self._current_iteration = 0
@@ -1128,9 +1153,9 @@ class NonequilibriumSwitchingFEP(DaskClient):
         _logger.info(f"instantiating trajectory filenames")
         if self._trajectory_directory and self._trajectory_prefix:
             self._write_traj = True
-            self._trajectory_filename = {lambda_state: os.path.join(os.getcwd(), self._trajectory_directory, f"{trajectory_prefix}.eq.lambda_{lambda_state}.h5") for lambda_state in [0,1]}
+            self._trajectory_filename = {lambda_state: os.path.join(self._trajectory_directory, f"{self._trajectory_prefix}.eq.lambda_{lambda_state}.h5") for lambda_state in [0,1]}
             _logger.debug(f"eq_traj_filenames: {self._trajectory_filename}")
-            self._neq_traj_filename = {direct: os.path.join(os.getcwd(), self._trajectory_directory, f"{trajectory_prefix}.neq.lambda_{direct}") for direct in ['forward', 'reverse']}
+            self._neq_traj_filename = {direct: os.path.join(self._trajectory_directory, f"{self._trajectory_prefix}.neq.lambda_{direct}") for direct in ['forward', 'reverse']}
             _logger.debug(f"neq_traj_filenames: {self._neq_traj_filename}")
         else:
             self._write_traj = False

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -874,7 +874,7 @@ class RelativeFEPSetup(object):
         solvated_positions = modeller.getPositions()
 
         # canonicalize the solvated positions: turn tuples into np.array
-        ssuffixolvated_positions = unit.quantity.Quantity(value = np.array([list(atom_pos) for atom_pos in solvated_positions.value_in_unit_system(unit.md_unit_system)]), unit = unit.nanometers)
+        solvated_positions = unit.quantity.Quantity(value = np.array([list(atom_pos) for atom_pos in solvated_positions.value_in_unit_system(unit.md_unit_system)]), unit = unit.nanometers)
         _logger.info(f"\tparameterizing...")
         solvated_system = self._system_generator.create_system(solvated_topology)
         _logger.info(f"\tSystem parameterized")

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -566,6 +566,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
 
         if 'render_atom_map' in list(setup_options.keys()) and setup_options['render_atom_map']:
             try:
+                atom_map_outfile = str(atom_map_outfile)
                 render_atom_mapping(atom_map_outfile, fe_setup._ligand_oemol_old, fe_setup._ligand_oemol_new, fe_setup.non_offset_new_to_old_atom_map)
             except TypeError:
                 _logger.critical("COULD NOT WRITE ATOM MAPPING. \

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -70,8 +70,9 @@ def getSetupOptions(filename, override_string=None):
     phases : list of strings
         phases to simulate, can be 'complex', 'solvent' or 'vacuum'
     """
+
+    filename = AnyPath(filename)
     yaml_file = open(filename, 'r')
-    yaml_file = AnyPath(yaml_file)
     setup_options = yaml.load(yaml_file, Loader=yaml.FullLoader)
     yaml_file.close()
     if override_string:
@@ -531,8 +532,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
 
         _logger.info(f"\twriting pickle output...")
         if setup_pickle_file is not None:
-            #TODO Problem with os.getcwd
-            with open(os.path.join(os.getcwd(), trajectory_directory, setup_pickle_file), 'wb') as f:
+            with open(AnyPath(os.path.join(trajectory_directory, setup_pickle_file)), 'wb') as f:
                 try:
                     pickle.dump(fe_setup, f)
                     _logger.info(f"\tsuccessfully dumped pickle.")

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -74,18 +74,14 @@ def test_dummy_cli_with_override(in_tmpdir):
     reason="This test needs API keys from AWS to work",
 )
 def test_s3_yaml_read(in_tmpdir):
-    from cloudpathlib import S3Client
-
-    # This is needed since we use aws envars in CI, so we need to use
-    # non-default names
-    client = S3Client(
-        aws_access_key_id=os.getenv("S3_TEST_KEY"),
-        aws_secret_access_key=os.getenv("S3_TEST_SECRET"),
-    )
-    client.set_as_default_client()
-
     runner = CliRunner()
+
+    key = os.getenv("S3_TEST_KEY")
+    secret = os.getenv("S3_TEST_SECRET")
+
     env = os.environ
+    env["AWS_SECRET_ACCESS_KEY"] = secret
+    env["AWS_ACCESS_KEY_ID"] = key
     with runner.isolated_filesystem():
         protein_pdb = resource_filename(
             "perses", os.path.join("data", "Tyk2_ligands_example", "Tyk2_protein.pdb")

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -76,12 +76,6 @@ def test_dummy_cli_with_override(in_tmpdir):
 def test_s3_yaml_read(in_tmpdir):
     runner = CliRunner()
 
-    key = os.getenv("S3_TEST_KEY")
-    secret = os.getenv("S3_TEST_SECRET")
-
-    env = os.environ
-    env["AWS_SECRET_ACCESS_KEY"] = secret
-    env["AWS_ACCESS_KEY_ID"] = key
     with runner.isolated_filesystem():
         protein_pdb = resource_filename(
             "perses", os.path.join("data", "Tyk2_ligands_example", "Tyk2_protein.pdb")
@@ -100,6 +94,5 @@ def test_s3_yaml_read(in_tmpdir):
                 "--override",
                 f"ligand_file:{ligand_file}",
             ],
-            env=env,
         )
         assert result.exit_code == 0

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -85,6 +85,7 @@ def test_s3_yaml_read(in_tmpdir):
     client.set_as_default_client()
 
     runner = CliRunner()
+    env = os.environ
     with runner.isolated_filesystem():
         protein_pdb = resource_filename(
             "perses", os.path.join("data", "Tyk2_ligands_example", "Tyk2_protein.pdb")
@@ -103,5 +104,6 @@ def test_s3_yaml_read(in_tmpdir):
                 "--override",
                 f"ligand_file:{ligand_file}",
             ],
+            env=env,
         )
         assert result.exit_code == 0

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -67,7 +67,17 @@ def test_dummy_cli_with_override(in_tmpdir):
         )
         assert result.exit_code == 0
 
+
 def test_s3_yaml_read(in_tmpdir):
+    from cloudpathlib import S3Client
+
+    # This is needed since we use aws envars in CI, so we need to use
+    # non-default names
+    client = S3Client(
+        aws_access_key_id=os.getenv("S3_TEST_KEY"),
+        aws_secret_access_key=os.getenv("S3_TEST_SECRET"),
+    )
+    client.set_as_default_client()
 
     runner = CliRunner()
     with runner.isolated_filesystem():
@@ -82,7 +92,7 @@ def test_s3_yaml_read(in_tmpdir):
             cli,
             [
                 "--yaml",
-                "test.yaml",
+                "s3://perses-testing/s3_test.yaml",
                 "--override",
                 f"protein_pdb:{protein_pdb}",
                 "--override",

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -66,3 +66,27 @@ def test_dummy_cli_with_override(in_tmpdir):
             ],
         )
         assert result.exit_code == 0
+
+def test_s3_yaml_read(in_tmpdir):
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        protein_pdb = resource_filename(
+            "perses", os.path.join("data", "Tyk2_ligands_example", "Tyk2_protein.pdb")
+        )
+        ligand_file = resource_filename(
+            "perses",
+            os.path.join("data", "Tyk2_ligands_example", "Tyk2_ligands_shifted.sdf"),
+        )
+        result = runner.invoke(
+            cli,
+            [
+                "--yaml",
+                "test.yaml",
+                "--override",
+                f"protein_pdb:{protein_pdb}",
+                "--override",
+                f"ligand_file:{ligand_file}",
+            ],
+        )
+        assert result.exit_code == 0

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 
+import pytest
 from click.testing import CliRunner
 from pkg_resources import resource_filename
 
@@ -68,6 +69,10 @@ def test_dummy_cli_with_override(in_tmpdir):
         assert result.exit_code == 0
 
 
+@pytest.mark.skipif(
+    not os.environ.get("GITHUB_ACTIONS", None),
+    reason="This test needs API keys from AWS to work",
+)
 def test_s3_yaml_read(in_tmpdir):
     from cloudpathlib import S3Client
 

--- a/perses/utils/data.py
+++ b/perses/utils/data.py
@@ -106,15 +106,17 @@ def serialize(item, filename):
     item : System, State, or Integrator
         The thing to be serialized
     filename : str
-        The filename to serialize to    
+        The filename to serialize to
     """
+    from cloudpathlib import AnyPath
     from simtk.openmm import XmlSerializer
-    if filename[-2:] == 'gz':
+    filename = AnyPath(filename)
+    if filename.suffix== '.gz':
         import gzip
         with gzip.open(filename, 'wb') as outfile:
             serialized_thing = XmlSerializer.serialize(item)
             outfile.write(serialized_thing.encode())
-    if filename[-3:] == 'bz2':
+    if filename.suffix == '.bz2':
         import bz2
         with bz2.open(filename, 'wb') as outfile:
             serialized_thing = XmlSerializer.serialize(item)

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -345,7 +345,7 @@ def createOEMolFromSDF(sdf_filename, index=0, add_hydrogens=True, allow_undefine
 
     # TODO this needs a test
     ifs = oechem.oemolistream()
-    ifs.open(sdf_filename)
+    ifs.open(str(sdf_filename))
     # get the list of molecules
     mol_list = [oechem.OEMol(mol) for mol in ifs.GetOEMols()]
     # we'll always take the first for now

--- a/perses/utils/smallmolecules.py
+++ b/perses/utils/smallmolecules.py
@@ -242,7 +242,7 @@ def render_atom_mapping(filename, molecule1, molecule2, new_to_old_atom_map, wid
     # Set up image options
     itf = oechem.OEInterface()
     oedepict.OEConfigureImageOptions(itf)
-    ext = oechem.OEGetFileExtension(filename)
+    ext = oechem.OEGetFileExtension(str(filename))
     if not oedepict.OEIsRegisteredImageFile(ext):
         raise Exception('Unknown image type for filename %s' % filename)
     ofs = oechem.oeofstream()


### PR DESCRIPTION
## Description

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1072 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Added upport for reading input files (ex yaml, sdf, pdbs) from AWS, GCP, and Azure. See the documentation for [cloudpathlib](https://cloudpathlib.drivendata.org/stable/authentication/) for how to setup authentication. Currently only reading the yaml from S3 is unit tested (ie `perses-cli --yaml s3://perses-testing/template_s3.yaml`), but other cloud providers and input files should work. Please report any issues on our issue tracker! 

```
