### PR TITLE
Not reassigning velocities on resume for small molecule pipeline

### DIFF
--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -694,7 +694,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                         timestep=timestep,
                         collision_rate=1.0 / unit.picosecond,
                         n_steps=n_steps_per_move_application,
-                        reassign_velocities=True,
+                        reassign_velocities=False,
                         n_restart_attempts=20, constraint_tolerance=1e-06),
                         hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                         online_analysis_minimum_iterations=10, flatness_criteria=setup_options['flatness-criteria'],
@@ -710,7 +710,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                         timestep=timestep,
                         collision_rate=1.0 / unit.picosecond,
                         n_steps=n_steps_per_move_application,
-                        reassign_velocities=True,
+                        reassign_velocities=False,
                         n_restart_attempts=20, constraint_tolerance=1e-06),
                         hybrid_factory=htf[phase], online_analysis_interval=setup_options['offline-freq'],
                     )


### PR DESCRIPTION
## Description

The small molecule pipeline (CLI) was reassigning velocities by default on resume. Changing this behavior to avoid equilibration issues when resuming simulations now that it is supported upstream https://github.com/choderalab/openmmtools/pull/602.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1114 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Now that upstream ``openmmtools`` is storing velocities on checkpoint, the small molecule transformation pipeline does not reassign velocities on resume. Instead, it is reading them from the checkpoint file.
```
