### PR TITLE
Remove basicConfig

### DIFF
--- a/perses/analysis/visualization.py
+++ b/perses/analysis/visualization.py
@@ -50,7 +50,6 @@ def _check_mpy():
 ################################################################################
 
 import logging
-logging.basicConfig(level=logging.NOTSET)
 
 _logger = logging.getLogger("visualization")
 _logger.setLevel(logging.INFO)

--- a/perses/annihilation/lambda_protocol.py
+++ b/perses/annihilation/lambda_protocol.py
@@ -4,7 +4,6 @@ import logging
 import copy
 from openmmtools.alchemy import AlchemicalState
 
-logging.basicConfig(level=logging.NOTSET)
 _logger = logging.getLogger("lambda_protocol")
 _logger.setLevel(logging.INFO)
 

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -9,7 +9,6 @@ InteractionGroup = enum.Enum("InteractionGroup", ['unique_old', 'unique_new', 'c
 
 #######LOGGING#############################
 import logging
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("relative")
 _logger.setLevel(logging.INFO)
 ###########################################

--- a/perses/annihilation/rest.py
+++ b/perses/annihilation/rest.py
@@ -11,7 +11,6 @@ from perses.annihilation.relative import HybridTopologyFactory
 
 #######LOGGING#############################
 import logging
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("REST")
 _logger.setLevel(logging.INFO)
 ###########################################

--- a/perses/app/cli.py
+++ b/perses/app/cli.py
@@ -9,11 +9,6 @@ import openmmtools.utils
 
 # Setting logging level config
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG").upper()
-logging.basicConfig(
-    format="%(asctime)s %(levelname)-8s %(message)s",
-    level=LOGLEVEL,
-    datefmt="%Y-%m-%d %H:%M:%S",
-)
 _logger = logging.getLogger()
 _logger.setLevel(LOGLEVEL)
 
@@ -93,6 +88,11 @@ def _test_platform(platform_name):
 def cli(yaml, platform_name, override):
     """Run perses relative free energy calculation."""
     from perses.app.setup_relative_calculation import run
+    logging.basicConfig(
+        format="%(asctime)s %(levelname)-8s %(message)s",
+        level=LOGLEVEL,
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     click.echo(click.style(percy, fg="bright_magenta"))
     if override:
         click.echo("✍️ \t Overrides used")

--- a/perses/app/fah_generator.py
+++ b/perses/app/fah_generator.py
@@ -31,10 +31,6 @@ class TimeFilter(logging.Filter):
 
 # TODO: Move logging configuration helpers to utils module
 fmt = logging.Formatter(fmt="%(asctime)s:(%(relative)ss):%(name)s:%(message)s")
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S')
 _logger = logging.getLogger()
 _logger.setLevel(logging.INFO)
 [hndl.addFilter(TimeFilter()) for hndl in _logger.handlers]

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -27,7 +27,6 @@ from collections import namedtuple
 import random
 from scipy.special import logsumexp
 
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("relative_setup")
 _logger.setLevel(logging.INFO)
 

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -35,12 +35,7 @@ class TimeFilter(logging.Filter):
 from perses.samplers.multistate import HybridSAMSSampler, HybridRepexSampler
 
 fmt = logging.Formatter(fmt="%(asctime)s:(%(relative)ss):%(name)s:%(message)s")
-#logging.basicConfig(level = logging.NOTSET)
 LOGLEVEL = os.environ.get("LOGLEVEL", "INFO").upper()
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=LOGLEVEL,
-    datefmt='%Y-%m-%d %H:%M:%S')
 _logger = logging.getLogger()
 _logger.setLevel(LOGLEVEL)
 [hndl.addFilter(TimeFilter()) for hndl in _logger.handlers]
@@ -1196,4 +1191,9 @@ def _generate_parsed_yaml(setup_options, input_yaml_file_path):
 
 
 if __name__ == "__main__":
+    logging.basicConfig(
+        format='%(asctime)s %(levelname)-8s %(message)s',
+        level=LOGLEVEL,
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
     run()

--- a/perses/dispersed/feptasks.py
+++ b/perses/dispersed/feptasks.py
@@ -20,7 +20,6 @@ from collections import namedtuple
 from perses.annihilation.lambda_protocol import LambdaProtocol
 
 # Instantiate logger
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("feptasks")
 _logger.setLevel(logging.INFO)
 

--- a/perses/dispersed/parallel.py
+++ b/perses/dispersed/parallel.py
@@ -3,7 +3,6 @@ import time
 import dask.distributed as distributed
 
 # Instantiate logger
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("parallelism")
 _logger.setLevel(logging.INFO)
 

--- a/perses/dispersed/smc.py
+++ b/perses/dispersed/smc.py
@@ -13,7 +13,6 @@ import random
 import pymbar
 from perses.dispersed.parallel import Parallelism
 # Instantiate logger
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("sMC")
 _logger.setLevel(logging.INFO)
 

--- a/perses/dispersed/utils.py
+++ b/perses/dispersed/utils.py
@@ -26,7 +26,6 @@ kT = kB * temperature
 beta = 1.0/kT
 
 # Instantiate logger
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("sMC_utils")
 _logger.setLevel(logging.INFO)
 DISTRIBUTED_ERROR_TOLERANCE = 1e-6

--- a/perses/rjmc/atom_mapping.py
+++ b/perses/rjmc/atom_mapping.py
@@ -19,7 +19,6 @@ import numpy as np
 ################################################################################
 
 import logging
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("atom_mapping")
 _logger.setLevel(logging.INFO)
 

--- a/perses/rjmc/geometry.py
+++ b/perses/rjmc/geometry.py
@@ -14,7 +14,6 @@ from perses.storage import NetCDFStorageView
 ################################################################################
 
 import logging
-logging.basicConfig(level=logging.NOTSET)
 _logger = logging.getLogger("geometry")
 _logger.setLevel(logging.INFO)
 

--- a/perses/rjmc/topology_proposal.py
+++ b/perses/rjmc/topology_proposal.py
@@ -25,7 +25,6 @@ except ImportError:
 ################################################################################
 
 import logging
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("proposal_generator")
 _logger.setLevel(logging.INFO)
 

--- a/perses/tests/test_atom_mapping.py
+++ b/perses/tests/test_atom_mapping.py
@@ -10,7 +10,6 @@ from openff.toolkit.topology import Molecule
 ################################################################################
 
 import logging
-logging.basicConfig(level = logging.NOTSET)
 _logger = logging.getLogger("atom_mapping")
 _logger.setLevel(logging.INFO)
 

--- a/perses/utils/openeye.py
+++ b/perses/utils/openeye.py
@@ -13,7 +13,6 @@ import simtk.unit as unit
 import numpy as np
 import logging
 
-logging.basicConfig(level=logging.NOTSET)
 _logger = logging.getLogger("utils.openeye")
 _logger.setLevel(logging.INFO)
 

--- a/perses/utils/url_utils.py
+++ b/perses/utils/url_utils.py
@@ -10,10 +10,10 @@ from http.client import RemoteDisconnected
 
 # Setting logging level config
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG").upper()
-logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
-    level=LOGLEVEL,
-    datefmt='%Y-%m-%d %H:%M:%S')
+# logging.basicConfig(
+#     format='%(asctime)s %(levelname)-8s %(message)s',
+#     level=LOGLEVEL,
+#     datefmt='%Y-%m-%d %H:%M:%S')
 _logger = logging.getLogger()
 _logger.setLevel(LOGLEVEL)
 


### PR DESCRIPTION
## Description

Removed `basicConfig` from being run on import, which causes problems for users, including one that is actually causing Python processes to crash for some users on `import perses.rjmc`.

* 7efc92931d9a9c64677a7872767baeb7e6b3583d : This is the minimal fix for the issue we're having
* d95a5fd30bfff2f4a90e5771382de339feb06af4 : I went ahead and removed similar issues from the rest of the library. I did not change things that looked like a script. For the CLI and anything with a `__main__` guard, I moved the `basicConfig` to only run on execution.

One I didn't change is in `tests/test_geometry_engine.py`. I'm not sure why that logging setting is there, but that looked like a Chesterton's fence.

I commented out the instance in `utils/url_utils.py` because maybe someone means to make that into a proper formatted version?

Places that still have `logging.basicConfig`:

```
benchmarks/run_benchmarks.py:22:logging.basicConfig(
perses/app/cli.py:91:    logging.basicConfig(
perses/app/setup_relative_calculation.py:1194:    logging.basicConfig(
perses/tests/test_geometry_engine.py:1012:    logging.basicConfig(level=logging.INFO)
perses/utils/url_utils.py:13:# logging.basicConfig(
```

## Motivation and context

Importing `perses.rjmc` in a fresh environment leads to a bunch of numba debug output. This seems to actually crash the Python process for some users (I haven't been able to reproduce, but have had 2 independent reports). This debug dump occurs on compile of numba functions, so after initial import, the compiled versions in `__pycache__` mean you don't get it again.

There are several places in `perses` with the line `logging.basicConfig(level=logging.NOTSET)`. This is the cause of the debug output, and I do not think it is the intended behavior:

1. The value of `logging.NOTSET` is `0`, meaning it gives the most verbose logging (more than `logging.DEBUG`). So what you probably want is `logging.basicConfig()`, taking the default behavior (which is `logging.WARNING`). This is why we're getting drowned in numba logging on first import. Doing this in `basicConfig` means that it is set for the root logger, so it affects all packages.

```python
In [1]: import logging
   ...: logger = logging.getLogger("foo")

In [2]: logger.debug("Speak into the void")

In [3]: logging.basicConfig(level=logging.NOTSET)
   ...: logger.debug("Now it's noisy")
DEBUG:foo:Now it's noisy
```


2. There is no need to call `logging.basicConfig` multiple times during import. Only the first call actually does anything; if there's already a handler attached to the root logger, the `basicConfig` doesn't do anything. In general, you probably only want it at the application (user-facing) level, not at the library (developer-facing) level. And you probably don't want it to be part of the imports, because you get things like this, which is not what a user would expect:

```python
In [1]: import perses.rjmc
   ...: import logging
WARNING:root:Warning: importing 'simtk.openmm' is deprecated.  Import 'openmm' instead.

In [2]: logging.basicConfig(level=logging.INFO)
   ...: logging.debug("this should not print, right?")
DEBUG:root:this should not print, right?
```

## How has this been tested?

Waiting on your CI? :laughing: 

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Removed use of `logging.basicConfig`, which was leading to excessive numba debug output on first import.
```
