### PR TITLE
[Draft] Self-consistently parameterize protein-ligand with espaloma-0.3.0

### DIFF
--- a/perses/annihilation/relative.py
+++ b/perses/annihilation/relative.py
@@ -2049,7 +2049,14 @@ class HybridTopologyFactory(object):
         core_heavy_atoms = [ int(index) for index in set(core_atoms).intersection(set(heavy_atoms)) ]
 
         # Determine protein CA atoms
-        protein_atoms = [ int(index) for index in self._hybrid_topology.select('protein and name CA') ]
+        # NOTE: Residue name starting with XX is a special residue name for proteins parameterized with espaloma.
+        # The special residue name is also defined in app/relative_setup.py#L929 and should be changed jointly
+        # when chaning the residue name.
+        x = self._hybrid_topology.select("resname =~ 'XX.*'")
+        if x.any():
+            protein_atoms = [ int(index) for index in self._hybrid_topology.select("resname =~ 'XX.*'" and "name CA") ]
+        else:
+            protein_atoms = [ int(index) for index in self._hybrid_topology.select('protein and name CA') ]
 
         if len(core_heavy_atoms)==0 or len(protein_atoms)==0:
             # No restraint to be added

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -935,6 +935,8 @@ class RelativeFEPSetup(object):
         indices = t.topology.select('resname ESP')
         pdb_filename = "target-espaloma.pdb"
         t.atom_slice(indices).save_pdb(f'{pdb_filename}')
+        
+        from openff.toolkit.topology import Molecule
         protein_molecule = Molecule.from_file(f'{pdb_filename}', file_format='pdb')
         
         # We already added small molecules to template generator when we first created ``self._system_generator``.

--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -165,7 +165,6 @@ class RelativeFEPSetup(object):
         self._use_given_geometries = use_given_geometries
         self._given_geometries_tolerance = given_geometries_tolerance
         self._ligand_input = ligand_input
-        self._use_protein_espaloma
 
         if self._use_given_geometries:
             assert self._ligand_input[-3:] == 'sdf' or self._ligand_input[-4:] == 'mol2', f"cannot use deterministic atom placement if the ligand input files do not contain geometry information (e.g. in .sdf or .mol2 format)"
@@ -388,7 +387,7 @@ class RelativeFEPSetup(object):
             _logger.info(f"successfully generated complex topology, positions, system")
 
             # Assign espaloma to protein. Topology and system will be regenerated.
-            if self._use_protein_espaloma:
+            if use_protein_espaloma:
                 _logger.info(f"Regenerating toplogy and system with espaloma...")
                 # Save and serialize current system
                 from openmm import XmlSerializer

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -395,11 +395,11 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
     #   such as deferring to defaults for modules we call unless the user
     #   chooses to override them.
 
-    if 'use_protein_espaloma' not in list(setup_options.keys()):
-        use_protein_espaloma = False
+    if 'use_espaloma_for_protein' not in list(setup_options.keys()):
+        use_espaloma_for_protein = False
     else:
-        assert type(setup_options['use_protein_espaloma']) == type(True)
-        use_protein_espaloma = setup_options['use_protein_espaloma']
+        assert type(setup_options['use_espaloma_for_protein']) == type(True)
+        use_espaloma_for_protein = setup_options['use_espaloma_for_protein']
 
     if 'use_given_geometries' not in list(setup_options.keys()):
         use_given_geometries = False
@@ -526,7 +526,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                                           atom_expr=setup_options['atom_expr'], bond_expr=setup_options['bond_expr'],
                                           neglect_angles = setup_options['neglect_angles'], anneal_14s = setup_options['anneal_1,4s'],
                                           small_molecule_forcefield=setup_options['small_molecule_forcefield'], small_molecule_parameters_cache=setup_options['small_molecule_parameters_cache'],
-                                          use_protein_espaloma=use_protein_espaloma,
+                                          use_espaloma_for_protein=use_espaloma_for_protein,
                                           trajectory_directory=trajectory_directory, trajectory_prefix=setup_options['trajectory_prefix'], nonbonded_method=setup_options['nonbonded_method'],
                                           complex_box_dimensions=setup_options['complex_box_dimensions'],solvent_box_dimensions=setup_options['solvent_box_dimensions'], ionic_strength=ionic_strength, remove_constraints=setup_options['remove_constraints'],
                                           use_given_geometries=use_given_geometries, given_geometries_tolerance=given_geometries_tolerance,

--- a/perses/app/setup_relative_calculation.py
+++ b/perses/app/setup_relative_calculation.py
@@ -100,6 +100,7 @@ def getSetupOptions(filename, override_string=None):
 
     if 'small_molecule_parameters_cache' not in setup_options:
         setup_options['small_molecule_parameters_cache'] = None
+        
 
     if 'remove_constraints' not in setup_options:
         setup_options['remove_constraints'] = False
@@ -394,6 +395,11 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
     #   such as deferring to defaults for modules we call unless the user
     #   chooses to override them.
 
+    if 'use_protein_espaloma' not in list(setup_options.keys()):
+        use_protein_espaloma = False
+    else:
+        assert type(setup_options['use_protein_espaloma']) == type(True)
+        use_protein_espaloma = setup_options['use_protein_espaloma']
 
     if 'use_given_geometries' not in list(setup_options.keys()):
         use_given_geometries = False
@@ -520,6 +526,7 @@ def run_setup(setup_options, serialize_systems=True, build_samplers=True):
                                           atom_expr=setup_options['atom_expr'], bond_expr=setup_options['bond_expr'],
                                           neglect_angles = setup_options['neglect_angles'], anneal_14s = setup_options['anneal_1,4s'],
                                           small_molecule_forcefield=setup_options['small_molecule_forcefield'], small_molecule_parameters_cache=setup_options['small_molecule_parameters_cache'],
+                                          use_protein_espaloma=use_protein_espaloma,
                                           trajectory_directory=trajectory_directory, trajectory_prefix=setup_options['trajectory_prefix'], nonbonded_method=setup_options['nonbonded_method'],
                                           complex_box_dimensions=setup_options['complex_box_dimensions'],solvent_box_dimensions=setup_options['solvent_box_dimensions'], ionic_strength=ionic_strength, remove_constraints=setup_options['remove_constraints'],
                                           use_given_geometries=use_given_geometries, given_geometries_tolerance=given_geometries_tolerance,


### PR DESCRIPTION
## Description
This PR is a draft to self-consistently parameterize protein-ligand systems with `espaloma-0.3.0` which was built on top of `perses-0.10.1`. Note that this PR is not ready to be merged to the latest release but intended to keep track of how one could self-consistently parameterize a protein-ligand systems with `espaloma-0.3.0`.

## Motivation and context
Current implementation of perses cannot parameterize the protein-ligand system self-consistently with `espaloma`.
One work around is to parameterize the system with the current implementation (protein: Amber, ligand: espaloma), and use the solvated system to regenerate the protein with `EspalomaTemplateGenerator` implemented in `openmmforcefields.generators`.

A more simple way is to handle the protein as a single residue `openff.topology.Molecule` object and append it with the other small molecules, Then load the list of `Molecules` into `openmmforcefields.generators.SystemGenerator`. However, this raised some issues described [here](https://github.com/kntkb/perses/issues/1).

## How has this been tested?
This version was used to run the [custom PL-benchmark](https://github.com/kntkb/protein-ligand-benchmark-custom) described [here](https://github.com/choderalab/pl-benchmark-espaloma-experiment).
