### PR TITLE
Fix spectator support

### DIFF
--- a/perses/app/relative_setup.py
+++ b/perses/app/relative_setup.py
@@ -326,12 +326,6 @@ class RelativeFEPSetup(object):
         self._ligand_md_topology_new = md.Topology.from_openmm(self._ligand_topology_new)
         _logger.info(f"Created mdtraj topologies for both ligands.")
 
-        # We must generate the complex topology and positions before the SystemGenerator is created because if the
-        # receptor is a mol2, it must be added to mol_list, which is use to create self._molecules, which is fed to the SystemGenerator
-        if 'complex' in phases:
-            _logger.info(f"setting up complex phase...")
-            self._setup_complex_phase()
-
         # Select barostat
         NONPERIODIC_NONBONDED_METHODS = [app.NoCutoff, app.CutoffNonPeriodic]
         if pressure is not None:
@@ -365,7 +359,7 @@ class RelativeFEPSetup(object):
                 spectator_mol = generate_unique_atom_names(spectator_mol)
                 self._spectator_molecules.append(spectator_mol)
                 # add this to a small molecule register
-                self._molecules.append(Molecule.from_openeye(spectator_mol,allow_undefined_stereo=True))
+                molecules.append(Molecule.from_openeye(spectator_mol, allow_undefined_stereo=True))
                 self._spectator_positions.append(extractPositionsFromOEMol(spectator_mol))
                 spectator_topology = forcefield_generators.generateTopologyFromOEMol(spectator_mol)
                 self._spectator_md_topologies.append(md.Topology.from_openmm(spectator_topology))

--- a/perses/tests/test_relative_setup.py
+++ b/perses/tests/test_relative_setup.py
@@ -204,11 +204,11 @@ def test_run_cdk2_iterations_repex():
 
         # TODO: Check output
 
-#@skipIf(running_on_github_actions, "Skip analysis test on GH Actions. SLOW")
-@pytest.mark.skip(reason="Skip analysis test on GH Actions. SLOW")
+
+# @pytest.mark.skip(reason="Skip analysis test on GH Actions. SLOW")
 def test_run_bace_spectator():
     """
-    Ensure that we can instantiate and run a repex relative free energy calculation the cdk2 ligands in vacuum
+    Ensure that we can setup a simulation of BACE system with an spectator
     """
     # Enter a temporary directory
     from perses.tests.utils import enter_temp_directory
@@ -242,14 +242,12 @@ def test_run_bace_spectator():
             setup_options[parameter] = os.path.join(setup_directory, setup_options[parameter])
             # only one spectator
             setup_options['spectators'] = [ os.path.join(setup_directory, setup_options['spectators'][0])]
-        for parameter in ['trajectory_directory', 'trajectory_prefix', 'save_setup_pickle_as']:
+        for parameter in ['trajectory_directory', 'save_setup_pickle_as']:
             setup_options[parameter] = os.path.join(tmpdirname, setup_options[parameter])
 
 
         # Run setup
-        n_iterations = 2
         setup_dict = setup_relative_calculation.run_setup(setup_options)
-        setup_dict['hybrid_samplers']['complex'].run(n_iterations=n_iterations)
 
         # test that there is TLA in the complex system
         found_tla = False

--- a/perses/tests/test_relative_setup.py
+++ b/perses/tests/test_relative_setup.py
@@ -204,8 +204,8 @@ def test_run_cdk2_iterations_repex():
 
         # TODO: Check output
 
-
-# @pytest.mark.skip(reason="Skip analysis test on GH Actions. SLOW")
+# Running it on gpu CI -- slow
+@pytest.mark.gpu_needed
 def test_run_bace_spectator():
     """
     Ensure that we can setup a simulation of BACE system with an spectator


### PR DESCRIPTION
## Description

These changes remove an unnecessary call to `RelativeFEPSetup._setup_complex_phase` method, fixing the support for spectator molecules.

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #1232 
Resolves #1219 

## How has this been tested?

Re-enabling previously skipped test for setting up bace system with spectator molecule.

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```
Regression error when setting up systems with spectator molecules has been fixed by avoiding early and unnecessary calls to setup methods.
```
