### PR TITLE
Fix incorrect implementation of logsumexp

### DIFF
--- a/perses/samplers/samplers.py
+++ b/perses/samplers/samplers.py
@@ -18,6 +18,7 @@ __author__ = 'John D. Chodera'
 import mdtraj as md
 import numpy as np
 import time
+from scipy.special import logsumexp
 from openmmtools.states import SamplerState, ThermodynamicState
 
 from perses.annihilation.ncmc_switching import NCMCEngine
@@ -49,7 +50,7 @@ def log_sum_exp(a_n):
 
     """
     a_n = np.array(list(a_n.values()))
-    return np.log( np.sum( np.exp(a_n - a_n.max() ) ) )
+    return logsumexp(a_n)
 
 
 ################################################################################


### PR DESCRIPTION
* Off by a_n.max() for the final value, needs to be added back in after the call to log
* Use the scipy.special.logsumexp rather than reimplement

## Description

<!-- Describe your changes in detail. -->

## Motivation and context

<!--- Why is this change required? What problem does it solve? -->

<!-- Replace ??? with the issue number that this pull request resolves. -->
Resolves #???

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Change log

<!-- Propose a change log entry. -->
<!-- Examples here https://github.com/choderalab/perses/blob/master/docs/changelog.rst -->
```

```
