### PR TITLE
Using default online analysis interval in GPU repex tests

### DIFF
--- a/perses/tests/test_repex.py
+++ b/perses/tests/test_repex.py
@@ -63,7 +63,7 @@ def test_RESTCapableHybridTopologyFactory_repex_neutral_mutation():
                                                                           constraint_tolerance=1e-06),
                                      replica_mixing_scheme='swap-all',
                                      hybrid_factory=htf,
-                                     online_analysis_interval=None)
+                                     )
 
             hss.setup(n_states=12, temperature=300 * unit.kelvin, t_max=300 * unit.kelvin,
                       storage_file=reporter, minimisation_steps=0, endstates=True)
@@ -169,7 +169,7 @@ def test_RESTCapableHybridTopologyFactory_repex_charge_mutation():
                                                                               constraint_tolerance=1e-06),
                                          replica_mixing_scheme='swap-all',
                                          hybrid_factory=htf,
-                                         online_analysis_interval=None)
+                                         )
 
                 hss.setup(n_states=36, temperature=300 * unit.kelvin, t_max=300 * unit.kelvin,
                           storage_file=reporter, minimisation_steps=0, endstates=True)
@@ -279,7 +279,7 @@ def test_RESTCapableHybridTopologyFactory_repex_neutral_transformation():
                     constraint_tolerance=1e-06),
                 replica_mixing_scheme='swap-all',
                 hybrid_factory=htf,
-                online_analysis_interval=None)
+            )
 
             sampler.setup(
                 n_states=n_states,
@@ -394,7 +394,7 @@ def test_RESTCapableHybridTopologyFactory_repex_charge_transformation():
                         constraint_tolerance=1e-06),
                     replica_mixing_scheme='swap-all',
                     hybrid_factory=htf,
-                    online_analysis_interval=None)
+                )
 
                 sampler.setup(
                     n_states=n_states,


### PR DESCRIPTION
## Description
Since openmmtools 0.23 the online analysis interval and the checkpoint interval are now correlated. See https://github.com/choderalab/openmmtools/releases/tag/0.23.0 for more info.

## Motivation and context

Work with latest openmmtools changes

<!-- Replace ??? with the issue number that this pull request resolves. -->

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Tested locally, will test with self-hosted GPU CI when merged.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
