### PR TITLE
Cleaning up platform and context usage in geometry engine

### DIFF
--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -732,6 +732,9 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         added_energy_components = compute_potential_components(mod_context)
         print(f"added energy components: {added_energy_components}")
 
+        # Explicitly clean up context memory allocation
+        del mod_context
+
         return modified_reduced_potential_energy
 
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -325,7 +325,8 @@ class FFAllAngleGeometryEngine(GeometryEngine):
         pdbfile.flush()
         pdbfile.write('ENDMDL\n')
 
-    def _logp_propose(self, top_proposal, old_positions, beta, new_positions=None, direction='forward', validate_energy_bookkeeping = True):
+    def _logp_propose(self, top_proposal, old_positions, beta, new_positions=None, direction='forward',
+                      validate_energy_bookkeeping=True, platform_name='CPU'):
         """
         This is an INTERNAL function that handles both the proposal and the logp calculation,
         to reduce code duplication. Whether it proposes or just calculates a logp is based on
@@ -449,8 +450,6 @@ class FFAllAngleGeometryEngine(GeometryEngine):
 
         if self._storage:
             self._storage.write_object("{}_proposal_order".format(direction), proposal_order_tool, iteration=self.nproposed)
-
-        platform_name = 'CUDA'
 
         # Create an OpenMM context
         from simtk import openmm

--- a/perses/tests/utils.py
+++ b/perses/tests/utils.py
@@ -29,7 +29,7 @@ temperature = 300.0 * unit.kelvin
 kT = kB * temperature
 beta = 1.0/kT
 ENERGY_THRESHOLD = 1e-1
-DEFAULT_PLATFORM = utils.get_fastest_platform()
+DEFAULT_PLATFORM = openmm.Platform.getPlatformByName('CPU')
 
 ################################################################################
 # UTILITIES


### PR DESCRIPTION
## Description
By default the `CUDA` platform was hardcoded in the geometry engine. Generating contexts that were not handled correctly. This PR is aimed towards making `CPU` to be the default platform for the geometry engine and cleans explicitly created contexts for a better memory management.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1085 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
``CUDA`` platform was hardcoded in geometry engine, generating performance issues by not clearing openmm contexts correctly. Fixed by defaulting to using the faster ``CPU`` platform (for the geometry engine) and explicitly deleting context variables after they are used.
```
