### PR TITLE
Include cloudpathlib as requirement in meta.yaml

### DIFF
--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -43,6 +43,7 @@ requirements:
     - dask-jobqueue
     - openmmforcefields
     - dicttoxml
+    - cloudpathlib
 #  - pip:
 #    - codecov
 


### PR DESCRIPTION
## Description

Includes package [cloudpathlib](https://anaconda.org/conda-forge/cloudpathlib) as dependency in conda recipe.

## Motivation and context

A `cloudpathlib` class is used in `app/relative_setup.py`

https://github.com/choderalab/perses/blob/a24067bfebae473fa014d34b9f0ef1dbc2406623/perses/app/relative_setup.py#L13

## How has this been tested?

It has not been tested. The mentioned package had to be installed manually.

## Change log

```
Included conda-forge package cloudpathlib as requirement.
```
