### PR TITLE
Avoid testing non-examples in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,11 +23,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10"]
-        openmm: ["nightly", "7.7", "beta"]
-        exclude:
-          - python-version: "3.10"
-            openmm: "7.6"
+        python-version: [3.8, 3.9 "3.10", "3.11"]
+        openmm: ["dev", "8.0", "7.7"]
 
     env:
       OPENMM: ${{ matrix.openmm }}
@@ -48,7 +45,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: devtools/conda-envs/test_env.yaml
-          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,defaults,omnia-dev,openeye
+          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,openeye
           activate-environment: test
           auto-update-conda: true
           auto-activate-base: false
@@ -60,13 +57,8 @@ jobs:
         shell: bash -l {0}
         run: |
           case ${{ matrix.openmm }} in
-            nightly)
-              echo "Using nightly dev build of OpenMM."
-              conda install -y -c omnia-dev openmm --override-channels --force-reinstall
-              echo "Using beta build of openeye toolkit"
-              conda install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;
-            beta)
-              echo "Using beta build of OpenMM."
+            dev)
+              echo "Using dev build of OpenMM"
               conda install -c conda-forge/label/openmm_dev -c conda-forge openmm
               echo "Using beta build of openeye toolkit"
               conda install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -60,7 +60,7 @@ jobs:
               micromamba install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;
             *)
               echo "installing OpenMM version ${{ matrix.openmm }}"
-              mamba install -y -c conda-forge openmm=${{ matrix.openmm }};;
+              micromamba install -y -c conda-forge openmm=${{ matrix.openmm }};;
           esac
 
       - name: Install package

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -71,7 +71,7 @@ jobs:
       - name: Environment Information
         shell: bash -l {0}
         run: |
-          micromamba info -a
+          micromamba info
           micromamba list
 
       - name: Decrypt OpenEye license

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           environment-file: devtools/conda-envs/test_env.yaml
-          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,openeye
+          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,openeye,defaults
           activate-environment: test
           auto-update-conda: true
           auto-activate-base: false

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -55,9 +55,7 @@ jobs:
           case ${{ matrix.openmm }} in
             dev)
               echo "Using dev build of OpenMM"
-              micromamba install -c conda-forge/label/openmm_dev -c conda-forge openmm
-              echo "Using beta build of openeye toolkit"
-              micromamba install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;
+              micromamba install -c conda-forge/label/openmm_dev -c conda-forge openmm;;
             *)
               echo "installing OpenMM version ${{ matrix.openmm }}"
               micromamba install -y -c conda-forge openmm=${{ matrix.openmm }};;

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10",]
         openmm: ["dev", "8.0", "7.7"]
 
     env:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,18 +40,14 @@ jobs:
           df -h
           ulimit -a
 
-      # More info on options: https://github.com/conda-incubator/setup-miniconda
-      - uses: conda-incubator/setup-miniconda@v2
+      - name: Setup micromamba
+        uses: uses: mamba-org/provision-with-micromamba@main
         with:
-          python-version: ${{ matrix.python-version }}
           environment-file: devtools/conda-envs/test_env.yaml
-          channels: jaimergp/label/unsupported-cudatoolkit-shim,conda-forge,openeye,defaults
-          activate-environment: test
-          auto-update-conda: true
-          auto-activate-base: false
-          show-channel-urls: true
-          channel-priority: true
-          miniforge-variant: Mambaforge
+          environment-name: test
+          extra-specs: |
+            python=${{ matrix.python-version }}
+
 
       - name: Refine test environment
         shell: bash -l {0}
@@ -59,9 +55,9 @@ jobs:
           case ${{ matrix.openmm }} in
             dev)
               echo "Using dev build of OpenMM"
-              conda install -c conda-forge/label/openmm_dev -c conda-forge openmm
+              micromamba install -c conda-forge/label/openmm_dev -c conda-forge openmm
               echo "Using beta build of openeye toolkit"
-              conda install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;
+              micromamba install -y -c openeye/label/beta openeye-toolkits --override-channels --force-reinstall;;
             *)
               echo "installing OpenMM version ${{ matrix.openmm }}"
               mamba install -y -c conda-forge openmm=${{ matrix.openmm }};;
@@ -75,8 +71,8 @@ jobs:
       - name: Environment Information
         shell: bash -l {0}
         run: |
-          mamba info -a
-          mamba list
+          micromamba info -a
+          micromamba list
 
       - name: Decrypt OpenEye license
         shell: bash -l {0}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,7 +41,7 @@ jobs:
           ulimit -a
 
       - name: Setup micromamba
-        uses: uses: mamba-org/provision-with-micromamba@main
+        uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: devtools/conda-envs/test_env.yaml
           environment-name: test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8, 3.9 "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11"]
         openmm: ["dev", "8.0", "7.7"]
 
     env:

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -9,7 +9,7 @@ dependencies:
   - arsenic
   - autograd
   - click
-  - cloudpathlib-s3
+  - cloudpathlib-s3 >=0.13.0
   - coverage
   - dask
   - dask-jobqueue
@@ -41,7 +41,7 @@ dependencies:
   - pytest-attrib
   - pytest-cov
   - pytest-xdist
-  - python >=3.6
+  - python
   - rich
   - scipy
   - seaborn

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -2,8 +2,6 @@ name: test
 channels:
   - jaimergp/label/unsupported-cudatoolkit-shim
   - conda-forge
-  - defaults
-  - omnia-dev
   - openeye
 dependencies:
   - arsenic

--- a/perses/tests/test_examples.py
+++ b/perses/tests/test_examples.py
@@ -18,6 +18,8 @@ import subprocess
 from perses.tests.utils import enter_temp_directory
 
 ROOT_DIR_PATH = pathlib.Path(__file__).joinpath("../../../").resolve()
+SLOW_EXAMPLES_KEYWORDS = ("barnase-barstar", "kinase-neq-switching")
+NOT_EXAMPLES_KEYWORDS = ("analyze-benchmark", "moonshot-mainseries")
 
 
 def run_script_file(file_path, cmd_args=None):
@@ -47,9 +49,11 @@ def find_example_scripts():
     for example_file_path in examples_dir_path.glob("*/*.py"):
         # TODO: find a better way to mark slow examples
         example_posix_path = example_file_path.as_posix()
-        if "barnase-barstar" in example_posix_path or "kinase-neq-switching" in example_posix_path:
+        # mark slow examples
+        if any(example in example_posix_path for example in SLOW_EXAMPLES_KEYWORDS):
             example_posix_path = pytest.param(example_posix_path, marks=pytest.mark.slow)
-        elif "analyze-benchmark" in example_posix_path:
+        # mark non-examples
+        elif any(example in example_posix_path for example in NOT_EXAMPLES_KEYWORDS):
             example_posix_path = pytest.param(example_posix_path, marks=pytest.mark.skip("not an example"))
         example_file_paths.append(example_posix_path)
 


### PR DESCRIPTION
## Description

From #1145 our examples directory was populated with many scripts that are not necessarily ready-to-run examples.

These changes avoid trying to run these as part of our CI, solving errors on running tests.

## How has this been tested?

Tested locally running `test_examples.py` tests.

