### PR TITLE
fix issue with logic, add debug statements

### DIFF
--- a/perses/utils/data.py
+++ b/perses/utils/data.py
@@ -4,6 +4,8 @@ Tools for managing datafiles in perses
 
 """
 
+import logging
+
 __author__ = 'John D. Chodera'
 
 
@@ -109,19 +111,23 @@ def serialize(item, filename):
         The filename to serialize to
     """
     from cloudpathlib import AnyPath
-    from simtk.openmm import XmlSerializer
+    from openmm import XmlSerializer
     filename = AnyPath(filename)
-    if filename.suffix== '.gz':
+    logging.debug(f"serializing item {item} to {filename} with suffix {filename.suffix}")
+    if filename.suffix == '.gz':
         import gzip
+        logging.debug("using gzip to serialize")
         with gzip.open(filename, 'wb') as outfile:
             serialized_thing = XmlSerializer.serialize(item)
             outfile.write(serialized_thing.encode())
-    if filename.suffix == '.bz2':
+    elif filename.suffix == '.bz2':
         import bz2
+        logging.debug("using bz2 to serialize")
         with bz2.open(filename, 'wb') as outfile:
             serialized_thing = XmlSerializer.serialize(item)
             outfile.write(serialized_thing.encode())
     else:
+        logging.debug("serializing without compression")
         with open(filename, 'w') as outfile:
             serialized_thing = XmlSerializer.serialize(item)
             outfile.write(serialized_thing)


### PR DESCRIPTION
## Description
There was a bug in the logic where if we saved a file with a `.gz` extension, we would save the file compressed, then overwrite the file with an uncompressed version.

## Motivation and context

Since this commit: 1145a7405f4beb0de10ab80aa80f6e01aa1a8794 we have not actually been compressing our xml files.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1157 

## How has this been tested?

Tested locally. I could be convinced to write a test, but with the refactoring coming up, I think will prefer to use a different method for this. 

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Resolves #1157 objects serialized with utils.data.serialize now will be compressed with bzip2 or gzip depending on file name (.gz and .bz2, respectively)
```