### PR TITLE
CI miscellaneous fixes

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -70,7 +70,6 @@ jobs:
           extra-specs: |
             python==${{ matrix.python-version }}
             openmm==${{ matrix.openmm }}
-            openmmtools==0.23.0
 
       - name: Install package
         shell: bash -l {0}
@@ -106,4 +105,4 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           file: ./coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -28,7 +28,7 @@ dependencies:
   - openff-units >=0.1.8
   - openmm >=7.7
   - openmmforcefields >=0.9.0
-  - openmmtools # may need to sort out ambermini/ambertools/parmed dependencies
+  - openmmtools >=0.23 # may need to sort out ambermini/ambertools/parmed dependencies
   - openmoltools # may need to sort out ambermini/ambertools/parmed dependencies (we don't want ambertools)
   - parmed # may need to sort out ambermini/ambertools/parmed dependencies
   - pdbfixer


### PR DESCRIPTION
## Description

* Allow codecov to fail without making our CI tests error out. This is desirable because codecov availability can be flaky, so we don't want to depend on it for our CI tests to pass.
* We don't need to pass `openmmtools >=0.23` as extra specs. Test environment file updated accordingly.
