### PR TITLE
Maximum temperature yaml parameter for REST with CLI

### DIFF
--- a/examples/new-cli/template.yaml
+++ b/examples/new-cli/template.yaml
@@ -36,6 +36,8 @@ pressure: 1 # atmsopheres
 temperature: 300 # kelvin
 timestep: 4 # femtoseconds
 ionic_strength: 0.15 # molar
+# Max temperature for REST scaling (optional)
+max_temperature: 600 # Kelvin
 
 # Atom mapping specification
 atom_expression:
@@ -78,3 +80,7 @@ phases:
 # Use geometry-derived mapping
 use_given_geometries: true
 given_geometries_tolerance: 0.4 # angstroms
+
+# Realtime analysis frequency
+offline-freq: 100
+

--- a/examples/new-cli/template.yaml
+++ b/examples/new-cli/template.yaml
@@ -84,3 +84,5 @@ given_geometries_tolerance: 0.4 # angstroms
 # Realtime analysis frequency
 offline-freq: 100
 
+# Advanced (optional) -- Specify HTF (HybridTopologyFactory or RESTCapableHybridTopologyFactory)
+# hybrid_topology_factory: RESTCapableHybridTopologyFactory

--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2833,14 +2833,7 @@ class RESTCapableHybridTopologyFactory(HybridTopologyFactory):
     _new_system_exceptions : dict of key: tuple of ints, value: list of floats
         key: new system indices of the atoms in the exception, value: chargeProd (units of the proton charge squared), sigma (nm), and epsilon (kJ/mol) for the exception
     """
-    
-    # Constants copied from: https://github.com/openmm/openmm/blob/master/platforms/reference/include/SimTKOpenMMRealType.h#L89. These will be imported directly once we have addresssed https://github.com/choderalab/openmmtools/issues/522
-    M_PI = 3.14159265358979323846
-    E_CHARGE = (1.602176634e-19)
-    AVOGADRO = (6.02214076e23)
-    EPSILON0 = (1e-6*8.8541878128e-12/(E_CHARGE*E_CHARGE*AVOGADRO))
-    ONE_4PI_EPS0 = (1/(4*M_PI*EPSILON0))
-    #from openmmtools.constants import ONE_4PI_EPS0
+    from openmmtools.constants import ONE_4PI_EPS0
 
     _default_electrostatics_expression_list = [
 


### PR DESCRIPTION
## Description

Adds handling of max temperature parameter from input yaml file with CLI.

## Motivation and context

We need to be able to specify the maximum temperature from input YAML file to be able to benefit from using REST in the small molecule simulations pipeline.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1195 

## How has this been tested?

Need to come up with a way of testing that REST scaling is being done from the serialized objects. I still don't know what would be the best way to accomplish this.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Enabling ``max_temperature`` parameter in input yaml file for CLI. This makes REST available for the small molecule pipeline using ``perses-cli``.
```
