### PR TITLE
WIP -- intuitive handling of minimization steps kwarg

### DIFF
--- a/perses/dispersed/feptasks.py
+++ b/perses/dispersed/feptasks.py
@@ -659,7 +659,6 @@ def check_EquilibriumFEPTask(task):
 
 def minimize(thermodynamic_state: states.ThermodynamicState, sampler_state: states.SamplerState,
              max_iterations: int=100) -> states.SamplerState:
-    # TODO: set max iterations to 1000 and check tyk2 benchmarks
     """
     Minimize the given system and state, up to a maximum number of steps.
     This does not return a copy of the samplerstate; it is an update-in-place.
@@ -687,6 +686,9 @@ def minimize(thermodynamic_state: states.ThermodynamicState, sampler_state: stat
         context, integrator = cache.global_context_cache.get_context(thermodynamic_state)
     sampler_state.apply_to_context(context, ignore_velocities = True)
     # TODO: Set logging for minimization
+    # If max_iterations = None, it means run as many iterations as needed to reach tolerance.
+    if max_iterations is None:
+        max_iterations = 0
     openmm.LocalEnergyMinimizer.minimize(context, maxIterations = max_iterations)
     sampler_state.update_from_context(context)
 

--- a/perses/samplers/multistate.py
+++ b/perses/samplers/multistate.py
@@ -84,7 +84,7 @@ class HybridCompatibilityMixin(object):
         sampler_state = SamplerState(positions, box_vectors=hybrid_system.getDefaultPeriodicBoxVectors())
 
         for lambda_val in lambda_schedule:
-           # Create a compound thermodynamic for lambda_val and set alchemical parameters
+            # Create a compound thermodynamic for lambda_val and set alchemical parameters
             compound_thermodynamic_state_copy = copy.deepcopy(compound_thermodynamic_state)
             if factory_name == 'HybridTopologyFactory':
                 compound_thermodynamic_state_copy.set_alchemical_parameters(lambda_val,lambda_protocol)
@@ -93,7 +93,8 @@ class HybridCompatibilityMixin(object):
             thermodynamic_state_list.append(compound_thermodynamic_state_copy)
 
             # Generate a sampler_state for each thermodynamic state
-            feptasks.minimize(compound_thermodynamic_state_copy, sampler_state, max_iterations=minimisation_steps)
+            if minimisation_steps != 0:  # only minimize if there are specified steps != 0
+                feptasks.minimize(compound_thermodynamic_state_copy, sampler_state, max_iterations=minimisation_steps)
             sampler_state_list.append(copy.deepcopy(sampler_state))
 
         reporter = storage_file


### PR DESCRIPTION
## Description

More intuitive handling of minimization steps argument `minimisation_steps` 

## Motivation and context

`minimisation_steps` should work like this instead:

* None should be interpreted to run until tolerance is reached
* 0 should be interpreted to run 0 steps


<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1086 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
