### PR TITLE
Allow specifying solvent model in input YAML file

### DIFF
--- a/examples/new-cli/template.yaml
+++ b/examples/new-cli/template.yaml
@@ -78,3 +78,6 @@ phases:
 # Use geometry-derived mapping
 use_given_geometries: true
 given_geometries_tolerance: 0.4 # angstroms
+
+# Solvent model
+solvent_model: "tip3p"

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -72,6 +72,7 @@ class RelativeFEPSetup(object):
                  use_given_geometries = False,
                  given_geometries_tolerance=0.2*unit.angstroms,
                  transform_waters_into_ions_for_charge_changes=True,
+                 solvent_model="tip3p"
                  ):
         """
         Initialize a NonequilibriumFEPSetup object
@@ -160,6 +161,7 @@ class RelativeFEPSetup(object):
         self._use_given_geometries = use_given_geometries
         self._given_geometries_tolerance = given_geometries_tolerance
         self.small_molecule_forcefield = small_molecule_forcefield
+        self._solvent_model = solvent_model
         if isinstance(ligand_input, str):
             self._ligand_input = AnyPath(ligand_input)
         else:
@@ -408,7 +410,9 @@ class RelativeFEPSetup(object):
             _logger.info(f"setting up complex phase...")
             self._setup_complex_phase()
             self._complex_topology_old_solvated, self._complex_positions_old_solvated, self._complex_system_old_solvated = self._solvate_system(
-            self._complex_topology_old, self._complex_positions_old,phase='complex',box_dimensions=self._complex_box_dimensions, ionic_strength=self._ionic_strength)
+                self._complex_topology_old, self._complex_positions_old, phase='complex',
+                box_dimensions=self._complex_box_dimensions, ionic_strength=self._ionic_strength,
+                model=self._solvent_model)
             _logger.info(f"successfully generated complex topology, positions, system")
 
             self._complex_md_topology_old_solvated = md.Topology.from_openmm(self._complex_topology_old_solvated)
@@ -466,7 +470,9 @@ class RelativeFEPSetup(object):
                 _logger.info(f"no complex detected in phases...generating unique topology/geometry proposals...")
                 _logger.info(f"solvating ligand...")
                 self._ligand_topology_old_solvated, self._ligand_positions_old_solvated, self._ligand_system_old_solvated = self._solvate_system(
-                self._ligand_topology_old, self._ligand_positions_old,phase='solvent',box_dimensions=self._solvent_box_dimensions,ionic_strength=self._ionic_strength)
+                    self._ligand_topology_old, self._ligand_positions_old, phase='solvent',
+                    box_dimensions=self._solvent_box_dimensions, ionic_strength=self._ionic_strength,
+                    model=self._solvent_model)
                 self._ligand_md_topology_old_solvated = md.Topology.from_openmm(self._ligand_topology_old_solvated)
 
                 _logger.info(f"creating TopologyProposal")
@@ -532,8 +538,10 @@ class RelativeFEPSetup(object):
 
             if self._proposal_phase is None:
                 _logger.info('No complex or solvent leg, so performing topology proposal for vacuum leg')
-                self._vacuum_topology_old, self._vacuum_positions_old, self._vacuum_system_old = self._solvate_system(self._ligand_topology_old,
-                                                                                                         self._ligand_positions_old,phase='vacuum')
+                # FIXME: We shouldn't use a "solvate" system method for the vacuum phase. Separate functionalities.
+                self._vacuum_topology_old, self._vacuum_positions_old, self._vacuum_system_old = self._solvate_system(
+                    self._ligand_topology_old,
+                    self._ligand_positions_old, phase='vacuum', model=self._solvent_model)
                 self._vacuum_topology_proposal = self._proposal_engine.propose(self._vacuum_system_old,
                                                                                self._vacuum_topology_old,
                                                                                current_mol_id=0, proposed_mol_id=1)
@@ -666,7 +674,8 @@ class RelativeFEPSetup(object):
 
         # solvate the old ligand topology:
         old_solvated_topology, old_solvated_positions, old_solvated_system = self._solvate_system(
-            old_ligand_topology.to_openmm(), old_ligand_positions,phase='solvent', box_dimensions=self._solvent_box_dimensions)
+            old_ligand_topology.to_openmm(), old_ligand_positions, phase='solvent',
+            box_dimensions=self._solvent_box_dimensions, model=self._solvent_model)
 
         old_solvated_md_topology = md.Topology.from_openmm(old_solvated_topology)
 
@@ -826,7 +835,7 @@ class RelativeFEPSetup(object):
         forcefield : SystemGenerator.forcefield
             forcefield file of solvent to add
         model : str, default 'tip3p'
-            solvent model to use for solvation
+            solvent model to use for solvation. Supported values are 'tip3p', 'spce', 'tip4pew', 'tip5p', and 'swm4ndp' (polarizable)
         box_dimensions : tuple of Vec3, default None
             if not None, padding distance will be omitted in favor of a pre-specified set of box dimensions
 

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -506,24 +506,37 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
 
     if 'topology_proposal' not in list(setup_options.keys()) or setup_options['topology_proposal'] is None:
         _logger.info(f"\tno topology_proposal specified; proceeding to RelativeFEPSetup...\n\n\n")
+        # TODO: This if-else is not doing anything as far as I can tell. Remove?
         if 'set_solvent_box_dims_to_complex' in list(setup_options.keys()) and setup_options['set_solvent_box_dims_to_complex']:
             set_solvent_box_dims_to_complex=True
         else:
             set_solvent_box_dims_to_complex=False
 
         _logger.info(f'Box dimensions: {setup_options["complex_box_dimensions"]} and {setup_options["solvent_box_dimensions"]}')
-        fe_setup = RelativeFEPSetup(ligand_file, old_ligand_index, new_ligand_index, forcefield_files,phases=phases,
-                                          protein_pdb_filename=protein_pdb_filename,
-                                          receptor_mol2_filename=receptor_mol2, pressure=pressure,
-                                          temperature=temperature, solvent_padding=solvent_padding_angstroms, spectator_filenames=setup_options['spectators'],
-                                          map_strength=setup_options['map_strength'],
-                                          atom_expr=setup_options['atom_expr'], bond_expr=setup_options['bond_expr'],
-                                          neglect_angles = setup_options['neglect_angles'], anneal_14s = setup_options['anneal_1,4s'],
-                                          small_molecule_forcefield=setup_options['small_molecule_forcefield'], small_molecule_parameters_cache=setup_options['small_molecule_parameters_cache'],
-                                          trajectory_directory=trajectory_directory, trajectory_prefix=setup_options['trajectory_prefix'], nonbonded_method=setup_options['nonbonded_method'],
-                                          complex_box_dimensions=setup_options['complex_box_dimensions'],solvent_box_dimensions=setup_options['solvent_box_dimensions'], ionic_strength=ionic_strength, remove_constraints=setup_options['remove_constraints'],
-                                          use_given_geometries=use_given_geometries, given_geometries_tolerance=given_geometries_tolerance,
-                                          transform_waters_into_ions_for_charge_changes = setup_options['transform_waters_into_ions_for_charge_changes'])
+        fe_setup = RelativeFEPSetup(ligand_file, old_ligand_index, new_ligand_index, forcefield_files, phases=phases,
+                                    protein_pdb_filename=protein_pdb_filename,
+                                    receptor_mol2_filename=receptor_mol2, pressure=pressure,
+                                    temperature=temperature, solvent_padding=solvent_padding_angstroms,
+                                    spectator_filenames=setup_options['spectators'],
+                                    map_strength=setup_options['map_strength'],
+                                    atom_expr=setup_options['atom_expr'], bond_expr=setup_options['bond_expr'],
+                                    neglect_angles=setup_options['neglect_angles'],
+                                    anneal_14s=setup_options['anneal_1,4s'],
+                                    small_molecule_forcefield=setup_options['small_molecule_forcefield'],
+                                    small_molecule_parameters_cache=setup_options['small_molecule_parameters_cache'],
+                                    trajectory_directory=trajectory_directory,
+                                    trajectory_prefix=setup_options['trajectory_prefix'],
+                                    nonbonded_method=setup_options['nonbonded_method'],
+                                    complex_box_dimensions=setup_options['complex_box_dimensions'],
+                                    solvent_box_dimensions=setup_options['solvent_box_dimensions'],
+                                    ionic_strength=ionic_strength,
+                                    remove_constraints=setup_options['remove_constraints'],
+                                    use_given_geometries=use_given_geometries,
+                                    given_geometries_tolerance=given_geometries_tolerance,
+                                    transform_waters_into_ions_for_charge_changes=setup_options[
+                                        'transform_waters_into_ions_for_charge_changes'],
+                                    solvent_model=setup_options.get("solvent_model", "tip3p"),
+                                    )
 
 
         _logger.info(f"\twriting pickle output...")

--- a/perses/tests/test_cli.py
+++ b/perses/tests/test_cli.py
@@ -1,52 +1,69 @@
 import os
-import subprocess
 
 import pytest
+import yaml
 from click.testing import CliRunner
 from pkg_resources import resource_filename
 
 from perses.app.cli import cli
 
-test_yaml = """
-protein_pdb: Tyk2_protein.pdb
-ligand_file: Tyk2_ligands_shifted.sdf
-old_ligand_index: 0
-new_ligand_index: 3
-forcefield_files:
-  - amber/ff14SB.xml
-  - amber/tip3p_standard.xml
-  - amber/tip3p_HFE_multivalent.xml
-  - amber/phosaa10.xml
-small_molecule_forcefield: openff-2.0.0
-pressure: 1
-temperature: 300
-solvent_padding: 9
-atom_expression:
-  - IntType
-bond_expession:
-  - DefaultBonds
-n_steps_per_move_application: 1
-fe_type: repex
-checkpoint_interval: 50
-n_cycles: 1
-n_states: 3
-n_equilibration_iterations: 0
-trajectory_directory: temp/offlig10to24
-trajectory_prefix: out
-atom_selection: not water
-phases:
-  - solvent
-  - vacuum
-timestep: 4
-h_constraints: true
-"""
+@pytest.fixture
+def default_input_yaml_template_cli():
+    test_yaml = """
+    protein_pdb: Tyk2_protein.pdb
+    ligand_file: Tyk2_ligands_shifted.sdf
+    old_ligand_index: 0
+    new_ligand_index: 3
+    forcefield_files:
+      - amber/ff14SB.xml
+      - amber/tip3p_standard.xml
+      - amber/tip3p_HFE_multivalent.xml
+      - amber/phosaa10.xml
+    small_molecule_forcefield: openff-2.0.0
+    pressure: 1
+    temperature: 300
+    solvent_padding: 9
+    atom_expression:
+      - IntType
+    bond_expession:
+      - DefaultBonds
+    n_steps_per_move_application: 1
+    fe_type: repex
+    checkpoint_interval: 10
+    n_cycles: 1
+    n_states: 3
+    n_equilibration_iterations: 0
+    trajectory_directory: temp/offlig10to24
+    trajectory_prefix: out
+    atom_selection: not water
+    phases:
+      - solvent
+      - vacuum
+    timestep: 4
+    h_constraints: true
+    """
+    return test_yaml
+
+@pytest.fixture
+def input_template_obj_cli(default_input_yaml_template_cli):
+    input_obj = yaml.safe_load(default_input_yaml_template_cli)
+    return input_obj
+
+@pytest.fixture
+def input_template_obj_tip5p_cli(input_template_obj_cli):
+    """Input yaml options changing the solvent model to spce."""
+    input_template_obj_cli["solvent_model"] = "spce"
+    return input_template_obj_cli
 
 
-def test_dummy_cli_with_override(in_tmpdir):
+@pytest.mark.parametrize("input_params", ["input_template_obj_cli",
+                                          "input_template_obj_tip5p_cli"])
+def test_dummy_cli_with_override(input_params, in_tmpdir, request):
     runner = CliRunner()
+    yaml_doc = request.getfixturevalue(input_params)
     with runner.isolated_filesystem():
         with open("test.yaml", "w") as f:
-            f.write(test_yaml)
+            yaml.dump(yaml_doc, f)
 
         protein_pdb = resource_filename(
             "perses", os.path.join("data", "Tyk2_ligands_example", "Tyk2_protein.pdb")


### PR DESCRIPTION
## Description

These changes allow the specification of the solvent model through the input YAML file for the small molecule pipeline in perses. This is intended to be used via the perses cli.

## Motivation and context

Some users have expressed the desire to use different solvent models for perses simulations.

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1192 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Users can now specify solvent model for simulations using the ``solvent_model`` field in the input YAML file.
```
